### PR TITLE
Add Composer installation support

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -55,6 +55,7 @@ if [ -f www/composer.json ] && [ ! -d www/vendor ]; then
   curl --silent --max-time 60 --location "$COMPOSER_URL" > www/composer.phar
   cd www
   LD_LIBRARY_PATH=$BUILD_DIR/php/ext $BUILD_DIR/php/bin/php -c $LP_DIR/conf/php.ini composer.phar install --prefer-source
+  rm -rf vendor/**/.git
   cd $BUILD_DIR
   rm www/composer.phar
   export GIT_DIR=$GIT_DIR_ORIG


### PR DESCRIPTION
[Composer](http://packagist.org/) is the new emerging default way of handling PHP library dependencies. This patch adds support for it that works very similarly to the NPM support in the Node.js buildpack: if there is a `composer.json` file in an app, then its dependencies are installed with Composer.

Here is a simple example app using it:

http://urlizer-service.herokuapp.com ([source code](https://github.com/bergie/urlizer_service))
