### PR TITLE
Tweak opcode cache settings

### DIFF
--- a/support/build/_conf/php/conf.d/010-ext-zend_opcache.ini
+++ b/support/build/_conf/php/conf.d/010-ext-zend_opcache.ini
@@ -3,5 +3,5 @@ opcache.enable_cli=1
 opcache.validate_timestamps=0
 opcache.fast_shutdown=0
 opcache.memory_consumption=128
-opcache.interned_strings_buffer=8
-opcache.max_accelerated_files=4000
+opcache.interned_strings_buffer=16
+opcache.max_accelerated_files=32531


### PR DESCRIPTION
I'd like to propose two opcode cache setting changes.

 * * *

### `opcache.interned_strings_buffer`

PHP 7's default is already `8`, we might as well double it, that leaves 112 MB for the rest of the cache.

 * * *

### `opcache.max_accelerated_files`

PHP 7's default is `10000`, which actually translates to `16229` ([see docs](http://php.net/manual/en/opcache.configuration.php#ini.opcache.interned-strings-buffer)).

The current Heroku default of `4000` is actually `7963`.

On a relatively small Laravel app you're easily past 8000 PHP files, so `32531` seems like a reasonable number.

 * * *

Alternatively, we could stay on the safe side and remove both lines, that way we default to PHP's standard values.




