### PR TITLE
$HTTP_RAW_POST_DATA automatic population removal

### DIFF
--- a/conf/php/php.ini
+++ b/conf/php/php.ini
@@ -775,6 +775,7 @@ default_mimetype = "text/html"
 ; to disable this feature.
 ; http://php.net/always-populate-raw-post-data
 ;always_populate_raw_post_data = On
+always_populate_raw_post_data = -1
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;
 ; Paths and Directories ;


### PR DESCRIPTION
Automatically populating $HTTP_RAW_POST_DATA is deprecated and will be removed in a future version of PHP. To avoid warnings, 'always_populate_raw_post_data' was set to '-1' in the php.ini configuration file.
http://php.net/manual/en/reserved.variables.httprawpostdata.php