### PR TITLE
Removed setting of NEW_RELIC_LOG in the bin/compile

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -336,7 +336,6 @@ fi
 cat > $BUILD_DIR/.profile.d/newrelic.sh <<"EOF"
 if [[ -n "$NEW_RELIC_LICENSE_KEY" ]]; then
     export NEW_RELIC_APP_NAME=${NEW_RELIC_APP_NAME:-"PHP Application on Heroku"}
-    export NEW_RELIC_LOG=${NEW_RELIC_LOG:-"stderr"}
     export NEW_RELIC_LOG_LEVEL=${NEW_RELIC_LOG_LEVEL:-"warning"}
 fi
 EOF


### PR DESCRIPTION
The PHP Agent needs to use stderr so that it doesn't interfere with
other features and configuration on the dyno (and in fact is hard-coded
to do so in ext-newrelic.ini).  So the setting of NEW_RELIC_LOG is harmless,
but not actually needed.
