### PR TITLE
Do not move to www to keep buildpack compatible with other buildpacks

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -28,16 +28,6 @@ shopt -s dotglob
 
 cd $BUILD_DIR
 
-# move app things to www
-mkdir -p $CACHE_DIR/www
-mv * $CACHE_DIR/www
-mv $CACHE_DIR/www .
-
-# keep Procfile
-if [ -f www/Procfile ]; then
-  mv www/Procfile .
-fi
-
 MCRYPT_URL="https://heroku-buildpack-php.s3.amazonaws.com/mcrypt-""$MCRYPT_VERSION""$heroku_rev"".tar.gz"
 echo "-----> Bundling mcrypt version $MCRYPT_VERSION"
 curl --silent --max-time 60 --location "$MCRYPT_URL" | tar xz
@@ -67,7 +57,7 @@ touch /app/apache/logs/access_log
 tail -F /app/apache/logs/error_log &
 tail -F /app/apache/logs/access_log &
 export LD_LIBRARY_PATH=/app/php/lib/php
-export PHP_INI_SCAN_DIR=/app/www
+export PHP_INI_SCAN_DIR=/app
 echo "Launching apache"
 exec /app/apache/bin/httpd -DNO_DETACH
 EOF

--- a/conf/httpd.conf
+++ b/conf/httpd.conf
@@ -106,7 +106,7 @@ ServerName 127.0.0.1
 # documents. By default, all requests are taken from this directory, but
 # symbolic links and aliases may be used to point to other locations.
 #
-DocumentRoot "/app/www"
+DocumentRoot "/app"
 
 #
 # Each directory to which Apache has access can be configured with respect
@@ -133,7 +133,7 @@ DocumentRoot "/app/www"
 #
 # This should be changed to whatever you set DocumentRoot to.
 #
-<Directory "/app/www">
+<Directory "/app">
     #
     # Possible values for the Options directive are "None", "All",
     # or any combination of:


### PR DESCRIPTION
Hello,

I know this probably won't be merged, but I would like to raise the concern that the PHP buildpack is not compatible with [heroku-multi-buildpack](https://github.com/ddollar/heroku-buildpack-multi) because you move all the files to www and other buildpack do not detect properly and it also creates issues with other buildpacks `$PATH`.

I think a better solution might be to add an option to enable or disable the moving of all files to `www`, but for now, for those having an issue with multi buildpack setup & the php buildpack, you may use [heroku-buildpack-php-multi](https://github.com/hooktstudios/heroku-buildpack-php-multi) fork which simply do not move files to a new folder.

Have a nice day and happy coding!
