### PR TITLE
Fix "$heroku local" failure on Ubuntu when using global executable composer.

### DIFF
--- a/bin/heroku-hhvm-apache2
+++ b/bin/heroku-hhvm-apache2
@@ -191,7 +191,7 @@ hhvm --php -r 'exit((int)version_compare(HHVM_VERSION, "3.0.1", "<"));' || { ech
 composer() {
     local composer_bin=$(which ./composer.phar composer | head -n1)
     # check if we the composer binary is executable by PHP
-    if file --brief --dereference $composer_bin | grep -e "shell" -e "bash" > /dev/null ; then # newer versions of file return "data" for .phar
+    if file --brief --dereference $composer_bin | grep -e "shell" -e "bash" -e "script" > /dev/null ; then # newer versions of file return "data" for .phar
         # run it directly; it's probably a bash script or similar (homebrew-php does this)
         $composer_bin "$@"
     else

--- a/bin/heroku-hhvm-nginx
+++ b/bin/heroku-hhvm-nginx
@@ -191,7 +191,7 @@ hhvm --php -r 'exit((int)version_compare(HHVM_VERSION, "3.0.1", "<"));' || { ech
 composer() {
     local composer_bin=$(which ./composer.phar composer | head -n1)
     # check if we the composer binary is executable by HHVM
-    if file --brief --dereference $composer_bin | grep -e "shell" -e "bash" > /dev/null ; then # newer versions of file return "data" for .phar
+    if file --brief --dereference $composer_bin | grep -e "shell" -e "bash" -e "script" > /dev/null ; then # newer versions of file return "data" for .phar
         # run it directly; it's probably a bash script or similar (homebrew-php does this)
         $composer_bin "$@"
     else

--- a/bin/heroku-php-apache2
+++ b/bin/heroku-php-apache2
@@ -200,7 +200,7 @@ php -n -r 'exit((int)version_compare(PHP_VERSION, "5.5.11", "<"));' || { echo "T
 composer() {
     local composer_bin=$(which ./composer.phar composer | head -n1)
     # check if we the composer binary is executable by PHP
-    if file --brief --dereference $composer_bin | grep -e "shell" -e "bash" > /dev/null ; then # newer versions of file return "data" for .phar
+    if file --brief --dereference $composer_bin | grep -e "shell" -e "bash" -e "script" > /dev/null ; then # newer versions of file return "data" for .phar
         # run it directly; it's probably a bash script or similar (homebrew-php does this)
         $composer_bin "$@"
     else

--- a/bin/heroku-php-nginx
+++ b/bin/heroku-php-nginx
@@ -201,7 +201,7 @@ unset -f php-fpm # remove the alias we made earlier that would prevent newrelic 
 composer() {
     local composer_bin=$(which ./composer.phar composer | head -n1)
     # check if we the composer binary is executable by PHP
-    if file --brief --dereference $composer_bin | grep -e "shell" -e "bash" > /dev/null ; then # newer versions of file return "data" for .phar
+    if file --brief --dereference $composer_bin | grep -e "shell" -e "bash" -e "script" > /dev/null ; then # newer versions of file return "data" for .phar
         # run it directly; it's probably a bash script or similar (homebrew-php does this)
         $composer_bin "$@"
     else


### PR DESCRIPTION
> -> % heroku local
[WARN] No ENV file found
7:22:34 AM web.1 |  Unable to determine Composer vendor-dir setting; is 'composer' executable on path or 'composer.phar' in current working directory?
[DONE] Killing all processes with signal  null
7:22:34 AM web.1 Exited with exit code 1
