### PR TITLE
Look at NEW_RELIC_CONFIG_FILE for user-provided agent configuration

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -338,6 +338,12 @@ if [[ -n "$NEW_RELIC_LICENSE_KEY" ]]; then
     export NEW_RELIC_APP_NAME=${NEW_RELIC_APP_NAME:-"PHP Application on Heroku"}
     export NEW_RELIC_LOG=${NEW_RELIC_LOG:-"stderr"}
     export NEW_RELIC_LOG_LEVEL=${NEW_RELIC_LOG_LEVEL:-"warning"}
+
+    if [[ -n "$NEW_RELIC_CONFIG_FILE" ]]; then
+      if [[ -f "/app/${NEW_RELIC_CONFIG_FILE}" ]]; then
+        cp "/app/${NEW_RELIC_CONFIG_FILE}" "/app/.heroku/php/etc/php/conf.d/zzz-ext-newrelic.ini"
+      fi
+    fi
 fi
 EOF
 


### PR DESCRIPTION
As is the convention for the python agent (see https://docs.newrelic.com/docs/agents/python-agent/hosting-services/python-agent-and-heroku#agent-configuration-file) ... we rely upon NEW_RELIC_CONFIG_FILE to allow the user to supply any additional agent configuration.
