### PR TITLE
v146: Install buildpack to .heroku/php/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # heroku-buildpack-php CHANGELOG
 
+## v146 (2019-11-06)
+
+### CHG
+
+- Install buildpack to .heroku/php/ instead of vendor/heroku/heroku-buildpack-php/ [David Zuelke]
+
 ## v145 (2019-10-16)
 
 ### ADD

--- a/bin/compile
+++ b/bin/compile
@@ -347,7 +347,7 @@ else
 fi
 export HEROKU_PHP_DEFAULT_RUNTIME_VERSION
 # extract requirements from composer.lock
-/app/.heroku/php-min/bin/php $bp_dir/bin/util/platform.php "$bp_dir/support/installer/" $HEROKU_PHP_PLATFORM_REPOSITORIES 2>&1 >$build_dir/.heroku/php/composer.json | indent || {
+/app/.heroku/php-min/bin/php $bp_dir/bin/util/platform.php "$bp_dir/support/installer/" "$bp_dir/" $HEROKU_PHP_PLATFORM_REPOSITORIES 2>&1 >$build_dir/.heroku/php/composer.json | indent || {
 	code=$?
 	if [[ $code -eq 3 ]]; then
 		mcount "failures.platform.composer_lock.runtime_only_in_dev"
@@ -704,18 +704,13 @@ fi
 
 status "Preparing runtime environment..."
 
-# install this buildpack like a composer package
+# this buildpack was installed as a composer package in the platform install step
 # it will contain the apache/nginx/php configs and the boot script
-# TODO: warn if require-dev has the package using a different branch
-shopt -u dotglob # we don't want .git, .gitignore et al
-# figure out the package dir name to write to and copy to it
-hbpdir="$composer_vendordir/$(cat $bp_dir/composer.json | python -c 'import sys, json; print(json.load(sys.stdin)["name"])')"
-mkdir -p "$build_dir/$hbpdir"
-cp -r "$bp_dir"/* "$build_dir/$hbpdir/"
+# we used to write this to /app/vendor/, so we need to put symlinks to the binaries in place, as most Procfiles will have "vendor/bin/heroku-php-apache2" and similar
 # make bin dir, just in case
 mkdir -p "$build_dir/$composer_bindir"
-# figure out shortest relative path from vendor/heroku/heroku-buildpack-php to vendor/bin (or whatever the bin dir is)
-relbin=$(python -c "import os.path; print(os.path.relpath('$hbpdir', '$composer_bindir'))")
+# figure out shortest relative path from .heroku/php/vendor/heroku/heroku-buildpack-php to vendor/bin (or whatever the bin dir is)
+relbin=$(python -c "import os.path; print(os.path.relpath('.heroku/php/vendor/heroku/heroku-buildpack-php', '$composer_bindir'))")
 # collect bin names from composer.json
 relbins=$(cat $bp_dir/composer.json | python -c 'from __future__ import print_function; import sys, json; { print(sys.argv[1]+"/"+bin) for bin in json.load(sys.stdin)["bin"] }' $relbin)
 # link to bins

--- a/bin/heroku-hhvm-apache2
+++ b/bin/heroku-hhvm-apache2
@@ -54,19 +54,19 @@ print_help() {
 		                          Recommended approach when customizing Apache2's config
 		                          in most cases, unless you need to set fundamental
 		                          server level options.
-		                          [default: \$COMPOSER_VENDOR_DIR/heroku/heroku-buildpack-php/conf/apache2/default_include.conf]
+		                          [default: <BPDIR>/conf/apache2/default_include.conf]
 		  -c <httpd.conf>         The path to the full VHost configuration file that is
 		                          included after Heroku's (or your local) Apache2 config
 		                          is loaded. Must contain a 'Listen \${PORT}' directive
 		                          and should have a '<VirtualHost>' and likely also a
 		                          '<Directory>' section (see option -C above).
-		                          [default: \$COMPOSER_VENDOR_DIR/heroku/heroku-buildpack-php/conf/apache2/heroku.conf]
+		                          [default: <BPDIR>/conf/apache2/heroku.conf]
 		  -h, --help              Display this help screen and exit.
 		  -I <php.extra.ini>      The path to an extra php.ini to use in addition to the
 		                          default HHVM php.ini (see option -i below).
 		  -i <php.ini>            The path to the php.ini file to use. It is highly
 		                          recommended to use the -I option (see above) instead.
-		                          [default: \$COMPOSER_VENDOR_DIR/heroku/heroku-buildpack-php/conf/hhvm/php.ini.php]
+		                          [default: <BPDIR>/conf/hhvm/php.ini.php]
 		  -l <tailme.log>         Path to additional log file to tail to STDERR so its
 		                          contents appear in 'heroku logs'. If the file does not
 		                          exist, it will be created. Wildcards are allowed, but
@@ -77,6 +77,9 @@ print_help() {
 		                          the \$PORT environment variable, or a random port is
 		                          chosen if that variable does not exist.
 		  -v, --verbose           Be more verbose during startup.
+		
+		The <BPDIR> placeholder above represents the base directory of this buildpack:
+		$bp_dir
 		
 		All file paths must be relative to '$HEROKU_APP_DIR'.
 		
@@ -95,6 +98,7 @@ export HEROKU_APP_DIR=$(pwd)
 export DOCUMENT_ROOT="$HEROKU_APP_DIR"
 # set a default port if none is given
 export PORT=${PORT:-$(( $RANDOM+1024 ))}
+bp_dir=$(cd $(dirname $(realpath $0)); cd ..; pwd)
 
 # init logs array here as empty before parsing options; -l could append to it, but the default list gets added later since we use $PORT in there and that can be set using -p
 declare -a logs
@@ -202,6 +206,7 @@ composer() {
 		hhvm $composer_bin "$@"
 	fi
 }
+# these exports are used in default web server configs to lock down access to composer directories
 COMPOSER_VENDOR_DIR=$(composer config vendor-dir 2> /dev/null | tail -n 1) && export COMPOSER_VENDOR_DIR || { echo "Unable to determine Composer vendor-dir setting; is 'composer' executable on path or 'composer.phar' in current working directory?" >&2; exit 1; } # tail, as composer echos outdated version warnings to STDOUT; export after the assignment or exit status will that be of 'export
 COMPOSER_BIN_DIR=$(composer config bin-dir 2> /dev/null | tail -n 1) && export COMPOSER_BIN_DIR || { echo "Unable to determine Composer bin-dir setting; is 'composer' executable on path or 'composer.phar' in current working directory?" >&2; exit 1; } # tail, as composer echos outdated version warnings to STDOUT; export after the assignment or exit status will that be of 'export
 
@@ -222,7 +227,7 @@ if [[ "$#" == "1" ]]; then
 fi
 
 function prepare_hhvm_ini() { # we have to do this twice, as the WEB_CONCURRENCY setting is evaluated using PHP code, not ${...} syntax which HHVM does not support; if a value for $1 is passed then it won't echo messages upon second invocation
-if [[ ( -n ${php_config:-} && ! ${1:-} ) || ( ${php_config:="$HEROKU_APP_DIR/$COMPOSER_VENDOR_DIR/heroku/heroku-buildpack-php/conf/hhvm/php.ini.php"} && $verbose && ! ${1:-} ) ]]; then
+if [[ ( -n ${php_config:-} && ! ${1:-} ) || ( ${php_config:="$bp_dir/conf/hhvm/php.ini.php"} && $verbose && ! ${1:-} ) ]]; then
 	echo "Using HHVM configuration (php.ini) file '${php_config#$HEROKU_APP_DIR/}'" >&2
 fi
 php_configs=( "-c" "$(php_passthrough "$php_config")" )
@@ -234,13 +239,13 @@ fi
 }
 prepare_hhvm_ini
 
-if [[ -n ${httpd_config_include:-} || ( ${httpd_config_include:="$HEROKU_APP_DIR/$COMPOSER_VENDOR_DIR/heroku/heroku-buildpack-php/conf/apache2/default_include.conf"} && $verbose ) ]]; then
+if [[ -n ${httpd_config_include:-} || ( ${httpd_config_include:="$bp_dir/conf/apache2/default_include.conf"} && $verbose ) ]]; then
 	echo "Using Apache2 VirtualHost-level configuration include '${httpd_config_include#$HEROKU_APP_DIR/}'" >&2
 fi
 httpd_config_include=$(php_passthrough "$httpd_config_include")
 export HEROKU_PHP_HTTPD_CONFIG_INCLUDE="$httpd_config_include"
 
-if [[ -n ${httpd_config:-} || ( ${httpd_config:="$HEROKU_APP_DIR/$COMPOSER_VENDOR_DIR/heroku/heroku-buildpack-php/conf/apache2/heroku.conf"} && $verbose) ]]; then
+if [[ -n ${httpd_config:-} || ( ${httpd_config:="$bp_dir/conf/apache2/heroku.conf"} && $verbose) ]]; then
 	echo "Using Apache2 configuration file '${httpd_config#$HEROKU_APP_DIR/}'" >&2
 fi
 httpd_config=$(php_passthrough "$httpd_config")
@@ -264,7 +269,7 @@ if [[ -z ${WEB_CONCURRENCY:-} ]]; then
 	fi
 
 	# determine number of HHVM threads to run
-	read WEB_CONCURRENCY php_memory_limit <<<$(hhvm "${php_configs[@]}" $(composer config vendor-dir 2> /dev/null | tail -n 1)/heroku/heroku-buildpack-php/bin/util/autotune.php "$ram") # tail, as composer echos outdated version warnings to STDOUT
+	read WEB_CONCURRENCY php_memory_limit <<<$(hhvm "${php_configs[@]}" $bp_dir/bin/util/autotune.php "$ram")
 	[[ $WEB_CONCURRENCY -lt 1 ]] && WEB_CONCURRENCY=1
 	export WEB_CONCURRENCY
 

--- a/bin/heroku-hhvm-nginx
+++ b/bin/heroku-hhvm-nginx
@@ -54,7 +54,7 @@ print_help() {
 		                          Recommended approach when customizing Nginx's config
 		                          in most cases, unless you need to set http or
 		                          fundamental server level options.
-		                          [default: \$COMPOSER_VENDOR_DIR/heroku/heroku-buildpack-php/conf/nginx/default_include.conf.php]
+		                          [default: <BPDIR>/conf/nginx/default_include.conf.php]
 		  -c <nginx.conf>         The path to the full configuration file that is
 		                          included after Heroku's (or your local) Nginx config
 		                          is loaded. It must contain an 'http { ... }' block
@@ -62,13 +62,13 @@ print_help() {
 		                          and 'root' (see option -C above), but no global,
 		                          directives (globals are read from the system's default
 		                          Nginx configuration files).
-		                          [default: \$COMPOSER_VENDOR_DIR/heroku/heroku-buildpack-php/conf/nginx/heroku.conf.php]
+		                          [default: <BPDIR>/conf/nginx/heroku.conf.php]
 		  -h, --help              Display this help screen and exit.
 		  -I <php.extra.ini>      The path to an extra php.ini to use in addition to the
 		                          default HHVM php.ini (see option -i below).
 		  -i <php.ini>            The path to the php.ini file to use. It is highly
 		                          recommended to use the -I option (see above) instead.
-		                          [default: \$COMPOSER_VENDOR_DIR/heroku/heroku-buildpack-php/conf/hhvm/php.ini.php]
+		                          [default: <BPDIR>/conf/hhvm/php.ini.php]
 		  -l <tailme.log>         Path to additional log file to tail to STDERR so its
 		                          contents appear in 'heroku logs'. If the file does not
 		                          exist, it will be created. Wildcards are allowed, but
@@ -79,6 +79,9 @@ print_help() {
 		                          the \$PORT environment variable, or a random port is
 		                          chosen if that variable does not exist.
 		  -v, --verbose           Be more verbose during startup.
+		
+		The <BPDIR> placeholder above represents the base directory of this buildpack:
+		$bp_dir
 		
 		All file paths must be relative to '$HEROKU_APP_DIR'.
 		
@@ -96,6 +99,7 @@ export HEROKU_APP_DIR=$(pwd)
 export DOCUMENT_ROOT="$HEROKU_APP_DIR"
 # set a default port if none is given
 export PORT=${PORT:-$(( $RANDOM+1024 ))}
+bp_dir=$(cd $(dirname $(realpath $0)); cd ..; pwd)
 
 # init logs array here as empty before parsing options; -l could append to it, but the default list gets added later since we use $PORT in there and that can be set using -p
 declare -a logs
@@ -202,6 +206,7 @@ composer() {
 		hhvm $composer_bin "$@"
 	fi
 }
+# these exports are used in default web server configs to lock down access to composer directories
 COMPOSER_VENDOR_DIR=$(composer config vendor-dir 2> /dev/null | tail -n 1) && export COMPOSER_VENDOR_DIR || { echo "Unable to determine Composer vendor-dir setting; is 'composer' executable on path or 'composer.phar' in current working directory?" >&2; exit 1; } # tail, as composer echos outdated version warnings to STDOUT; export after the assignment or exit status will that be of 'export
 COMPOSER_BIN_DIR=$(composer config bin-dir 2> /dev/null | tail -n 1) && export COMPOSER_BIN_DIR || { echo "Unable to determine Composer bin-dir setting; is 'composer' executable on path or 'composer.phar' in current working directory?" >&2; exit 1; } # tail, as composer echos outdated version warnings to STDOUT; export after the assignment or exit status will that be of 'export
 
@@ -222,7 +227,7 @@ if [[ "$#" == "1" ]]; then
 fi
 
 function prepare_hhvm_ini() { # we have to do this twice, as the WEB_CONCURRENCY setting is evaluated using PHP code, not ${...} syntax which HHVM does not support; if a value for $1 is passed then it won't echo messages upon second invocation
-if [[ ( -n ${php_config:-} && ! ${1:-} ) || ( ${php_config:="$HEROKU_APP_DIR/$COMPOSER_VENDOR_DIR/heroku/heroku-buildpack-php/conf/hhvm/php.ini.php"} && $verbose && ! ${1:-} ) ]]; then
+if [[ ( -n ${php_config:-} && ! ${1:-} ) || ( ${php_config:="$bp_dir/conf/hhvm/php.ini.php"} && $verbose && ! ${1:-} ) ]]; then
 	echo "Using HHVM configuration (php.ini) file '${php_config#$HEROKU_APP_DIR/}'" >&2
 fi
 php_configs=( "-c" "$(php_passthrough "$php_config")" )
@@ -234,13 +239,13 @@ fi
 }
 prepare_hhvm_ini
 
-if [[ -n ${nginx_config_include:-} || ( ${nginx_config_include:="$HEROKU_APP_DIR/$COMPOSER_VENDOR_DIR/heroku/heroku-buildpack-php/conf/nginx/default_include.conf.php"} && $verbose ) ]]; then
+if [[ -n ${nginx_config_include:-} || ( ${nginx_config_include:="$bp_dir/conf/nginx/default_include.conf.php"} && $verbose ) ]]; then
 	echo "Using Nginx server-level configuration include '${nginx_config_include#$HEROKU_APP_DIR/}'" >&2
 fi
 nginx_config_include=$(php_passthrough "$nginx_config_include")
 export HEROKU_PHP_NGINX_CONFIG_INCLUDE="$nginx_config_include"
 
-if [[ -n ${nginx_config:-} || ( ${nginx_config:="$HEROKU_APP_DIR/$COMPOSER_VENDOR_DIR/heroku/heroku-buildpack-php/conf/nginx/heroku.conf.php"} && $verbose) ]]; then
+if [[ -n ${nginx_config:-} || ( ${nginx_config:="$bp_dir/conf/nginx/heroku.conf.php"} && $verbose) ]]; then
 	echo "Using Nginx configuration file '${nginx_config#$HEROKU_APP_DIR/}'" >&2
 fi
 nginx_config=$(php_passthrough "$nginx_config")
@@ -264,7 +269,7 @@ if [[ -z ${WEB_CONCURRENCY:-} ]]; then
 	fi
 
 	# determine number of HHVM threads to run
-	read WEB_CONCURRENCY php_memory_limit <<<$(hhvm "${php_configs[@]}" $(composer config vendor-dir 2> /dev/null | tail -n 1)/heroku/heroku-buildpack-php/bin/util/autotune.php "$ram") # tail, as composer echos outdated version warnings to STDOUT
+	read WEB_CONCURRENCY php_memory_limit <<<$(hhvm "${php_configs[@]}" $bp_dir/bin/util/autotune.php "$ram")
 	[[ $WEB_CONCURRENCY -lt 1 ]] && WEB_CONCURRENCY=1
 	export WEB_CONCURRENCY
 

--- a/bin/heroku-php-apache2
+++ b/bin/heroku-php-apache2
@@ -54,23 +54,23 @@ print_help() {
 		                          Recommended approach when customizing Apache2's config
 		                          in most cases, unless you need to set fundamental
 		                          server level options.
-		                          [default: \$COMPOSER_VENDOR_DIR/heroku/heroku-buildpack-php/conf/apache2/default_include.conf]
+		                          [default: <BPDIR>/conf/apache2/default_include.conf]
 		  -c <httpd.conf>         The path to the full VHost configuration file that is
 		                          included after Heroku's (or your local) Apache2 config
 		                          is loaded. Must contain a 'Listen \${PORT}' directive
 		                          and should have a '<VirtualHost>' and likely also a
 		                          '<Directory>' section (see option -C above).
-		                          [default: \$COMPOSER_VENDOR_DIR/heroku/heroku-buildpack-php/conf/apache2/heroku.conf]
+		                          [default: <BPDIR>/conf/apache2/heroku.conf]
 		  -F <php-fpm.inc.conf>   The path to the configuration file to include at the
 		                          end of php-fpm.conf (see option -f below), in the
 		                          '[www]' pool section. Recommended approach when
 		                          customizing PHP-FPM's configuration in most cases,
 		                          unless you need to set global options.
 		  -f <php-fpm.conf>       The path to the full PHP-FPM configuration file.
-		                          [default: \$COMPOSER_VENDOR_DIR/heroku/heroku-buildpack-php/conf/php/php-fpm.conf]
+		                          [default: <BPDIR>/conf/php/php-fpm.conf]
 		  -h, --help              Display this help screen and exit.
 		  -i <php.ini>            The path to the php.ini file to use.
-		                          [default: \$COMPOSER_VENDOR_DIR/heroku/heroku-buildpack-php/conf/php/php.ini]
+		                          [default: <BPDIR>/conf/php/php.ini]
 		  -l <tailme.log>         Path to additional log file to tail to STDERR so its
 		                          contents appear in 'heroku logs'. If the file does not
 		                          exist, it will be created. Wildcards are allowed, but
@@ -81,6 +81,9 @@ print_help() {
 		                          the \$PORT environment variable, or a random port is
 		                          chosen if that variable does not exist.
 		  -v, --verbose           Be more verbose during startup.
+		
+		The <BPDIR> placeholder above represents the base directory of this buildpack:
+		$bp_dir
 		
 		All file paths must be relative to '$HEROKU_APP_DIR'.
 		
@@ -99,6 +102,7 @@ export HEROKU_APP_DIR=$(pwd)
 export DOCUMENT_ROOT="$HEROKU_APP_DIR"
 # set a default port if none is given
 export PORT=${PORT:-$(( $RANDOM+1024 ))}
+bp_dir=$(cd $(dirname $(realpath $0)); cd ..; pwd)
 
 # init logs array here as empty before parsing options; -l could append to it, but the default list gets added later since we use $PORT in there and that can be set using -p
 declare -a logs
@@ -211,6 +215,7 @@ composer() {
 		php -n $composer_bin "$@"
 	fi
 }
+# these exports are used in default web server configs to lock down access to composer directories
 COMPOSER_VENDOR_DIR=$(composer config vendor-dir 2> /dev/null | tail -n 1) && export COMPOSER_VENDOR_DIR || { echo "Unable to determine Composer vendor-dir setting; is 'composer' executable on path or 'composer.phar' in current working directory?" >&2; exit 1; } # tail, as composer echos outdated version warnings to STDOUT; export after the assignment or exit status will that be of 'export
 COMPOSER_BIN_DIR=$(composer config bin-dir 2> /dev/null | tail -n 1) && export COMPOSER_BIN_DIR || { echo "Unable to determine Composer bin-dir setting; is 'composer' executable on path or 'composer.phar' in current working directory?" >&2; exit 1; } # tail, as composer echos outdated version warnings to STDOUT; export after the assignment or exit status will that be of 'export
 
@@ -236,7 +241,7 @@ if [[ -n ${fpm_config_include:-} ]]; then
 	export HEROKU_PHP_FPM_CONFIG_INCLUDE="$fpm_config_include"
 fi
 
-if [[ -n ${fpm_config:-} || ( ${fpm_config:="$HEROKU_APP_DIR/$COMPOSER_VENDOR_DIR/heroku/heroku-buildpack-php/conf/php/php-fpm.conf"} && $verbose ) ]]; then
+if [[ -n ${fpm_config:-} || ( ${fpm_config:="$bp_dir/conf/php/php-fpm.conf"} && $verbose ) ]]; then
 	echo "Using PHP-FPM configuration file '${fpm_config#$HEROKU_APP_DIR/}'" >&2
 fi
 fpm_config=$(php_passthrough "$fpm_config")
@@ -246,13 +251,13 @@ if [[ -n ${php_config:-} ]]; then
 	php_config=$(php_passthrough "$php_config")
 fi
 
-if [[ -n ${httpd_config_include:-} || ( ${httpd_config_include:="$HEROKU_APP_DIR/$COMPOSER_VENDOR_DIR/heroku/heroku-buildpack-php/conf/apache2/default_include.conf"} && $verbose ) ]]; then
+if [[ -n ${httpd_config_include:-} || ( ${httpd_config_include:="$bp_dir/conf/apache2/default_include.conf"} && $verbose ) ]]; then
 	echo "Using Apache2 VirtualHost-level configuration include '${httpd_config_include#$HEROKU_APP_DIR/}'" >&2
 fi
 httpd_config_include=$(php_passthrough "$httpd_config_include")
 export HEROKU_PHP_HTTPD_CONFIG_INCLUDE="$httpd_config_include"
 
-if [[ -n ${httpd_config:-} || ( ${httpd_config:="$HEROKU_APP_DIR/$COMPOSER_VENDOR_DIR/heroku/heroku-buildpack-php/conf/apache2/heroku.conf"} && $verbose) ]]; then
+if [[ -n ${httpd_config:-} || ( ${httpd_config:="$bp_dir/conf/apache2/heroku.conf"} && $verbose) ]]; then
 	echo "Using Apache2 configuration file '${httpd_config#$HEROKU_APP_DIR/}'" >&2
 fi
 httpd_config=$(php_passthrough "$httpd_config")
@@ -277,7 +282,7 @@ if [[ -z ${WEB_CONCURRENCY:-} ]]; then
 
 	# determine number of FPM processes to run
 	# prevent loading of extension INIs (and thus e.g. newrelic) using empty PHP_INI_SCAN_DIR
-	read WEB_CONCURRENCY php_memory_limit <<<$(PHP_INI_SCAN_DIR= php ${php_config:+-c "$php_config"} $(composer config vendor-dir 2> /dev/null | tail -n 1)/heroku/heroku-buildpack-php/bin/util/autotune.php -y "$fpm_config" -t "$DOCUMENT_ROOT" "$ram") # tail, as composer echos outdated version warnings to STDOUT
+	read WEB_CONCURRENCY php_memory_limit <<<$(PHP_INI_SCAN_DIR= php ${php_config:+-c "$php_config"} "$bp_dir/bin/util/autotune.php" -y "$fpm_config" -t "$DOCUMENT_ROOT" "$ram")
 	[[ $WEB_CONCURRENCY -lt 1 ]] && WEB_CONCURRENCY=1
 	export WEB_CONCURRENCY
 

--- a/bin/heroku-php-nginx
+++ b/bin/heroku-php-nginx
@@ -54,7 +54,7 @@ print_help() {
 		                          Recommended approach when customizing Nginx's config
 		                          in most cases, unless you need to set http or
 		                          fundamental server level options.
-		                          [default: \$COMPOSER_VENDOR_DIR/heroku/heroku-buildpack-php/conf/nginx/default_include.conf.php]
+		                          [default: <BPDIR>/conf/nginx/default_include.conf.php]
 		  -c <nginx.conf>         The path to the full configuration file that is
 		                          included after Heroku's (or your local) Nginx config
 		                          is loaded. It must contain an 'http { ... }' block
@@ -62,17 +62,17 @@ print_help() {
 		                          and 'root' (see option -C above), but no global,
 		                          directives (globals are read from the system's default
 		                          Nginx configuration files).
-		                          [default: \$COMPOSER_VENDOR_DIR/heroku/heroku-buildpack-php/conf/nginx/heroku.conf.php]
+		                          [default: <BPDIR>/conf/nginx/heroku.conf.php]
 		  -F <php-fpm.inc.conf>   The path to the configuration file to include at the  
 		                          end of php-fpm.conf (see option -f below), in the
 		                          '[www]' pool section. Recommended approach when
 		                          customizing PHP-FPM's configuration in most cases,
 		                          unless you need to set global options.
 		  -f <php-fpm.conf>       The path to the full PHP-FPM configuration file.
-		                          [default: \$COMPOSER_VENDOR_DIR/heroku/heroku-buildpack-php/conf/php/php-fpm.conf]
+		                          [default: <BPDIR>/conf/php/php-fpm.conf]
 		  -h, --help              Display this help screen and exit.
 		  -i <php.ini>            The path to the php.ini file to use.
-		                          [default: \$COMPOSER_VENDOR_DIR/heroku/heroku-buildpack-php/conf/php/php.ini]
+		                          [default: <BPDIR>/conf/php/php.ini]
 		  -l <tailme.log>         Path to additional log file to tail to STDERR so its
 		                          contents appear in 'heroku logs'. If the file does not
 		                          exist, it will be created. Wildcards are allowed, but
@@ -83,6 +83,9 @@ print_help() {
 		                          the \$PORT environment variable, or a random port is
 		                          chosen if that variable does not exist.
 		  -v, --verbose           Be more verbose during startup.
+		
+		The <BPDIR> placeholder above represents the base directory of this buildpack:
+		$bp_dir
 		
 		All file paths must be relative to '$HEROKU_APP_DIR'.
 		
@@ -100,6 +103,7 @@ export HEROKU_APP_DIR=$(pwd)
 export DOCUMENT_ROOT="$HEROKU_APP_DIR"
 # set a default port if none is given
 export PORT=${PORT:-$(( $RANDOM+1024 ))}
+bp_dir=$(cd $(dirname $(realpath $0)); cd ..; pwd)
 
 # init logs array here as empty before parsing options; -l could append to it, but the default list gets added later since we use $PORT in there and that can be set using -p
 declare -a logs
@@ -212,6 +216,7 @@ composer() {
 		php -n $composer_bin "$@"
 	fi
 }
+# these exports are used in default web server configs to lock down access to composer directories
 COMPOSER_VENDOR_DIR=$(composer config vendor-dir 2> /dev/null | tail -n 1) && export COMPOSER_VENDOR_DIR || { echo "Unable to determine Composer vendor-dir setting; is 'composer' executable on path or 'composer.phar' in current working directory?" >&2; exit 1; } # tail, as composer echos outdated version warnings to STDOUT; export after the assignment or exit status will that be of 'export
 COMPOSER_BIN_DIR=$(composer config bin-dir 2> /dev/null | tail -n 1) && export COMPOSER_BIN_DIR || { echo "Unable to determine Composer bin-dir setting; is 'composer' executable on path or 'composer.phar' in current working directory?" >&2; exit 1; } # tail, as composer echos outdated version warnings to STDOUT; export after the assignment or exit status will that be of 'export
 
@@ -237,7 +242,7 @@ if [[ -n ${fpm_config_include:-} ]]; then
 	export HEROKU_PHP_FPM_CONFIG_INCLUDE="$fpm_config_include"
 fi
 
-if [[ -n ${fpm_config:-} || ( ${fpm_config:="$HEROKU_APP_DIR/$COMPOSER_VENDOR_DIR/heroku/heroku-buildpack-php/conf/php/php-fpm.conf"} && $verbose ) ]]; then
+if [[ -n ${fpm_config:-} || ( ${fpm_config:="$bp_dir/conf/php/php-fpm.conf"} && $verbose ) ]]; then
 	echo "Using PHP-FPM configuration file '${fpm_config#$HEROKU_APP_DIR/}'" >&2
 fi
 fpm_config=$(php_passthrough "$fpm_config")
@@ -247,13 +252,13 @@ if [[ -n ${php_config:-} ]]; then
 	php_config=$(php_passthrough "$php_config")
 fi
 
-if [[ -n ${nginx_config_include:-} || ( ${nginx_config_include:="$HEROKU_APP_DIR/$COMPOSER_VENDOR_DIR/heroku/heroku-buildpack-php/conf/nginx/default_include.conf.php"} && $verbose ) ]]; then
+if [[ -n ${nginx_config_include:-} || ( ${nginx_config_include:="$bp_dir/conf/nginx/default_include.conf.php"} && $verbose ) ]]; then
 	echo "Using Nginx server-level configuration include '${nginx_config_include#$HEROKU_APP_DIR/}'" >&2
 fi
 nginx_config_include=$(php_passthrough "$nginx_config_include")
 export HEROKU_PHP_NGINX_CONFIG_INCLUDE="$nginx_config_include"
 
-if [[ -n ${nginx_config:-} || ( ${nginx_config:="$HEROKU_APP_DIR/$COMPOSER_VENDOR_DIR/heroku/heroku-buildpack-php/conf/nginx/heroku.conf.php"} && $verbose) ]]; then
+if [[ -n ${nginx_config:-} || ( ${nginx_config:="$bp_dir/conf/nginx/heroku.conf.php"} && $verbose) ]]; then
 	echo "Using Nginx configuration file '${nginx_config#$HEROKU_APP_DIR/}'" >&2
 fi
 nginx_config=$(php_passthrough "$nginx_config")
@@ -278,7 +283,7 @@ if [[ -z ${WEB_CONCURRENCY:-} ]]; then
 
 	# determine number of FPM processes to run
 	# prevent loading of extension INIs (and thus e.g. newrelic) using empty PHP_INI_SCAN_DIR
-	read WEB_CONCURRENCY php_memory_limit <<<$(PHP_INI_SCAN_DIR= php ${php_config:+-c "$php_config"} $(composer config vendor-dir 2> /dev/null | tail -n 1)/heroku/heroku-buildpack-php/bin/util/autotune.php -y "$fpm_config" -t "$DOCUMENT_ROOT" "$ram") # tail, as composer echos outdated version warnings to STDOUT
+	read WEB_CONCURRENCY php_memory_limit <<<$(PHP_INI_SCAN_DIR= php ${php_config:+-c "$php_config"} "$bp_dir/bin/util/autotune.php" -y "$fpm_config" -t "$DOCUMENT_ROOT" "$ram")
 	[[ $WEB_CONCURRENCY -lt 1 ]] && WEB_CONCURRENCY=1
 	export WEB_CONCURRENCY
 

--- a/bin/util/platform.php
+++ b/bin/util/platform.php
@@ -64,6 +64,9 @@ array_shift($argv);
 // base repos we need - no packagist, and the installer plugin path (first arg)
 $repositories = [
 	["packagist" => false],
+	# this installer
+	["type" => "path", "url" => array_shift($argv), "options" => ["symlink" => false]],
+	# the whole buildpack
 	["type" => "path", "url" => array_shift($argv), "options" => ["symlink" => false]],
 ];
 // all other args are repo URLs; they get passed in ascending order of precedence, so we reverse
@@ -164,6 +167,10 @@ if(!$have_runtime_req) {
 
 $require["heroku-sys/apache"] = "^2.4.10";
 $require["heroku-sys/nginx"] = "~1.8.0";
+
+// we want the buildpack itself to also get installed
+// the dev stability flag is there because Composer defaults to "dev-master" in the absence of a version field in composer.json
+$require["heroku/heroku-buildpack-php"] = "*@dev";
 
 preg_match("#^([^-]+)(?:-([0-9]+))?\$#", $STACK, $stack);
 $provide = ["heroku-sys/".$stack[1] => (isset($stack[2])?$stack[2]:"1").gmdate(".Y.m.d")]; # cedar: 14.2016.02.16 etc


### PR DESCRIPTION
This avoids cluttering the user-owned vendor/ folder with our buildpack system installation, and we could in the future potentially allow users to specify their own buildpack fork/version for runtime stuff as a dependency in composer.json (right now, bin/compile still throws an error if the buildpack is detected).