### PR TITLE
Don't suppress FPM errors

### DIFF
--- a/conf/php/php-fpm.conf
+++ b/conf/php/php-fpm.conf
@@ -522,9 +522,9 @@ clear_env = no
 ; Default Value: nothing is defined by default except the values in php.ini and
 ;                specified at startup with the -d argument
 ;php_admin_value[sendmail_path] = /usr/sbin/sendmail -t -i -f www@my.domain.com
-;php_flag[display_errors] = off
+php_admin_flag[display_errors] = off
 ;php_admin_value[error_log] = /var/log/fpm-php.www.log
-;php_admin_flag[log_errors] = on
+php_admin_flag[log_errors] = on
 ;php_admin_value[memory_limit] = 32M
 
 ; log PHP errors to a file, otherwise they're bubbled up through FPM via stderr


### PR DESCRIPTION
When using php in a frontend application it's relatively fine, but in an API context this is a much bigger issue.
Essentially what happens is nginx sees any output from php-fpm as valid, even though it's not, and will return 200 ok. 

[reference](https://ma.ttias.be/nginx-sets-http-200-ok-php-fpm-parse-errors/)

By default, it should fail, not provide a false sense of security.