### PR TITLE
run tests if 'composer test' is defined

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+main() {
+    # parse the arguments into variables
+    declare build_dir="${1:-}"
+
+    # check if composer tests are available
+    if composer run-script -l 2>/dev/null | grep -q '^\s*test\b'; then
+        # cd into the build directory and run the tests via composer
+        cd "$build_dir" && composer test
+    else # if no tests are defined...
+        # ...display a friendly reminder to define some
+        printf "\033[0;31mNo test command found! Please define a test command in the composer.json in order to run test.\033[0m\n"
+    fi
+}
+
+# fail hard
+set -eo pipefail
+# fail harder
+set -eu
+
+# execute the main function with command line arguments
+main "$@"

--- a/bin/test
+++ b/bin/test
@@ -13,7 +13,7 @@ declare build_dir="${1:-}"
 # check if composer tests are available
 if cd "$build_dir" && composer run-script -l 2>/dev/null | grep -q '^\s*test\b'; then
     # cd into the build directory and run the tests via composer
-    cd "$build_dir" && composer  run-script --timeout=0 test
+    cd "$build_dir" && composer run-script --timeout=0 test
 else # if no tests are defined...
     # ...display a friendly reminder to define some
     printf "\033[0;31mNo test command found! Please define a test command in the composer.json in order to run test.\033[0m\n"

--- a/bin/test
+++ b/bin/test
@@ -10,10 +10,10 @@ set -eu
 # name the command line argument for this script
 declare build_dir="${1:-}"
 
-# check if composer tests are available
-if cd "$build_dir" && composer run-script -l 2>/dev/null | grep -q '^\s*test\b'; then
-    # cd into the build directory and run the tests via composer
-    cd "$build_dir" && composer run-script --timeout=0 test
+# push the builddir to the directory stack and check if composer tests are available
+if pushd "$build_dir" && composer run-script -l 2>/dev/null | grep -q '^\s*test\b'; then
+    # run tests via composer in the build_dir
+    composer run-script --timeout=0 test
 else # if no tests are defined...
     # ...display a friendly reminder to define some
     printf "\033[0;31mNo test command found! Please define a test command in the composer.json in order to run test.\033[0m\n"

--- a/bin/test
+++ b/bin/test
@@ -1,23 +1,20 @@
 #!/bin/bash
 
-main() {
-    # name the argument to this function
-    declare build_dir="${1:-}"
-
-    # check if composer tests are available
-    if cd "$build_dir" && composer run-script -l 2>/dev/null | grep -q '^\s*test\b'; then
-        # cd into the build directory and run the tests via composer
-        cd "$build_dir" && composer test
-    else # if no tests are defined...
-        # ...display a friendly reminder to define some
-        printf "\033[0;31mNo test command found! Please define a test command in the composer.json in order to run test.\033[0m\n"
-    fi
-}
 
 # fail hard
 set -eo pipefail
 # fail harder
 set -eu
 
-# execute the main function with command line arguments
-main "$@"
+
+# name the argument to this function
+declare build_dir="${1:-}"
+
+# check if composer tests are available
+if cd "$build_dir" && composer run-script -l 2>/dev/null | grep -q '^\s*test\b'; then
+    # cd into the build directory and run the tests via composer
+    cd "$build_dir" && composer test
+else # if no tests are defined...
+    # ...display a friendly reminder to define some
+    printf "\033[0;31mNo test command found! Please define a test command in the composer.json in order to run test.\033[0m\n"
+fi

--- a/bin/test
+++ b/bin/test
@@ -7,13 +7,13 @@ set -eo pipefail
 set -eu
 
 
-# name the argument to this function
+# name the command line argument for this script
 declare build_dir="${1:-}"
 
 # check if composer tests are available
 if cd "$build_dir" && composer run-script -l 2>/dev/null | grep -q '^\s*test\b'; then
     # cd into the build directory and run the tests via composer
-    cd "$build_dir" && composer test
+    cd "$build_dir" && composer  run-script --timeout=0 test
 else # if no tests are defined...
     # ...display a friendly reminder to define some
     printf "\033[0;31mNo test command found! Please define a test command in the composer.json in order to run test.\033[0m\n"

--- a/bin/test
+++ b/bin/test
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 main() {
-    # parse the arguments into variables
+    # name the argument to this function
     declare build_dir="${1:-}"
 
     # check if composer tests are available
-    if composer run-script -l 2>/dev/null | grep -q '^\s*test\b'; then
+    if cd "$build_dir" && composer run-script -l 2>/dev/null | grep -q '^\s*test\b'; then
         # cd into the build directory and run the tests via composer
         cd "$build_dir" && composer test
     else # if no tests are defined...

--- a/bin/test
+++ b/bin/test
@@ -14,7 +14,4 @@ declare build_dir="${1:-}"
 if pushd "$build_dir" && composer run-script -l 2>/dev/null | grep -q '^\s*test\b'; then
     # run tests via composer in the build_dir
     composer run-script --timeout=0 test
-else # if no tests are defined...
-    # ...display a friendly reminder to define some
-    printf "\033[0;31mNo test command found! Please define a test command in the composer.json in order to run test.\033[0m\n"
 fi


### PR DESCRIPTION
The buildpack for php should feature tests, like in the nodejs or ruby buildpack. As the nodejs features tests with `yarn test` or `npm test`the php-buildpack should feature tests run
with `composer test`.

This pull request contains a small test script, that executes the test command if it is definded.
If the command is not defined, a notice is printed.