### PR TITLE
Sodium for php-min

### DIFF
--- a/support/build/php-min
+++ b/support/build/php-min
@@ -47,6 +47,7 @@ export PATH=${OUT_PREFIX}/bin:$PATH
     --disable-session \
     --disable-simplexml \
     --without-sqlite3 \
+    --with-sodium \
     --enable-sockets \
     --disable-xml \
     --disable-xmlreader \


### PR DESCRIPTION
Otherwise applications like Symfony break who run scripts during Composer Install.

closes #259 