### PR TITLE
add pear mail and smtp for use with sendgrid/mandrill/etc addons

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -386,3 +386,7 @@ if [[ ! -f "Procfile" ]]; then
     echo "web: $bindir/heroku-$engine-apache2" > Procfile
     notice_inline "No Procfile, using 'web: $bindir/heroku-$engine-apache2'."
 fi
+
+# Install pear mail and smtp for use with email addons
+/app/.heroku/php/bin/pear install mail
+/app/.heroku/php/bin/pear install Net_SMTP


### PR DESCRIPTION
There are a large number of buildpacks on GH that claim to do this, but they are not maintained. This is such a common feature that I believe it is worth considering it for the core buildpack.