### PR TITLE
Add a default nginx proxy cache location

### DIFF
--- a/conf/nginx/heroku.conf.php
+++ b/conf/nginx/heroku.conf.php
@@ -18,6 +18,9 @@ http {
 
     fastcgi_buffers 256 4k;
 
+    # define a disk cache for this nginx instance
+    proxy_cache_path /var/tmp/nginx_cache levels=1:2 keys_zone=DYNOCACHE:16m inactive=24h max_size=512m;
+
     # define an easy to reference name that can be used in fastgi_pass
     upstream heroku-fcgi {
         #server 127.0.0.1:4999 max_fails=3 fail_timeout=3s;


### PR DESCRIPTION
In order to use nginx proxy caches a named zone must be created via `proxy_cache_path` however I believe that can only be called within the HTTP context. This means there's no way to use proxy caches if the `-C` server context configs are used.

I think it should be fine to define a cache zone in the default config that can then be optionally used in the app specific configs which would give us more flexibility.
