### PR TITLE
BP-root-relative and version-specific config lookups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # heroku-buildpack-php CHANGELOG
 
+## v147 (2018-??-??)
+
+### CHG
+
+- Look for configs relative to buildpack dir, and not to $CWD/vendor/heroku/…, in boot scripts [David Zuelke]
+
 ## v146 (2018-11-08)
 
 ### ADD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### CHG
 
 - Look for configs relative to buildpack dir, and not to $CWD/vendor/heroku/…, in boot scripts [David Zuelke]
+- Look for default configs using version specific paths first in boot scripts [David Zuelke]
 
 ## v146 (2018-11-08)
 

--- a/bin/heroku-hhvm-apache2
+++ b/bin/heroku-hhvm-apache2
@@ -9,6 +9,9 @@ shopt -s extglob
 # for detecting when -l 'logs/*.log' matches nothing
 shopt -s nullglob
 
+# we very likely got called via a symlink, so we have to realpath $0 first to find the base buildpack directory
+bp_dir=$(cd $(dirname $(realpath $0)); cd ..; pwd)
+
 verbose=
 
 php_passthrough() {
@@ -54,19 +57,19 @@ print_help() {
 		                          Recommended approach when customizing Apache2's config
 		                          in most cases, unless you need to set fundamental
 		                          server level options.
-		                          [default: \$COMPOSER_VENDOR_DIR/heroku/heroku-buildpack-php/conf/apache2/default_include.conf]
+		                          [default: <BPDIR>/conf/apache2/default_include.conf]
 		  -c <httpd.conf>         The path to the full VHost configuration file that is
 		                          included after Heroku's (or your local) Apache2 config
 		                          is loaded. Must contain a 'Listen \${PORT}' directive
 		                          and should have a '<VirtualHost>' and likely also a
 		                          '<Directory>' section (see option -C above).
-		                          [default: \$COMPOSER_VENDOR_DIR/heroku/heroku-buildpack-php/conf/apache2/heroku.conf]
+		                          [default: <BPDIR>/conf/apache2/heroku.conf]
 		  -h, --help              Display this help screen and exit.
 		  -I <php.extra.ini>      The path to an extra php.ini to use in addition to the
 		                          default HHVM php.ini (see option -i below).
 		  -i <php.ini>            The path to the php.ini file to use. It is highly
 		                          recommended to use the -I option (see above) instead.
-		                          [default: \$COMPOSER_VENDOR_DIR/heroku/heroku-buildpack-php/conf/hhvm/php.ini.php]
+		                          [default: <BPDIR>/conf/hhvm/php.ini.php]
 		  -l <tailme.log>         Path to additional log file to tail to STDERR so its
 		                          contents appear in 'heroku logs'. If the file does not
 		                          exist, it will be created. Wildcards are allowed, but
@@ -77,6 +80,9 @@ print_help() {
 		                          the \$PORT environment variable, or a random port is
 		                          chosen if that variable does not exist.
 		  -v, --verbose           Be more verbose during startup.
+		
+		The <BPDIR> placeholder above represents the base directory of this buildpack:
+		$bp_dir
 		
 		All file paths must be relative to '$HEROKU_APP_DIR'.
 		
@@ -202,6 +208,7 @@ composer() {
 		hhvm $composer_bin "$@"
 	fi
 }
+# these exports are used in default web server configs to lock down access to composer directories
 COMPOSER_VENDOR_DIR=$(composer config vendor-dir 2> /dev/null | tail -n 1) && export COMPOSER_VENDOR_DIR || { echo "Unable to determine Composer vendor-dir setting; is 'composer' executable on path or 'composer.phar' in current working directory?" >&2; exit 1; } # tail, as composer echos outdated version warnings to STDOUT; export after the assignment or exit status will that be of 'export
 COMPOSER_BIN_DIR=$(composer config bin-dir 2> /dev/null | tail -n 1) && export COMPOSER_BIN_DIR || { echo "Unable to determine Composer bin-dir setting; is 'composer' executable on path or 'composer.phar' in current working directory?" >&2; exit 1; } # tail, as composer echos outdated version warnings to STDOUT; export after the assignment or exit status will that be of 'export
 
@@ -222,7 +229,7 @@ if [[ "$#" == "1" ]]; then
 fi
 
 function prepare_hhvm_ini() { # we have to do this twice, as the WEB_CONCURRENCY setting is evaluated using PHP code, not ${...} syntax which HHVM does not support; if a value for $1 is passed then it won't echo messages upon second invocation
-if [[ ( -n ${php_config:-} && ! ${1:-} ) || ( ${php_config:="$HEROKU_APP_DIR/$COMPOSER_VENDOR_DIR/heroku/heroku-buildpack-php/conf/hhvm/php.ini.php"} && $verbose && ! ${1:-} ) ]]; then
+if [[ ( -n ${php_config:-} && ! ${1:-} ) || ( ${php_config:="$bp_dir/conf/hhvm/php.ini.php"} && $verbose && ! ${1:-} ) ]]; then
 	echo "Using HHVM configuration (php.ini) file '${php_config#$HEROKU_APP_DIR/}'" >&2
 fi
 php_configs=( "-c" "$(php_passthrough "$php_config")" )
@@ -234,13 +241,13 @@ fi
 }
 prepare_hhvm_ini
 
-if [[ -n ${httpd_config_include:-} || ( ${httpd_config_include:="$HEROKU_APP_DIR/$COMPOSER_VENDOR_DIR/heroku/heroku-buildpack-php/conf/apache2/default_include.conf"} && $verbose ) ]]; then
+if [[ -n ${httpd_config_include:-} || ( ${httpd_config_include:="$bp_dir/conf/apache2/default_include.conf"} && $verbose ) ]]; then
 	echo "Using Apache2 VirtualHost-level configuration include '${httpd_config_include#$HEROKU_APP_DIR/}'" >&2
 fi
 httpd_config_include=$(php_passthrough "$httpd_config_include")
 export HEROKU_PHP_HTTPD_CONFIG_INCLUDE="$httpd_config_include"
 
-if [[ -n ${httpd_config:-} || ( ${httpd_config:="$HEROKU_APP_DIR/$COMPOSER_VENDOR_DIR/heroku/heroku-buildpack-php/conf/apache2/heroku.conf"} && $verbose) ]]; then
+if [[ -n ${httpd_config:-} || ( ${httpd_config:="$bp_dir/conf/apache2/heroku.conf"} && $verbose) ]]; then
 	echo "Using Apache2 configuration file '${httpd_config#$HEROKU_APP_DIR/}'" >&2
 fi
 httpd_config=$(php_passthrough "$httpd_config")
@@ -264,7 +271,7 @@ if [[ -z ${WEB_CONCURRENCY:-} ]]; then
 	fi
 
 	# determine number of HHVM threads to run
-	read WEB_CONCURRENCY php_memory_limit <<<$(hhvm "${php_configs[@]}" $(composer config vendor-dir 2> /dev/null | tail -n 1)/heroku/heroku-buildpack-php/bin/util/autotune.php "$ram") # tail, as composer echos outdated version warnings to STDOUT
+	read WEB_CONCURRENCY php_memory_limit <<<$(hhvm "${php_configs[@]}" $bp_dir/bin/util/autotune.php "$ram")
 	[[ $WEB_CONCURRENCY -lt 1 ]] && WEB_CONCURRENCY=1
 	export WEB_CONCURRENCY
 

--- a/bin/heroku-hhvm-apache2
+++ b/bin/heroku-hhvm-apache2
@@ -9,8 +9,16 @@ shopt -s extglob
 # for detecting when -l 'logs/*.log' matches nothing
 shopt -s nullglob
 
+if ! type -p "realpath" > /dev/null; then
+	# cedar-14 doesn't have realpath
+	# must be a function so subshells, including $(…), can use it
+	realpath() {
+		readlink "$@"
+	}
+fi
+
 # we very likely got called via a symlink, so we have to realpath $0 first to find the base buildpack directory
-bp_dir=$(cd $(dirname $(realpath $0)); cd ..; pwd)
+bp_dir=$(cd $(dirname $(realpath -e $0)); cd ..; pwd)
 
 verbose=
 
@@ -41,6 +49,25 @@ touch_log() {
 	mkdir -p $(dirname "$1") && touch "$1"
 }
 
+findconfig() {
+	local dir=$(dirname "$2")
+	local file=$(basename "$2")
+	IFS='.' read -r -a version <<< "$1" # read the parts of $1 (version number) into an array, e.g. (7 2 33)
+
+	# iterate "backwards" over version parts so we try "7/2/11" first, then "7/2", then "7" for a version "7.2.11"
+	# we go down to 0, which will yield an empty string, for the last fallback layer without any version number
+	for (( i = ${#version[@]}; i >= 0; i--)); do
+		version_dir=$(IFS=/; echo "${version[*]:0:$i}") # set IFS to "/" for merging, but echo is a builtin, so it must be a subshell and a separate command
+		full_path="${dir}/${version_dir}${version_dir:+/}${file}" # concat, but if scandir is empty (last fallback), don't produce a double slash
+		if [[ -f "$full_path" ]]; then
+			echo "$full_path";
+			return 0;
+		fi
+	done
+	echo "$2"
+	return 1;
+}
+
 print_help() {
 	cat >&2 <<-EOF
 		
@@ -57,19 +84,22 @@ print_help() {
 		                          Recommended approach when customizing Apache2's config
 		                          in most cases, unless you need to set fundamental
 		                          server level options.
-		                          [default: <BPDIR>/conf/apache2/default_include.conf]
+		                          [default: <BPDIR>/conf/apache2/default_include.conf,
+		                          or a more version-specific file from a subdirectory]
 		  -c <httpd.conf>         The path to the full VHost configuration file that is
 		                          included after Heroku's (or your local) Apache2 config
 		                          is loaded. Must contain a 'Listen \${PORT}' directive
 		                          and should have a '<VirtualHost>' and likely also a
 		                          '<Directory>' section (see option -C above).
-		                          [default: <BPDIR>/conf/apache2/heroku.conf]
+		                          [default: <BPDIR>/conf/apache2/heroku.conf,
+		                          or a more version-specific file from a subdirectory]
 		  -h, --help              Display this help screen and exit.
 		  -I <php.extra.ini>      The path to an extra php.ini to use in addition to the
 		                          default HHVM php.ini (see option -i below).
 		  -i <php.ini>            The path to the php.ini file to use. It is highly
 		                          recommended to use the -I option (see above) instead.
-		                          [default: <BPDIR>/conf/hhvm/php.ini.php]
+		                          [default: <BPDIR>/conf/hhvm/php.ini.php,
+		                          or a more version-specific file from a subdirectory]
 		  -l <tailme.log>         Path to additional log file to tail to STDERR so its
 		                          contents appear in 'heroku logs'. If the file does not
 		                          exist, it will be created. Wildcards are allowed, but
@@ -197,6 +227,9 @@ logs+=( "/tmp/heroku.apache2_error.$PORT.log" "/tmp/heroku.apache2_access.$PORT.
 hhvm --php -r 'exit((int)version_compare(HHVM_VERSION, "3.0.1", "<"));' || { echo "This program requires HHVM 3.0.1 or newer" >&2; exit 1; }
 { { httpd -v | hhvm --php -r 'exit((int)version_compare(preg_replace("#^Server version: Apache/(\S+).+$#sm", "\\1", file_get_contents("php://stdin")), "2.4.10", "<"));'; } && { httpd -t -D DUMP_MODULES | grep 'proxy_fcgi_module' > /dev/null; }; } || { echo "This program requires Apache 2.4.10 or newer with mod_proxy and mod_proxy_fcgi enabled; check your 'httpd' command." >&2; exit 1; }
 
+hhvm_version="$(hhvm --php -r 'echo HHVM_VERSION;')"
+httpd_version="$(httpd -v | hhvm --php -r 'echo preg_replace("#^Server version: Apache/(\S+).+$#sm", "\\1", file_get_contents("php://stdin"));')"
+
 # make sure we run a local composer.phar if present, or global composer if not
 composer() {
 	local composer_bin=$(which ./composer.phar composer | head -n1)
@@ -229,7 +262,7 @@ if [[ "$#" == "1" ]]; then
 fi
 
 function prepare_hhvm_ini() { # we have to do this twice, as the WEB_CONCURRENCY setting is evaluated using PHP code, not ${...} syntax which HHVM does not support; if a value for $1 is passed then it won't echo messages upon second invocation
-if [[ ( -n ${php_config:-} && ! ${1:-} ) || ( ${php_config:="$bp_dir/conf/hhvm/php.ini.php"} && $verbose && ! ${1:-} ) ]]; then
+if [[ ( -n ${php_config:-} && ! ${1:-} ) || ( ${php_config:=$(findconfig "$hhvm_version" "$bp_dir/conf/hhvm/php.ini.php")} && $verbose && ! ${1:-} ) ]]; then
 	echo "Using HHVM configuration (php.ini) file '${php_config#$HEROKU_APP_DIR/}'" >&2
 fi
 php_configs=( "-c" "$(php_passthrough "$php_config")" )
@@ -241,13 +274,13 @@ fi
 }
 prepare_hhvm_ini
 
-if [[ -n ${httpd_config_include:-} || ( ${httpd_config_include:="$bp_dir/conf/apache2/default_include.conf"} && $verbose ) ]]; then
+if [[ -n ${httpd_config_include:-} || ( ${httpd_config_include:=$(findconfig "$httpd_version" "$bp_dir/conf/apache2/default_include.conf")} && $verbose ) ]]; then
 	echo "Using Apache2 VirtualHost-level configuration include '${httpd_config_include#$HEROKU_APP_DIR/}'" >&2
 fi
 httpd_config_include=$(php_passthrough "$httpd_config_include")
 export HEROKU_PHP_HTTPD_CONFIG_INCLUDE="$httpd_config_include"
 
-if [[ -n ${httpd_config:-} || ( ${httpd_config:="$bp_dir/conf/apache2/heroku.conf"} && $verbose) ]]; then
+if [[ -n ${httpd_config:-} || ( ${httpd_config:=$(findconfig "$httpd_version" "$bp_dir/conf/apache2/heroku.conf")} && $verbose) ]]; then
 	echo "Using Apache2 configuration file '${httpd_config#$HEROKU_APP_DIR/}'" >&2
 fi
 httpd_config=$(php_passthrough "$httpd_config")

--- a/bin/heroku-hhvm-nginx
+++ b/bin/heroku-hhvm-nginx
@@ -9,6 +9,9 @@ shopt -s extglob
 # for detecting when -l 'logs/*.log' matches nothing
 shopt -s nullglob
 
+# we very likely got called via a symlink, so we have to realpath $0 first to find the base buildpack directory
+bp_dir=$(cd $(dirname $(realpath $0)); cd ..; pwd)
+
 verbose=
 
 php_passthrough() {
@@ -54,7 +57,7 @@ print_help() {
 		                          Recommended approach when customizing Nginx's config
 		                          in most cases, unless you need to set http or
 		                          fundamental server level options.
-		                          [default: \$COMPOSER_VENDOR_DIR/heroku/heroku-buildpack-php/conf/nginx/default_include.conf.php]
+		                          [default: <BPDIR>/conf/nginx/default_include.conf.php]
 		  -c <nginx.conf>         The path to the full configuration file that is
 		                          included after Heroku's (or your local) Nginx config
 		                          is loaded. It must contain an 'http { ... }' block
@@ -62,13 +65,13 @@ print_help() {
 		                          and 'root' (see option -C above), but no global,
 		                          directives (globals are read from the system's default
 		                          Nginx configuration files).
-		                          [default: \$COMPOSER_VENDOR_DIR/heroku/heroku-buildpack-php/conf/nginx/heroku.conf.php]
+		                          [default: <BPDIR>/conf/nginx/heroku.conf.php]
 		  -h, --help              Display this help screen and exit.
 		  -I <php.extra.ini>      The path to an extra php.ini to use in addition to the
 		                          default HHVM php.ini (see option -i below).
 		  -i <php.ini>            The path to the php.ini file to use. It is highly
 		                          recommended to use the -I option (see above) instead.
-		                          [default: \$COMPOSER_VENDOR_DIR/heroku/heroku-buildpack-php/conf/hhvm/php.ini.php]
+		                          [default: <BPDIR>/conf/hhvm/php.ini.php]
 		  -l <tailme.log>         Path to additional log file to tail to STDERR so its
 		                          contents appear in 'heroku logs'. If the file does not
 		                          exist, it will be created. Wildcards are allowed, but
@@ -79,6 +82,9 @@ print_help() {
 		                          the \$PORT environment variable, or a random port is
 		                          chosen if that variable does not exist.
 		  -v, --verbose           Be more verbose during startup.
+		
+		The <BPDIR> placeholder above represents the base directory of this buildpack:
+		$bp_dir
 		
 		All file paths must be relative to '$HEROKU_APP_DIR'.
 		
@@ -202,6 +208,7 @@ composer() {
 		hhvm $composer_bin "$@"
 	fi
 }
+# these exports are used in default web server configs to lock down access to composer directories
 COMPOSER_VENDOR_DIR=$(composer config vendor-dir 2> /dev/null | tail -n 1) && export COMPOSER_VENDOR_DIR || { echo "Unable to determine Composer vendor-dir setting; is 'composer' executable on path or 'composer.phar' in current working directory?" >&2; exit 1; } # tail, as composer echos outdated version warnings to STDOUT; export after the assignment or exit status will that be of 'export
 COMPOSER_BIN_DIR=$(composer config bin-dir 2> /dev/null | tail -n 1) && export COMPOSER_BIN_DIR || { echo "Unable to determine Composer bin-dir setting; is 'composer' executable on path or 'composer.phar' in current working directory?" >&2; exit 1; } # tail, as composer echos outdated version warnings to STDOUT; export after the assignment or exit status will that be of 'export
 
@@ -222,7 +229,7 @@ if [[ "$#" == "1" ]]; then
 fi
 
 function prepare_hhvm_ini() { # we have to do this twice, as the WEB_CONCURRENCY setting is evaluated using PHP code, not ${...} syntax which HHVM does not support; if a value for $1 is passed then it won't echo messages upon second invocation
-if [[ ( -n ${php_config:-} && ! ${1:-} ) || ( ${php_config:="$HEROKU_APP_DIR/$COMPOSER_VENDOR_DIR/heroku/heroku-buildpack-php/conf/hhvm/php.ini.php"} && $verbose && ! ${1:-} ) ]]; then
+if [[ ( -n ${php_config:-} && ! ${1:-} ) || ( ${php_config:="$bp_dir/conf/hhvm/php.ini.php"} && $verbose && ! ${1:-} ) ]]; then
 	echo "Using HHVM configuration (php.ini) file '${php_config#$HEROKU_APP_DIR/}'" >&2
 fi
 php_configs=( "-c" "$(php_passthrough "$php_config")" )
@@ -234,13 +241,13 @@ fi
 }
 prepare_hhvm_ini
 
-if [[ -n ${nginx_config_include:-} || ( ${nginx_config_include:="$HEROKU_APP_DIR/$COMPOSER_VENDOR_DIR/heroku/heroku-buildpack-php/conf/nginx/default_include.conf.php"} && $verbose ) ]]; then
+if [[ -n ${nginx_config_include:-} || ( ${nginx_config_include:="$bp_dir/conf/nginx/default_include.conf.php"} && $verbose ) ]]; then
 	echo "Using Nginx server-level configuration include '${nginx_config_include#$HEROKU_APP_DIR/}'" >&2
 fi
 nginx_config_include=$(php_passthrough "$nginx_config_include")
 export HEROKU_PHP_NGINX_CONFIG_INCLUDE="$nginx_config_include"
 
-if [[ -n ${nginx_config:-} || ( ${nginx_config:="$HEROKU_APP_DIR/$COMPOSER_VENDOR_DIR/heroku/heroku-buildpack-php/conf/nginx/heroku.conf.php"} && $verbose) ]]; then
+if [[ -n ${nginx_config:-} || ( ${nginx_config:="$bp_dir/conf/nginx/heroku.conf.php"} && $verbose) ]]; then
 	echo "Using Nginx configuration file '${nginx_config#$HEROKU_APP_DIR/}'" >&2
 fi
 nginx_config=$(php_passthrough "$nginx_config")
@@ -264,7 +271,7 @@ if [[ -z ${WEB_CONCURRENCY:-} ]]; then
 	fi
 
 	# determine number of HHVM threads to run
-	read WEB_CONCURRENCY php_memory_limit <<<$(hhvm "${php_configs[@]}" $(composer config vendor-dir 2> /dev/null | tail -n 1)/heroku/heroku-buildpack-php/bin/util/autotune.php "$ram") # tail, as composer echos outdated version warnings to STDOUT
+	read WEB_CONCURRENCY php_memory_limit <<<$(hhvm "${php_configs[@]}" $bp_dir/bin/util/autotune.php "$ram")
 	[[ $WEB_CONCURRENCY -lt 1 ]] && WEB_CONCURRENCY=1
 	export WEB_CONCURRENCY
 

--- a/bin/heroku-hhvm-nginx
+++ b/bin/heroku-hhvm-nginx
@@ -9,8 +9,16 @@ shopt -s extglob
 # for detecting when -l 'logs/*.log' matches nothing
 shopt -s nullglob
 
+if ! type -p "realpath" > /dev/null; then
+	# cedar-14 doesn't have realpath
+	# must be a function so subshells, including $(…), can use it
+	realpath() {
+		readlink "$@"
+	}
+fi
+
 # we very likely got called via a symlink, so we have to realpath $0 first to find the base buildpack directory
-bp_dir=$(cd $(dirname $(realpath $0)); cd ..; pwd)
+bp_dir=$(cd $(dirname $(realpath -e $0)); cd ..; pwd)
 
 verbose=
 
@@ -41,6 +49,25 @@ touch_log() {
 	mkdir -p $(dirname "$1") && touch "$1"
 }
 
+findconfig() {
+	local dir=$(dirname "$2")
+	local file=$(basename "$2")
+	IFS='.' read -r -a version <<< "$1" # read the parts of $1 (version number) into an array, e.g. (7 2 33)
+
+	# iterate "backwards" over version parts so we try "7/2/11" first, then "7/2", then "7" for a version "7.2.11"
+	# we go down to 0, which will yield an empty string, for the last fallback layer without any version number
+	for (( i = ${#version[@]}; i >= 0; i--)); do
+		version_dir=$(IFS=/; echo "${version[*]:0:$i}") # set IFS to "/" for merging, but echo is a builtin, so it must be a subshell and a separate command
+		full_path="${dir}/${version_dir}${version_dir:+/}${file}" # concat, but if scandir is empty (last fallback), don't produce a double slash
+		if [[ -f "$full_path" ]]; then
+			echo "$full_path";
+			return 0;
+		fi
+	done
+	echo "$2"
+	return 1;
+}
+
 print_help() {
 	cat >&2 <<-EOF
 		
@@ -57,7 +84,8 @@ print_help() {
 		                          Recommended approach when customizing Nginx's config
 		                          in most cases, unless you need to set http or
 		                          fundamental server level options.
-		                          [default: <BPDIR>/conf/nginx/default_include.conf.php]
+		                          [default: <BPDIR>/conf/nginx/default_include.conf.php,
+		                          or a more version-specific file from a subdirectory]
 		  -c <nginx.conf>         The path to the full configuration file that is
 		                          included after Heroku's (or your local) Nginx config
 		                          is loaded. It must contain an 'http { ... }' block
@@ -65,13 +93,15 @@ print_help() {
 		                          and 'root' (see option -C above), but no global,
 		                          directives (globals are read from the system's default
 		                          Nginx configuration files).
-		                          [default: <BPDIR>/conf/nginx/heroku.conf.php]
+		                          [default: <BPDIR>/conf/nginx/heroku.conf.php,
+		                          or a more version-specific file from a subdirectory]
 		  -h, --help              Display this help screen and exit.
 		  -I <php.extra.ini>      The path to an extra php.ini to use in addition to the
 		                          default HHVM php.ini (see option -i below).
 		  -i <php.ini>            The path to the php.ini file to use. It is highly
 		                          recommended to use the -I option (see above) instead.
-		                          [default: <BPDIR>/conf/hhvm/php.ini.php]
+		                          [default: <BPDIR>/conf/hhvm/php.ini.php,
+		                          or a more version-specific file from a subdirectory]
 		  -l <tailme.log>         Path to additional log file to tail to STDERR so its
 		                          contents appear in 'heroku logs'. If the file does not
 		                          exist, it will be created. Wildcards are allowed, but
@@ -197,6 +227,9 @@ logs+=( "/tmp/heroku.nginx_access.$PORT.log" )
 
 hhvm --php -r 'exit((int)version_compare(HHVM_VERSION, "3.0.1", "<"));' || { echo "This program requires HHVM 3.0.1 or newer" >&2; exit 1; }
 
+hhvm_version="$(hhvm --php -r 'echo HHVM_VERSION;')"
+nginx_version="$(nginx -v 2>&1 | grep -oP "nginx\/\K[\d\.]+")" # \K, available with -P, resets the start of the match
+
 # make sure we run a local composer.phar if present, or global composer if not
 composer() {
 	local composer_bin=$(which ./composer.phar composer | head -n1)
@@ -229,7 +262,7 @@ if [[ "$#" == "1" ]]; then
 fi
 
 function prepare_hhvm_ini() { # we have to do this twice, as the WEB_CONCURRENCY setting is evaluated using PHP code, not ${...} syntax which HHVM does not support; if a value for $1 is passed then it won't echo messages upon second invocation
-if [[ ( -n ${php_config:-} && ! ${1:-} ) || ( ${php_config:="$bp_dir/conf/hhvm/php.ini.php"} && $verbose && ! ${1:-} ) ]]; then
+if [[ ( -n ${php_config:-} && ! ${1:-} ) || ( ${php_config:=$(findconfig "$hhvm_version" "$bp_dir/conf/hhvm/php.ini.php")} && $verbose && ! ${1:-} ) ]]; then
 	echo "Using HHVM configuration (php.ini) file '${php_config#$HEROKU_APP_DIR/}'" >&2
 fi
 php_configs=( "-c" "$(php_passthrough "$php_config")" )
@@ -241,13 +274,13 @@ fi
 }
 prepare_hhvm_ini
 
-if [[ -n ${nginx_config_include:-} || ( ${nginx_config_include:="$bp_dir/conf/nginx/default_include.conf.php"} && $verbose ) ]]; then
+if [[ -n ${nginx_config_include:-} || ( ${nginx_config_include:=$(findconfig "$nginx_version" "$bp_dir/conf/nginx/default_include.conf.php")} && $verbose ) ]]; then
 	echo "Using Nginx server-level configuration include '${nginx_config_include#$HEROKU_APP_DIR/}'" >&2
 fi
 nginx_config_include=$(php_passthrough "$nginx_config_include")
 export HEROKU_PHP_NGINX_CONFIG_INCLUDE="$nginx_config_include"
 
-if [[ -n ${nginx_config:-} || ( ${nginx_config:="$bp_dir/conf/nginx/heroku.conf.php"} && $verbose) ]]; then
+if [[ -n ${nginx_config:-} || ( ${nginx_config:=$(findconfig "$nginx_version" "$bp_dir/conf/nginx/heroku.conf.php")} && $verbose) ]]; then
 	echo "Using Nginx configuration file '${nginx_config#$HEROKU_APP_DIR/}'" >&2
 fi
 nginx_config=$(php_passthrough "$nginx_config")

--- a/bin/heroku-php-apache2
+++ b/bin/heroku-php-apache2
@@ -9,8 +9,16 @@ shopt -s extglob
 # for detecting when -l 'logs/*.log' matches nothing
 shopt -s nullglob
 
+if ! type -p "realpath" > /dev/null; then
+	# cedar-14 doesn't have realpath
+	# must be a function so subshells, including $(…), can use it
+	realpath() {
+		readlink "$@"
+	}
+fi
+
 # we very likely got called via a symlink, so we have to realpath $0 first to find the base buildpack directory
-bp_dir=$(cd $(dirname $(realpath $0)); cd ..; pwd)
+bp_dir=$(cd $(dirname $(realpath -e $0)); cd ..; pwd)
 
 verbose=
 
@@ -41,6 +49,25 @@ touch_log() {
 	mkdir -p $(dirname "$1") && touch "$1"
 }
 
+findconfig() {
+	local dir=$(dirname "$2")
+	local file=$(basename "$2")
+	IFS='.' read -r -a version <<< "$1" # read the parts of $1 (version number) into an array, e.g. (7 2 33)
+
+	# iterate "backwards" over version parts so we try "7/2/11" first, then "7/2", then "7" for a version "7.2.11"
+	# we go down to 0, which will yield an empty string, for the last fallback layer without any version number
+	for (( i = ${#version[@]}; i >= 0; i--)); do
+		version_dir=$(IFS=/; echo "${version[*]:0:$i}") # set IFS to "/" for merging, but echo is a builtin, so it must be a subshell and a separate command
+		full_path="${dir}/${version_dir}${version_dir:+/}${file}" # concat, but if scandir is empty (last fallback), don't produce a double slash
+		if [[ -f "$full_path" ]]; then
+			echo "$full_path";
+			return 0;
+		fi
+	done
+	echo "$2"
+	return 1;
+}
+
 print_help() {
 	cat >&2 <<-EOF
 		
@@ -57,20 +84,23 @@ print_help() {
 		                          Recommended approach when customizing Apache2's config
 		                          in most cases, unless you need to set fundamental
 		                          server level options.
-		                          [default: <BPDIR>/conf/apache2/default_include.conf]
+		                          [default: <BPDIR>/conf/apache2/default_include.conf,
+		                          or a more version-specific file from a subdirectory]
 		  -c <httpd.conf>         The path to the full VHost configuration file that is
 		                          included after Heroku's (or your local) Apache2 config
 		                          is loaded. Must contain a 'Listen \${PORT}' directive
 		                          and should have a '<VirtualHost>' and likely also a
 		                          '<Directory>' section (see option -C above).
-		                          [default: <BPDIR>/conf/apache2/heroku.conf]
+		                          [default: <BPDIR>/conf/apache2/heroku.conf,
+		                          or a more version-specific file from a subdirectory]
 		  -F <php-fpm.inc.conf>   The path to the configuration file to include at the
 		                          end of php-fpm.conf (see option -f below), in the
 		                          '[www]' pool section. Recommended approach when
 		                          customizing PHP-FPM's configuration in most cases,
 		                          unless you need to set global options.
 		  -f <php-fpm.conf>       The path to the full PHP-FPM configuration file.
-		                          [default: <BPDIR>/conf/php/php-fpm.conf]
+		                          [default: <BPDIR>/conf/php/php-fpm.conf,
+		                          or a more version-specific file from a subdirectory]
 		  -h, --help              Display this help screen and exit.
 		  -i <php.ini>            The path to the php.ini file to use.
 		                          [default: <BPDIR>/conf/php/php.ini]
@@ -206,6 +236,9 @@ php -n -r 'exit((int)version_compare(PHP_VERSION, "5.5.11", "<"));' || { echo "T
 { php-fpm -n -v | php -n -r 'exit((int)version_compare(preg_replace("#PHP (\S+) \(fpm-fcgi\).+$#sm", "\\1", file_get_contents("php://stdin")), "5.5.11", "<"));'; } || { echo "This program requires PHP 5.5.11 or newer; check your 'php-fpm' command." >&2; exit 1; }
 { { httpd -v | php -n -r 'exit((int)version_compare(preg_replace("#^Server version: Apache/(\S+).+$#sm", "\\1", file_get_contents("php://stdin")), "2.4.10", "<"));'; } && { httpd -t -D DUMP_MODULES | grep 'proxy_fcgi_module' > /dev/null; }; } || { echo "This program requires Apache 2.4.10 or newer with mod_proxy and mod_proxy_fcgi enabled; check your 'httpd' command." >&2; exit 1; }
 
+php_version="$(php-fpm -n -v | php -n -r 'echo preg_replace("#PHP (\S+) \(fpm-fcgi\).+$#sm", "\\1", file_get_contents("php://stdin"));')"
+httpd_version="$(httpd -v | php -n -r 'echo preg_replace("#^Server version: Apache/(\S+).+$#sm", "\\1", file_get_contents("php://stdin"));')"
+
 # make sure we run a local composer.phar if present, or global composer if not
 composer() {
 	local composer_bin=$(which ./composer.phar composer | head -n1)
@@ -243,7 +276,7 @@ if [[ -n ${fpm_config_include:-} ]]; then
 	export HEROKU_PHP_FPM_CONFIG_INCLUDE="$fpm_config_include"
 fi
 
-if [[ -n ${fpm_config:-} || ( ${fpm_config:="$bp_dir/conf/php/php-fpm.conf"} && $verbose ) ]]; then
+if [[ -n ${fpm_config:-} || ( ${fpm_config:=$(findconfig "$php_version" "$bp_dir/conf/php/php-fpm.conf")} && $verbose ) ]]; then
 	echo "Using PHP-FPM configuration file '${fpm_config#$HEROKU_APP_DIR/}'" >&2
 fi
 fpm_config=$(php_passthrough "$fpm_config")
@@ -253,13 +286,13 @@ if [[ -n ${php_config:-} ]]; then
 	php_config=$(php_passthrough "$php_config")
 fi
 
-if [[ -n ${httpd_config_include:-} || ( ${httpd_config_include:="$bp_dir/conf/apache2/default_include.conf"} && $verbose ) ]]; then
+if [[ -n ${httpd_config_include:-} || ( ${httpd_config_include:=$(findconfig "$httpd_version" "$bp_dir/conf/apache2/default_include.conf")} && $verbose ) ]]; then
 	echo "Using Apache2 VirtualHost-level configuration include '${httpd_config_include#$HEROKU_APP_DIR/}'" >&2
 fi
 httpd_config_include=$(php_passthrough "$httpd_config_include")
 export HEROKU_PHP_HTTPD_CONFIG_INCLUDE="$httpd_config_include"
 
-if [[ -n ${httpd_config:-} || ( ${httpd_config:="$bp_dir/conf/apache2/heroku.conf"} && $verbose) ]]; then
+if [[ -n ${httpd_config:-} || ( ${httpd_config:=$(findconfig "$httpd_version" "$bp_dir/conf/apache2/heroku.conf")} && $verbose) ]]; then
 	echo "Using Apache2 configuration file '${httpd_config#$HEROKU_APP_DIR/}'" >&2
 fi
 httpd_config=$(php_passthrough "$httpd_config")

--- a/bin/heroku-php-apache2
+++ b/bin/heroku-php-apache2
@@ -9,6 +9,9 @@ shopt -s extglob
 # for detecting when -l 'logs/*.log' matches nothing
 shopt -s nullglob
 
+# we very likely got called via a symlink, so we have to realpath $0 first to find the base buildpack directory
+bp_dir=$(cd $(dirname $(realpath $0)); cd ..; pwd)
+
 verbose=
 
 php_passthrough() {
@@ -54,23 +57,23 @@ print_help() {
 		                          Recommended approach when customizing Apache2's config
 		                          in most cases, unless you need to set fundamental
 		                          server level options.
-		                          [default: \$COMPOSER_VENDOR_DIR/heroku/heroku-buildpack-php/conf/apache2/default_include.conf]
+		                          [default: <BPDIR>/conf/apache2/default_include.conf]
 		  -c <httpd.conf>         The path to the full VHost configuration file that is
 		                          included after Heroku's (or your local) Apache2 config
 		                          is loaded. Must contain a 'Listen \${PORT}' directive
 		                          and should have a '<VirtualHost>' and likely also a
 		                          '<Directory>' section (see option -C above).
-		                          [default: \$COMPOSER_VENDOR_DIR/heroku/heroku-buildpack-php/conf/apache2/heroku.conf]
+		                          [default: <BPDIR>/conf/apache2/heroku.conf]
 		  -F <php-fpm.inc.conf>   The path to the configuration file to include at the
 		                          end of php-fpm.conf (see option -f below), in the
 		                          '[www]' pool section. Recommended approach when
 		                          customizing PHP-FPM's configuration in most cases,
 		                          unless you need to set global options.
 		  -f <php-fpm.conf>       The path to the full PHP-FPM configuration file.
-		                          [default: \$COMPOSER_VENDOR_DIR/heroku/heroku-buildpack-php/conf/php/php-fpm.conf]
+		                          [default: <BPDIR>/conf/php/php-fpm.conf]
 		  -h, --help              Display this help screen and exit.
 		  -i <php.ini>            The path to the php.ini file to use.
-		                          [default: \$COMPOSER_VENDOR_DIR/heroku/heroku-buildpack-php/conf/php/php.ini]
+		                          [default: <BPDIR>/conf/php/php.ini]
 		  -l <tailme.log>         Path to additional log file to tail to STDERR so its
 		                          contents appear in 'heroku logs'. If the file does not
 		                          exist, it will be created. Wildcards are allowed, but
@@ -81,6 +84,9 @@ print_help() {
 		                          the \$PORT environment variable, or a random port is
 		                          chosen if that variable does not exist.
 		  -v, --verbose           Be more verbose during startup.
+		
+		The <BPDIR> placeholder above represents the base directory of this buildpack:
+		$bp_dir
 		
 		All file paths must be relative to '$HEROKU_APP_DIR'.
 		
@@ -211,6 +217,7 @@ composer() {
 		php -n $composer_bin "$@"
 	fi
 }
+# these exports are used in default web server configs to lock down access to composer directories
 COMPOSER_VENDOR_DIR=$(composer config vendor-dir 2> /dev/null | tail -n 1) && export COMPOSER_VENDOR_DIR || { echo "Unable to determine Composer vendor-dir setting; is 'composer' executable on path or 'composer.phar' in current working directory?" >&2; exit 1; } # tail, as composer echos outdated version warnings to STDOUT; export after the assignment or exit status will that be of 'export
 COMPOSER_BIN_DIR=$(composer config bin-dir 2> /dev/null | tail -n 1) && export COMPOSER_BIN_DIR || { echo "Unable to determine Composer bin-dir setting; is 'composer' executable on path or 'composer.phar' in current working directory?" >&2; exit 1; } # tail, as composer echos outdated version warnings to STDOUT; export after the assignment or exit status will that be of 'export
 
@@ -236,7 +243,7 @@ if [[ -n ${fpm_config_include:-} ]]; then
 	export HEROKU_PHP_FPM_CONFIG_INCLUDE="$fpm_config_include"
 fi
 
-if [[ -n ${fpm_config:-} || ( ${fpm_config:="$HEROKU_APP_DIR/$COMPOSER_VENDOR_DIR/heroku/heroku-buildpack-php/conf/php/php-fpm.conf"} && $verbose ) ]]; then
+if [[ -n ${fpm_config:-} || ( ${fpm_config:="$bp_dir/conf/php/php-fpm.conf"} && $verbose ) ]]; then
 	echo "Using PHP-FPM configuration file '${fpm_config#$HEROKU_APP_DIR/}'" >&2
 fi
 fpm_config=$(php_passthrough "$fpm_config")
@@ -246,13 +253,13 @@ if [[ -n ${php_config:-} ]]; then
 	php_config=$(php_passthrough "$php_config")
 fi
 
-if [[ -n ${httpd_config_include:-} || ( ${httpd_config_include:="$HEROKU_APP_DIR/$COMPOSER_VENDOR_DIR/heroku/heroku-buildpack-php/conf/apache2/default_include.conf"} && $verbose ) ]]; then
+if [[ -n ${httpd_config_include:-} || ( ${httpd_config_include:="$bp_dir/conf/apache2/default_include.conf"} && $verbose ) ]]; then
 	echo "Using Apache2 VirtualHost-level configuration include '${httpd_config_include#$HEROKU_APP_DIR/}'" >&2
 fi
 httpd_config_include=$(php_passthrough "$httpd_config_include")
 export HEROKU_PHP_HTTPD_CONFIG_INCLUDE="$httpd_config_include"
 
-if [[ -n ${httpd_config:-} || ( ${httpd_config:="$HEROKU_APP_DIR/$COMPOSER_VENDOR_DIR/heroku/heroku-buildpack-php/conf/apache2/heroku.conf"} && $verbose) ]]; then
+if [[ -n ${httpd_config:-} || ( ${httpd_config:="$bp_dir/conf/apache2/heroku.conf"} && $verbose) ]]; then
 	echo "Using Apache2 configuration file '${httpd_config#$HEROKU_APP_DIR/}'" >&2
 fi
 httpd_config=$(php_passthrough "$httpd_config")
@@ -277,7 +284,7 @@ if [[ -z ${WEB_CONCURRENCY:-} ]]; then
 
 	# determine number of FPM processes to run
 	# prevent loading of extension INIs (and thus e.g. newrelic) using empty PHP_INI_SCAN_DIR
-	read WEB_CONCURRENCY php_memory_limit <<<$(PHP_INI_SCAN_DIR= php ${php_config:+-c "$php_config"} $(composer config vendor-dir 2> /dev/null | tail -n 1)/heroku/heroku-buildpack-php/bin/util/autotune.php -y "$fpm_config" -t "$DOCUMENT_ROOT" "$ram") # tail, as composer echos outdated version warnings to STDOUT
+	read WEB_CONCURRENCY php_memory_limit <<<$(PHP_INI_SCAN_DIR= php ${php_config:+-c "$php_config"} "$bp_dir/bin/util/autotune.php" -y "$fpm_config" -t "$DOCUMENT_ROOT" "$ram")
 	[[ $WEB_CONCURRENCY -lt 1 ]] && WEB_CONCURRENCY=1
 	export WEB_CONCURRENCY
 

--- a/bin/heroku-php-nginx
+++ b/bin/heroku-php-nginx
@@ -9,8 +9,16 @@ shopt -s extglob
 # for detecting when -l 'logs/*.log' matches nothing
 shopt -s nullglob
 
+if ! type -p "realpath" > /dev/null; then
+	# cedar-14 doesn't have realpath
+	# must be a function so subshells, including $(…), can use it
+	realpath() {
+		readlink "$@"
+	}
+fi
+
 # we very likely got called via a symlink, so we have to realpath $0 first to find the base buildpack directory
-bp_dir=$(cd $(dirname $(realpath $0)); cd ..; pwd)
+bp_dir=$(cd $(dirname $(realpath -e $0)); cd ..; pwd)
 
 verbose=
 
@@ -41,6 +49,25 @@ touch_log() {
 	mkdir -p $(dirname "$1") && touch "$1"
 }
 
+findconfig() {
+	local dir=$(dirname "$2")
+	local file=$(basename "$2")
+	IFS='.' read -r -a version <<< "$1" # read the parts of $1 (version number) into an array, e.g. (7 2 33)
+
+	# iterate "backwards" over version parts so we try "7/2/11" first, then "7/2", then "7" for a version "7.2.11"
+	# we go down to 0, which will yield an empty string, for the last fallback layer without any version number
+	for (( i = ${#version[@]}; i >= 0; i--)); do
+		version_dir=$(IFS=/; echo "${version[*]:0:$i}") # set IFS to "/" for merging, but echo is a builtin, so it must be a subshell and a separate command
+		full_path="${dir}/${version_dir}${version_dir:+/}${file}" # concat, but if scandir is empty (last fallback), don't produce a double slash
+		if [[ -f "$full_path" ]]; then
+			echo "$full_path";
+			return 0;
+		fi
+	done
+	echo "$2"
+	return 1;
+}
+
 print_help() {
 	cat >&2 <<-EOF
 		
@@ -57,7 +84,8 @@ print_help() {
 		                          Recommended approach when customizing Nginx's config
 		                          in most cases, unless you need to set http or
 		                          fundamental server level options.
-		                          [default: <BPDIR>/conf/nginx/default_include.conf.php]
+		                          [default: <BPDIR>/conf/nginx/default_include.conf.php,
+		                          or a more version-specific file from a subdirectory]
 		  -c <nginx.conf>         The path to the full configuration file that is
 		                          included after Heroku's (or your local) Nginx config
 		                          is loaded. It must contain an 'http { ... }' block
@@ -65,14 +93,16 @@ print_help() {
 		                          and 'root' (see option -C above), but no global,
 		                          directives (globals are read from the system's default
 		                          Nginx configuration files).
-		                          [default: <BPDIR>/conf/nginx/heroku.conf.php]
+		                          [default: <BPDIR>/conf/nginx/heroku.conf.php,
+		                          or a more version-specific file from a subdirectory]
 		  -F <php-fpm.inc.conf>   The path to the configuration file to include at the  
 		                          end of php-fpm.conf (see option -f below), in the
 		                          '[www]' pool section. Recommended approach when
 		                          customizing PHP-FPM's configuration in most cases,
 		                          unless you need to set global options.
 		  -f <php-fpm.conf>       The path to the full PHP-FPM configuration file.
-		                          [default: <BPDIR>/conf/php/php-fpm.conf]
+		                          [default: <BPDIR>/conf/php/php-fpm.conf,
+		                          or a more version-specific file from a subdirectory]
 		  -h, --help              Display this help screen and exit.
 		  -i <php.ini>            The path to the php.ini file to use.
 		                          [default: <BPDIR>/conf/php/php.ini]
@@ -207,6 +237,9 @@ php -n -r 'exit((int)version_compare(PHP_VERSION, "5.5.11", "<"));' || { echo "T
 { php-fpm -n -v | php -n -r 'exit((int)version_compare(preg_replace("#PHP (\S+) \(fpm-fcgi\).+$#sm", "\\1", file_get_contents("php://stdin")), "5.5.11", "<"));'; } || { echo "This program requires PHP 5.5.11 or newer; check your 'php-fpm' command." >&2; exit 1; }
 unset -f php-fpm # remove the alias we made earlier that would prevent newrelic from starting on php-fpm -v
 
+php_version="$(php-fpm -n -v | php -n -r 'echo preg_replace("#PHP (\S+) \(fpm-fcgi\).+$#sm", "\\1", file_get_contents("php://stdin"));')"
+nginx_version="$(nginx -v 2>&1 | grep -oP "nginx\/\K[\d\.]+")" # \K, available with -P, resets the start of the match
+
 # make sure we run a local composer.phar if present, or global composer if not
 composer() {
 	local composer_bin=$(which ./composer.phar composer | head -n1)
@@ -244,7 +277,7 @@ if [[ -n ${fpm_config_include:-} ]]; then
 	export HEROKU_PHP_FPM_CONFIG_INCLUDE="$fpm_config_include"
 fi
 
-if [[ -n ${fpm_config:-} || ( ${fpm_config:="$bp_dir/conf/php/php-fpm.conf"} && $verbose ) ]]; then
+if [[ -n ${fpm_config:-} || ( ${fpm_config:=$(findconfig "$php_version" "$bp_dir/conf/php/php-fpm.conf")} && $verbose ) ]]; then
 	echo "Using PHP-FPM configuration file '${fpm_config#$HEROKU_APP_DIR/}'" >&2
 fi
 fpm_config=$(php_passthrough "$fpm_config")
@@ -254,13 +287,13 @@ if [[ -n ${php_config:-} ]]; then
 	php_config=$(php_passthrough "$php_config")
 fi
 
-if [[ -n ${nginx_config_include:-} || ( ${nginx_config_include:="$bp_dir/conf/nginx/default_include.conf.php"} && $verbose ) ]]; then
+if [[ -n ${nginx_config_include:-} || ( ${nginx_config_include:=$(findconfig "$nginx_version" "$bp_dir/conf/nginx/default_include.conf.php")} && $verbose ) ]]; then
 	echo "Using Nginx server-level configuration include '${nginx_config_include#$HEROKU_APP_DIR/}'" >&2
 fi
 nginx_config_include=$(php_passthrough "$nginx_config_include")
 export HEROKU_PHP_NGINX_CONFIG_INCLUDE="$nginx_config_include"
 
-if [[ -n ${nginx_config:-} || ( ${nginx_config:="$bp_dir/conf/nginx/heroku.conf.php"} && $verbose) ]]; then
+if [[ -n ${nginx_config:-} || ( ${nginx_config:=$(findconfig "$nginx_version" "$bp_dir/conf/nginx/heroku.conf.php")} && $verbose) ]]; then
 	echo "Using Nginx configuration file '${nginx_config#$HEROKU_APP_DIR/}'" >&2
 fi
 nginx_config=$(php_passthrough "$nginx_config")

--- a/bin/heroku-php-nginx
+++ b/bin/heroku-php-nginx
@@ -9,6 +9,9 @@ shopt -s extglob
 # for detecting when -l 'logs/*.log' matches nothing
 shopt -s nullglob
 
+# we very likely got called via a symlink, so we have to realpath $0 first to find the base buildpack directory
+bp_dir=$(cd $(dirname $(realpath $0)); cd ..; pwd)
+
 verbose=
 
 php_passthrough() {
@@ -54,7 +57,7 @@ print_help() {
 		                          Recommended approach when customizing Nginx's config
 		                          in most cases, unless you need to set http or
 		                          fundamental server level options.
-		                          [default: \$COMPOSER_VENDOR_DIR/heroku/heroku-buildpack-php/conf/nginx/default_include.conf.php]
+		                          [default: <BPDIR>/conf/nginx/default_include.conf.php]
 		  -c <nginx.conf>         The path to the full configuration file that is
 		                          included after Heroku's (or your local) Nginx config
 		                          is loaded. It must contain an 'http { ... }' block
@@ -62,17 +65,17 @@ print_help() {
 		                          and 'root' (see option -C above), but no global,
 		                          directives (globals are read from the system's default
 		                          Nginx configuration files).
-		                          [default: \$COMPOSER_VENDOR_DIR/heroku/heroku-buildpack-php/conf/nginx/heroku.conf.php]
+		                          [default: <BPDIR>/conf/nginx/heroku.conf.php]
 		  -F <php-fpm.inc.conf>   The path to the configuration file to include at the  
 		                          end of php-fpm.conf (see option -f below), in the
 		                          '[www]' pool section. Recommended approach when
 		                          customizing PHP-FPM's configuration in most cases,
 		                          unless you need to set global options.
 		  -f <php-fpm.conf>       The path to the full PHP-FPM configuration file.
-		                          [default: \$COMPOSER_VENDOR_DIR/heroku/heroku-buildpack-php/conf/php/php-fpm.conf]
+		                          [default: <BPDIR>/conf/php/php-fpm.conf]
 		  -h, --help              Display this help screen and exit.
 		  -i <php.ini>            The path to the php.ini file to use.
-		                          [default: \$COMPOSER_VENDOR_DIR/heroku/heroku-buildpack-php/conf/php/php.ini]
+		                          [default: <BPDIR>/conf/php/php.ini]
 		  -l <tailme.log>         Path to additional log file to tail to STDERR so its
 		                          contents appear in 'heroku logs'. If the file does not
 		                          exist, it will be created. Wildcards are allowed, but
@@ -83,6 +86,9 @@ print_help() {
 		                          the \$PORT environment variable, or a random port is
 		                          chosen if that variable does not exist.
 		  -v, --verbose           Be more verbose during startup.
+		
+		The <BPDIR> placeholder above represents the base directory of this buildpack:
+		$bp_dir
 		
 		All file paths must be relative to '$HEROKU_APP_DIR'.
 		
@@ -212,6 +218,7 @@ composer() {
 		php -n $composer_bin "$@"
 	fi
 }
+# these exports are used in default web server configs to lock down access to composer directories
 COMPOSER_VENDOR_DIR=$(composer config vendor-dir 2> /dev/null | tail -n 1) && export COMPOSER_VENDOR_DIR || { echo "Unable to determine Composer vendor-dir setting; is 'composer' executable on path or 'composer.phar' in current working directory?" >&2; exit 1; } # tail, as composer echos outdated version warnings to STDOUT; export after the assignment or exit status will that be of 'export
 COMPOSER_BIN_DIR=$(composer config bin-dir 2> /dev/null | tail -n 1) && export COMPOSER_BIN_DIR || { echo "Unable to determine Composer bin-dir setting; is 'composer' executable on path or 'composer.phar' in current working directory?" >&2; exit 1; } # tail, as composer echos outdated version warnings to STDOUT; export after the assignment or exit status will that be of 'export
 
@@ -237,7 +244,7 @@ if [[ -n ${fpm_config_include:-} ]]; then
 	export HEROKU_PHP_FPM_CONFIG_INCLUDE="$fpm_config_include"
 fi
 
-if [[ -n ${fpm_config:-} || ( ${fpm_config:="$HEROKU_APP_DIR/$COMPOSER_VENDOR_DIR/heroku/heroku-buildpack-php/conf/php/php-fpm.conf"} && $verbose ) ]]; then
+if [[ -n ${fpm_config:-} || ( ${fpm_config:="$bp_dir/conf/php/php-fpm.conf"} && $verbose ) ]]; then
 	echo "Using PHP-FPM configuration file '${fpm_config#$HEROKU_APP_DIR/}'" >&2
 fi
 fpm_config=$(php_passthrough "$fpm_config")
@@ -247,13 +254,13 @@ if [[ -n ${php_config:-} ]]; then
 	php_config=$(php_passthrough "$php_config")
 fi
 
-if [[ -n ${nginx_config_include:-} || ( ${nginx_config_include:="$HEROKU_APP_DIR/$COMPOSER_VENDOR_DIR/heroku/heroku-buildpack-php/conf/nginx/default_include.conf.php"} && $verbose ) ]]; then
+if [[ -n ${nginx_config_include:-} || ( ${nginx_config_include:="$bp_dir/conf/nginx/default_include.conf.php"} && $verbose ) ]]; then
 	echo "Using Nginx server-level configuration include '${nginx_config_include#$HEROKU_APP_DIR/}'" >&2
 fi
 nginx_config_include=$(php_passthrough "$nginx_config_include")
 export HEROKU_PHP_NGINX_CONFIG_INCLUDE="$nginx_config_include"
 
-if [[ -n ${nginx_config:-} || ( ${nginx_config:="$HEROKU_APP_DIR/$COMPOSER_VENDOR_DIR/heroku/heroku-buildpack-php/conf/nginx/heroku.conf.php"} && $verbose) ]]; then
+if [[ -n ${nginx_config:-} || ( ${nginx_config:="$bp_dir/conf/nginx/heroku.conf.php"} && $verbose) ]]; then
 	echo "Using Nginx configuration file '${nginx_config#$HEROKU_APP_DIR/}'" >&2
 fi
 nginx_config=$(php_passthrough "$nginx_config")
@@ -278,7 +285,7 @@ if [[ -z ${WEB_CONCURRENCY:-} ]]; then
 
 	# determine number of FPM processes to run
 	# prevent loading of extension INIs (and thus e.g. newrelic) using empty PHP_INI_SCAN_DIR
-	read WEB_CONCURRENCY php_memory_limit <<<$(PHP_INI_SCAN_DIR= php ${php_config:+-c "$php_config"} $(composer config vendor-dir 2> /dev/null | tail -n 1)/heroku/heroku-buildpack-php/bin/util/autotune.php -y "$fpm_config" -t "$DOCUMENT_ROOT" "$ram") # tail, as composer echos outdated version warnings to STDOUT
+	read WEB_CONCURRENCY php_memory_limit <<<$(PHP_INI_SCAN_DIR= php ${php_config:+-c "$php_config"} "$bp_dir/bin/util/autotune.php" -y "$fpm_config" -t "$DOCUMENT_ROOT" "$ram")
 	[[ $WEB_CONCURRENCY -lt 1 ]] && WEB_CONCURRENCY=1
 	export WEB_CONCURRENCY
 


### PR DESCRIPTION
Default configs in boot scripts are currently looked for in `$(cwd)/vendor/heroku/heroku-buildpack-php/`, which is annoying for e.g. testing runs, and it can lead to inconsistencies in cases where the buildpack in `vendor/…` isn't the one being invoked (coming in a future update, where installs happen in `.heroku/php`). 961fca7 changes the path base to be relative to the location where the boot script binary itself is located.

For PHP 7.3, we need at least a different `php-fpm.conf` (for logging changes), so with 791bf0d default configs are now passed through a `findconfig` lookup function that for e.g. PHP 7.3.0 and `foo/bar.conf`will try `foo/7/3/0/bar.conf`, then `foo/7/3/bar.conf`, then `foo/7/bar.conf`, and finally `foo/bar.conf`.