### PR TITLE
Update Imagemagick version

### DIFF
--- a/support/build/libraries/imagemagick
+++ b/support/build/libraries/imagemagick
@@ -8,7 +8,7 @@ set -o pipefail
 # fail harder
 set -eux
 
-DEFAULT_VERSION="6.8.9-5"
+DEFAULT_VERSION="6.8.9-6"
 dep_version=${VERSION:-$DEFAULT_VERSION}
 dep_dirname=ImageMagick-${dep_version}
 dep_archive_name=${dep_dirname}.tar.gz


### PR DESCRIPTION
The currently used Imagemagick version is no longer available for download. 
