### PR TITLE
Implemented newrelic-daemon to be observed via 'heroku logs'

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -338,6 +338,17 @@ if [[ -n "$NEW_RELIC_LICENSE_KEY" ]]; then
     export NEW_RELIC_APP_NAME=${NEW_RELIC_APP_NAME:-"PHP Application on Heroku"}
     export NEW_RELIC_LOG=${NEW_RELIC_LOG:-"stderr"}
     export NEW_RELIC_LOG_LEVEL=${NEW_RELIC_LOG_LEVEL:-"warning"}
+
+    # The daemon is a spawned process, invoked by the PHP agent, which is truly
+    # daemonized (i.e., it is disassociated from the controlling TTY and
+    # running in the background). Therefore, the daemon is configured to write
+    # its log output to a file instead of to STDIO 
+    # (see .heroku/php/etc/php/conf.d/ext-newrelic.ini).
+    #
+    # Perpetually tail and redirect the daemon log file to stderr so that it
+    # may be observed via 'heroku logs'.
+    touch /tmp/heroku.ext-newrelic.newrelic-daemon.${PORT}.log
+    tail -qF -n 0 /tmp/heroku.ext-newrelic.newrelic-daemon.${PORT}.log 1>&2 &
 fi
 EOF
 

--- a/conf/php/conf.d/ext-newrelic.ini
+++ b/conf/php/conf.d/ext-newrelic.ini
@@ -8,4 +8,13 @@ newrelic.daemon.loglevel = ${NEW_RELIC_LOG_LEVEL}
 newrelic.license = ${NEW_RELIC_LICENSE_KEY}
 newrelic.appname = ${NEW_RELIC_APP_NAME}
 newrelic.logfile = stderr ; the stdout default messes up boots as we capture output for crash detection
-newrelic.daemon.logfile = stderr ; the stdout default messes up boots as we capture output for crash detection
+
+; The daemon is a spawned process, invoked by the PHP agent, which is truly
+; daemonized (i.e., it is disassociated from the controlling TTY and running
+; in the background). Therefore, the daemon is configured to write its log
+; output to a file instead of to STDIO.
+;
+; There is code in bin/compile to create the .profile.d/newrelic.sh. This
+; script contains the perpetual tail command which will redirect the daemon
+; log file to stderr so that it may be observed via 'heroku logs'.
+newrelic.daemon.logfile = /tmp/heroku.ext-newrelic.newrelic-daemon.${PORT}.log


### PR DESCRIPTION
The newrelic-daemon is a spawned process, invoked by the PHP agent, which is truly daemonized (i.e., it is disassociated from the controlling TTY and running in the background). Therefore, the daemon is configured to write its log output to a file instead of to STDIO.

This change enables observation of the newrelic-daemon logs via 'heroku logs'.
