### PR TITLE
Minimalistic nginx Server header

### DIFF
--- a/conf/nginx/nginx.conf.default
+++ b/conf/nginx/nginx.conf.default
@@ -31,4 +31,5 @@ http {
     keepalive_timeout  65;
 
     #gzip  on;
+    server_tokens off;
 }


### PR DESCRIPTION
Replace "Server: nginx/1.x.x" with just "Server: nginx".