### PR TITLE
fix declared build deps on composer

### DIFF
--- a/support/build/composer
+++ b/support/build/composer
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-5.5.12
+# Build Deps: php-min
 
 OUT_PREFIX=$1
 

--- a/support/build/composer-1.0.0alpha11
+++ b/support/build/composer-1.0.0alpha11
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-5.5.12
+# Build Deps: php-min
 
 VERSION=1.0.0-alpha11
 


### PR DESCRIPTION
The composer recipe still references php-5.5.12 as build dep, however that one was removed recently.

This patch changes this to php-min