### PR TITLE
Set composer files explicitly

### DIFF
--- a/conf/apache2/heroku.conf
+++ b/conf/apache2/heroku.conf
@@ -29,7 +29,7 @@ Listen ${PORT}
         # lock it down fully by default
         # if it's also the docroot, it'll be opened up again further below
         Require all denied
-        <FilesMatch "^(\.|composer\.|Procfile$)">
+        <FilesMatch "^(\.|composer\.json|composer\.lock|Procfile$)">
             # explicitly deny these again, merged with the docroot later
             Require all denied
         </FilesMatch>

--- a/conf/nginx/default_include.conf.php
+++ b/conf/nginx/default_include.conf.php
@@ -3,6 +3,6 @@ location / {
 }
 
 # for people with app root as doc root, restrict access to a few things
-location ~ ^/(composer\.|Procfile$|<?=getenv('COMPOSER_VENDOR_DIR')?>/|<?=getenv('COMPOSER_BIN_DIR')?>/) {
+location ~ ^/(composer\.json|composer\.lock|Procfile$|<?=getenv('COMPOSER_VENDOR_DIR')?>/|<?=getenv('COMPOSER_BIN_DIR')?>/) {
     deny all;
 }


### PR DESCRIPTION
The current buildpack version breaks WordPress Hybrid Composer plugin (it has composer.js file inside). Maybe it's better to explicitly exclude composer.json and composer.lock files.