### PR TITLE
Turn gzip on for nginx conf

### DIFF
--- a/conf/nginx/heroku.conf.php
+++ b/conf/nginx/heroku.conf.php
@@ -14,7 +14,7 @@ http {
     #keepalive_timeout  0;
     keepalive_timeout  65;
 
-    #gzip  on;
+    gzip  on;
 
     server_tokens off;
 


### PR DESCRIPTION
Deploys kept failing after git pushed the tar to remote, would output this:

```
gzip: stdin: not in gzip format
tar: Child returned status 1
```

This commit fixed it.