### PR TITLE
Add heroku.json support

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -263,6 +263,13 @@ if [[ "${PHP_VERSION}" ]]; then
         exts=($(cat "$COMPOSER" | python -c 'from __future__ import print_function; import sys, json; { print(key[4:].lower()) for key in json.load(sys.stdin)["require"] if key.startswith("ext-")}' 2> /dev/null || true)) # convert to array
         ext_source="$COMPOSER"
     fi
+
+    # adds Heroku only ext-* requirements
+    HEROKU_COMPOSER_SUPPORT="heroku.json"
+    if [[ -f "$HEROKU_COMPOSER_SUPPORT" ]]; then
+        exts+=($(cat "$HEROKU_COMPOSER_SUPPORT" | python -c 'from __future__ import print_function; import sys, json; { print(key[4:].lower()) for key in json.load(sys.stdin).get("require", {}) if key.startswith("ext-")}' 2> /dev/null || true)) # convert to array
+    fi
+    
     for ext in "${!exts[@]}"; do # loop over keys in case the array is empty or else it'll error out
         install_ext "${exts[$ext]}" $ext_source
     done


### PR DESCRIPTION
This PR is a proposal for an additional `heroku.json` file.

What's the problem? Composer currently doesn't support a `X or Y` requirement, so to work with packages like [Imagine](http://imagine.readthedocs.org/en/latest/) (afaik) there are three solutions:

 1. include `"ext-gd": "*"` or `"ext-imagick": "*"` in the composer.json/lock, this could be a problem if the library is included as a dependency
 2. edit project to add one of them in the composer.json, not so OSS-friendly, this forces the project to start on platforms with the GD extension already installed
 3. create a custom buildpack, not a long-term solution

This PR is to add to the project some Heroku only requirements.
Why are them in the `require` section? To allow a possible future usage of other root-level keys.