### PR TITLE
Remove useless files

### DIFF
--- a/support/build/extensions/no-debug-non-zts-20131226/blackfire
+++ b/support/build/extensions/no-debug-non-zts-20131226/blackfire
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
-
-source $(dirname $0)/../no-debug-non-zts-20121212/blackfire

--- a/support/build/extensions/no-debug-non-zts-20131226/blackfire-1.14.1
+++ b/support/build/extensions/no-debug-non-zts-20131226/blackfire-1.14.1
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
 
-source $(dirname $0)/blackfire
+source $(dirname $0)/../no-debug-non-zts-20121212/blackfire

--- a/support/build/extensions/no-debug-non-zts-20151012/blackfire
+++ b/support/build/extensions/no-debug-non-zts-20151012/blackfire
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
-
-source $(dirname $0)/../no-debug-non-zts-20121212/blackfire

--- a/support/build/extensions/no-debug-non-zts-20151012/blackfire-1.14.1
+++ b/support/build/extensions/no-debug-non-zts-20151012/blackfire-1.14.1
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
 
-source $(dirname $0)/blackfire
+source $(dirname $0)/../no-debug-non-zts-20121212/blackfire

--- a/support/build/extensions/no-debug-non-zts-20160303/blackfire
+++ b/support/build/extensions/no-debug-non-zts-20160303/blackfire
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
-
-source $(dirname $0)/../no-debug-non-zts-20121212/blackfire

--- a/support/build/extensions/no-debug-non-zts-20160303/blackfire-1.14.1
+++ b/support/build/extensions/no-debug-non-zts-20160303/blackfire-1.14.1
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
 
-source $(dirname $0)/blackfire
+source $(dirname $0)/../no-debug-non-zts-20121212/blackfire


### PR DESCRIPTION
blackfire was the only extension having an unversioned file for each PHP version. All other extensions are referencing the ``no-debug-non-zts-20121212`` one directly from the unversioned file. So I did the same for blackfire for consistency.