### PR TITLE
Add --enable-proxy to Apache config

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Pre-compiling binaries
 
     # apache
     mkdir /app
-    wget http://apache.cyberuse.com/httpd/httpd-2.2.22.tar.gz
+    curl -O http://apache.cyberuse.com/httpd/httpd-2.2.22.tar.gz
     tar xvzf httpd-2.2.22.tar.gz
     cd httpd-2.2.22
     ./configure --prefix=/app/apache --enable-rewrite --enable-proxy --enable-proxy-http
@@ -26,10 +26,10 @@ Pre-compiling binaries
     cd ..
     
     # php
-    wget http://us2.php.net/get/php-5.3.6.tar.gz/from/us.php.net/mirror 
+    curl -LO http://us2.php.net/get/php-5.3.14.tar.gz/from/us.php.net/mirror
     mv mirror php.tar.gz
     tar xzvf php.tar.gz
-    cd php-5.3.6/
+    cd php-5.3.14/
     ./configure --prefix=/app/php --with-apxs2=/app/apache/bin/apxs --with-mysql --with-pdo-mysql --with-pgsql --with-pdo-pgsql --with-iconv --with-gd --with-curl=/usr/lib --with-config-file-path=/app/php --enable-soap=shared --with-openssl
     make
     make install
@@ -37,7 +37,7 @@ Pre-compiling binaries
     
     # php extensions
     mkdir /app/php/ext
-    cp /usr/lib/libmysqlclient.so.15 /app/php/ext/
+    cp /usr/lib/libmysqlclient.so.16 /app/php/ext/
     
     # pear
     apt-get install php5-dev php-pear
@@ -52,7 +52,7 @@ Pre-compiling binaries
     cd /app
     echo '2.2.22' > apache/VERSION
     tar -zcvf apache.tar.gz apache
-    echo '5.3.6' > php/VERSION
+    echo '5.3.14' > php/VERSION
     tar -zcvf php.tar.gz php
 
 

--- a/bin/compile
+++ b/bin/compile
@@ -7,7 +7,7 @@ set -e
 # config
 APACHE_VERSION="2.2.22"
 APACHE_PATH="apache"
-PHP_VERSION="5.3.10"
+PHP_VERSION="5.3.14"
 PHP_PATH="php"
 
 BIN_DIR=$(dirname $0)
@@ -34,7 +34,7 @@ APACHE_URL="https://s3.amazonaws.com/rhodesmill/apache-$APACHE_VERSION.tar.gz"
 echo "-----> Bundling Apache version $APACHE_VERSION"
 curl --silent --max-time 60 --location "$APACHE_URL" | tar xz
 
-PHP_URL="https://s3.amazonaws.com/php-lp/php-$PHP_VERSION.tar.gz"
+PHP_URL="https://s3.amazonaws.com/rhodesmill/php-$PHP_VERSION.tar.gz"
 echo "-----> Bundling PHP version $PHP_VERSION"
 curl --silent --max-time 60 --location "$PHP_URL" | tar xz
 

--- a/conf/httpd.conf
+++ b/conf/httpd.conf
@@ -54,7 +54,7 @@ ListenBackLog 1024
 #
 # Example:
 # LoadModule foo_module modules/mod_foo.so
-# LoadModule php5_module        modules/libphp5.so
+LoadModule php5_module        modules/libphp5.so
 #
 
 <IfModule !mpm_netware_module>


### PR DESCRIPTION
It is often not reasonable to assign a separate hostname to each of several apps that make up a web site. If, for example, my mailing list sign-up page happens to be implemented with a different programming language than the rest of my site, current Heroku practice would have me create a separate hostname like “list.example.com” to hold that one page — thus exposing an internal implementation detail (why should users care whether that page is written in the same language as the rest of my site?) in the URL's domain component. And the approach does not scale well: every time a small piece of functionality on my site grows large enough that I want to split it out into its own full-fledged app, I have to allocate a new hostname and create redirects for all of the old URLs that existed underneath my main “www” hostname.

This pull request is intended to do only one simple thing (but it cleans up lots of old broken URLs and version numbers along the way): it adds “--enable-proxy” to the Apache ./configure options for the PHP buildpack.

This allows the PHP buildpack to be used not only to host PHP apps and to serve static content with Apache (per Kenneth Reitz), but to accept “RewriteRule … [P]” statements in its “.htaccess” files that efficiently reverse-proxy certain URLs back to applications (like the hypothetical mailing-list sign-up page mentioned above) written in other languages and that need to be deployed to Heroku with other buildpacks as separate Heroku applications.

If you accept this pull request, you might think about providing an internal Amazon IP address by which apps could contact each other without having to route out to the public IP addresses that are the normal entrance point for your network fabric — that way, app A on Heroku, that is reverse-proxying app B for a few of its URLs, could do so WITHOUT creating “external” Amazon EC2 traffic. Instead, the traffic could be taught to loop back to one or more of those 10._._.\* internal IP address that Amazon uses internally for EC2 instances.

If you accept this pull request, remember to rewrite the URLs in “bin/compile” once you have rebuilt Apache, so that it pulls from your “php-lp” bucket instead of from my “rhodesmill” S3 bucket!
