### PR TITLE
Add -r flag to git rm --cached instructions

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -223,7 +223,7 @@ This directory should not be under version control; only your
 '$COMPOSER' and '$COMPOSER_LOCK' files should be added, which
 will let Composer handle installation of dependencies on deploy.
 To suppress this notice, first remove the folder from your index
-by running 'git rm --cached $composer_vendordir/'.
+by running 'git rm --cached $composer_vendordir/ -r'.
 Next, edit your project's '.gitignore' file and add the folder
 '/$composer_vendordir/' to the list.$composer_warn_bindir
 For more info, refer to the Composer FAQ: http://bit.ly/1rlCSZU"

--- a/bin/compile
+++ b/bin/compile
@@ -223,7 +223,7 @@ This directory should not be under version control; only your
 '$COMPOSER' and '$COMPOSER_LOCK' files should be added, which
 will let Composer handle installation of dependencies on deploy.
 To suppress this notice, first remove the folder from your index
-by running 'git rm --cached $composer_vendordir/ -r'.
+by running 'git rm -r --cached $composer_vendordir/'.
 Next, edit your project's '.gitignore' file and add the folder
 '/$composer_vendordir/' to the list.$composer_warn_bindir
 For more info, refer to the Composer FAQ: http://bit.ly/1rlCSZU"


### PR DESCRIPTION
Currently if you accidentally commit and deploy a PHP project with the `vendor/` directory, you get a warning as you should.

However, it tells you to use `git rm --cached` but doesn't tell you to use the `-r` flag to recursively remove the directory from source control. This just updates the warning to something that works.