### PR TITLE
Improve the docker setup

### DIFF
--- a/support/build/_docker/cedar-14.Dockerfile
+++ b/support/build/_docker/cedar-14.Dockerfile
@@ -3,8 +3,7 @@ FROM heroku/cedar:14
 WORKDIR /app
 ENV WORKSPACE_DIR=/app/support/build
 
-RUN apt-get update
-RUN apt-get install -y python-pip
+RUN apt-get update && apt-get install -y python-pip
 
 RUN pip install 'bob-builder>=0.0.10' 's3cmd>=1.6.0'
 

--- a/support/build/_docker/cedar-14.Dockerfile
+++ b/support/build/_docker/cedar-14.Dockerfile
@@ -5,8 +5,8 @@ ENV WORKSPACE_DIR=/app/support/build
 
 RUN apt-get update && apt-get install -y python-pip
 
-ADD requirements.txt /app/requirements.txt
+COPY requirements.txt /app/requirements.txt
 
 RUN pip install -r /app/requirements.txt
 
-ADD . /app
+COPY . /app

--- a/support/build/_docker/cedar-14.Dockerfile
+++ b/support/build/_docker/cedar-14.Dockerfile
@@ -5,6 +5,8 @@ ENV WORKSPACE_DIR=/app/support/build
 
 RUN apt-get update && apt-get install -y python-pip
 
-RUN pip install 'bob-builder>=0.0.10' 's3cmd>=1.6.0'
+ADD requirements.txt /app/requirements.txt
+
+RUN pip install -r /app/requirements.txt
 
 ADD . /app


### PR DESCRIPTION
Due to layer caching, apt-get update would not run again when changing the list of installed packages if they are in separate layers.

The second commit reads pip requirements from the requirements.txt file instead of duplicating them, making things easier to maintain (no need to change them in 2 places)