### PR TITLE
Build formula cleanup

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-bob-builder>=0.0.10
+bob-builder>=0.0.15
 s3cmd>=1.6.0

--- a/support/build/README.md
+++ b/support/build/README.md
@@ -186,9 +186,9 @@ That's where the `UPSTREAM_S3_BUCKET` and `UPSTREAM_S3_PREFIX` env vars document
 That way, if your Bob formula for an extension contains e.g. this dependency declaration at the top:
 
     # Build Path: /app/.heroku/php
-    # Build Deps: php-7.3.3
+    # Build Deps: php-7.3.*
 
-then on build, Bob will first look for "`php-7.3.3`" in your S3 bucket, and then fall back to pulling it from the upstream bucket. This frees you of the burden of hosting and maintaining unnecessary packages yourself.
+then on build, Bob will first look for "`php-7.3.*`" in your S3 bucket, and then fall back to pulling it from the upstream bucket. This frees you of the burden of hosting and maintaining unnecessary packages yourself.
 
 ### Building a Package
 
@@ -198,7 +198,7 @@ To verify a formula, `bob build` can be used to build it:
     ~ $ bob build extensions/no-debug-non-zts-20180731/yourextension-1.2.3
     
     Fetching dependencies... found 1:
-      - php-7.3.3
+      - php-7.3.*
     Building formula extensions/no-debug-non-zts-20180731/yourextension-1.2.3
     ...
 
@@ -707,13 +707,11 @@ For instance, for PHP 7.3 and Xdebug version 2.7.0, have a `php-7.3/xdebug-2.7.0
 
     #!/usr/bin/env bash
     # Build Path: /app/.heroku/php
-    # Build Deps: php-7.3.3
+    # Build Deps: php-7.3.*
     
     source $(dirname $0)/../xdebug
 
-The `php-7.3.3` dependency will not be found in the current S3 bucket and prefix, so Bob will fall back to `UPSTREAM_S3_BUCKET` and `UPSTREAM_S3_PREFIX`.
-
-It's possible that the `php-…` version in the example above no longer exists, so it may have to be adjusted to a newer version.
+The `php-7.3.*` dependency will not be found in the current S3 bucket and prefix, so Bob will fall back to `UPSTREAM_S3_BUCKET` and `UPSTREAM_S3_PREFIX`.
 
 #### Build Dockerfiles
 

--- a/support/build/apache
+++ b/support/build/apache
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 
 # fail hard
 set -o pipefail

--- a/support/build/apache
+++ b/support/build/apache
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php
 
 # fail hard
 set -o pipefail

--- a/support/build/apache-2.4.38
+++ b/support/build/apache-2.4.38
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 
 source $(dirname $0)/apache

--- a/support/build/composer
+++ b/support/build/composer
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 
 # fail hard
 set -o pipefail

--- a/support/build/composer
+++ b/support/build/composer
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php
 
 # fail hard
 set -o pipefail

--- a/support/build/composer-1.8.4
+++ b/support/build/composer-1.8.4
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-min-*
 
 source $(dirname $0)/composer

--- a/support/build/composer-1.8.4
+++ b/support/build/composer-1.8.4
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-min-7.3.3
+# Build Deps: php-min-*
 
 source $(dirname $0)/composer

--- a/support/build/extensions/no-debug-non-zts-20121212/apcu-4.0.11
+++ b/support/build/extensions/no-debug-non-zts-20121212/apcu-4.0.11
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-5.5.38
+# Build Deps: php-5.5.*
 
 source $(dirname $0)/apcu

--- a/support/build/extensions/no-debug-non-zts-20121212/apcu-4.0.11
+++ b/support/build/extensions/no-debug-non-zts-20121212/apcu-4.0.11
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-5.5.*
 
 source $(dirname $0)/apcu

--- a/support/build/extensions/no-debug-non-zts-20121212/blackfire-1.24.4
+++ b/support/build/extensions/no-debug-non-zts-20121212/blackfire-1.24.4
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 
 source $(dirname $0)/blackfire

--- a/support/build/extensions/no-debug-non-zts-20121212/cassandra-1.2.2
+++ b/support/build/extensions/no-debug-non-zts-20121212/cassandra-1.2.2
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-5.5.*, libraries/libcassandra-2.*
 
 source $(dirname $0)/cassandra

--- a/support/build/extensions/no-debug-non-zts-20121212/cassandra-1.2.2
+++ b/support/build/extensions/no-debug-non-zts-20121212/cassandra-1.2.2
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-5.5.38, libraries/libcassandra-2.9.0
+# Build Deps: php-5.5.*, libraries/libcassandra-2.*
 
 source $(dirname $0)/cassandra

--- a/support/build/extensions/no-debug-non-zts-20121212/ev-1.0.4
+++ b/support/build/extensions/no-debug-non-zts-20121212/ev-1.0.4
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-5.5.38
+# Build Deps: php-5.5.*
 
 source $(dirname $0)/ev

--- a/support/build/extensions/no-debug-non-zts-20121212/ev-1.0.4
+++ b/support/build/extensions/no-debug-non-zts-20121212/ev-1.0.4
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-5.5.*
 
 source $(dirname $0)/ev

--- a/support/build/extensions/no-debug-non-zts-20121212/event-2.4.3
+++ b/support/build/extensions/no-debug-non-zts-20121212/event-2.4.3
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-5.5.38
+# Build Deps: php-5.5.*
 
 source $(dirname $0)/event

--- a/support/build/extensions/no-debug-non-zts-20121212/event-2.4.3
+++ b/support/build/extensions/no-debug-non-zts-20121212/event-2.4.3
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-5.5.*
 
 source $(dirname $0)/event

--- a/support/build/extensions/no-debug-non-zts-20121212/imagick-3.4.3
+++ b/support/build/extensions/no-debug-non-zts-20121212/imagick-3.4.3
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-5.5.38
+# Build Deps: php-5.5.*
 
 source $(dirname $0)/imagick

--- a/support/build/extensions/no-debug-non-zts-20121212/imagick-3.4.3
+++ b/support/build/extensions/no-debug-non-zts-20121212/imagick-3.4.3
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-5.5.*
 
 source $(dirname $0)/imagick

--- a/support/build/extensions/no-debug-non-zts-20121212/memcached-2.2.0
+++ b/support/build/extensions/no-debug-non-zts-20121212/memcached-2.2.0
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-5.5.38, libraries/libmemcached-1.0.18
+# Build Deps: php-5.5.*, libraries/libmemcached-1.0.18
 
 source $(dirname $0)/memcached

--- a/support/build/extensions/no-debug-non-zts-20121212/memcached-2.2.0
+++ b/support/build/extensions/no-debug-non-zts-20121212/memcached-2.2.0
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-5.5.*, libraries/libmemcached-1.0.18
 
 source $(dirname $0)/memcached

--- a/support/build/extensions/no-debug-non-zts-20121212/mongo-1.6.16
+++ b/support/build/extensions/no-debug-non-zts-20121212/mongo-1.6.16
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-5.5.38
+# Build Deps: php-5.5.*
 
 source $(dirname $0)/mongo

--- a/support/build/extensions/no-debug-non-zts-20121212/mongo-1.6.16
+++ b/support/build/extensions/no-debug-non-zts-20121212/mongo-1.6.16
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-5.5.*
 
 source $(dirname $0)/mongo

--- a/support/build/extensions/no-debug-non-zts-20121212/mongodb-1.5.3
+++ b/support/build/extensions/no-debug-non-zts-20121212/mongodb-1.5.3
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-5.5.38
+# Build Deps: php-5.5.*
 
 source $(dirname $0)/mongodb

--- a/support/build/extensions/no-debug-non-zts-20121212/mongodb-1.5.3
+++ b/support/build/extensions/no-debug-non-zts-20121212/mongodb-1.5.3
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-5.5.*
 
 source $(dirname $0)/mongodb

--- a/support/build/extensions/no-debug-non-zts-20121212/newrelic
+++ b/support/build/extensions/no-debug-non-zts-20121212/newrelic
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 
 # fail hard
 set -o pipefail

--- a/support/build/extensions/no-debug-non-zts-20121212/newrelic
+++ b/support/build/extensions/no-debug-non-zts-20121212/newrelic
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php
 
 # fail hard
 set -o pipefail

--- a/support/build/extensions/no-debug-non-zts-20121212/newrelic-8.6.0.238
+++ b/support/build/extensions/no-debug-non-zts-20121212/newrelic-8.6.0.238
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 
 source $(dirname $0)/newrelic

--- a/support/build/extensions/no-debug-non-zts-20121212/oauth-1.2.3
+++ b/support/build/extensions/no-debug-non-zts-20121212/oauth-1.2.3
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-5.5.38
+# Build Deps: php-5.5.*
 
 source $(dirname $0)/oauth

--- a/support/build/extensions/no-debug-non-zts-20121212/oauth-1.2.3
+++ b/support/build/extensions/no-debug-non-zts-20121212/oauth-1.2.3
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-5.5.*
 
 source $(dirname $0)/oauth

--- a/support/build/extensions/no-debug-non-zts-20121212/phalcon
+++ b/support/build/extensions/no-debug-non-zts-20121212/phalcon
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 
 # fail hard
 set -o pipefail

--- a/support/build/extensions/no-debug-non-zts-20121212/phalcon
+++ b/support/build/extensions/no-debug-non-zts-20121212/phalcon
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php
 
 # fail hard
 set -o pipefail

--- a/support/build/extensions/no-debug-non-zts-20121212/phalcon-2.0.13
+++ b/support/build/extensions/no-debug-non-zts-20121212/phalcon-2.0.13
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-5.5.38
+# Build Deps: php-5.5.*
 
 source $(dirname $0)/phalcon

--- a/support/build/extensions/no-debug-non-zts-20121212/phalcon-2.0.13
+++ b/support/build/extensions/no-debug-non-zts-20121212/phalcon-2.0.13
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-5.5.*
 
 source $(dirname $0)/phalcon

--- a/support/build/extensions/no-debug-non-zts-20121212/phalcon-3.4.3
+++ b/support/build/extensions/no-debug-non-zts-20121212/phalcon-3.4.3
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-5.5.38
+# Build Deps: php-5.5.*
 
 source $(dirname $0)/phalcon

--- a/support/build/extensions/no-debug-non-zts-20121212/phalcon-3.4.3
+++ b/support/build/extensions/no-debug-non-zts-20121212/phalcon-3.4.3
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-5.5.*
 
 source $(dirname $0)/phalcon

--- a/support/build/extensions/no-debug-non-zts-20121212/pq-1.1.1
+++ b/support/build/extensions/no-debug-non-zts-20121212/pq-1.1.1
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-5.5.*, extensions/no-debug-non-zts-20121212/raphf-1.*
 
 source $(dirname $0)/pq

--- a/support/build/extensions/no-debug-non-zts-20121212/pq-1.1.1
+++ b/support/build/extensions/no-debug-non-zts-20121212/pq-1.1.1
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-5.5.38, extensions/no-debug-non-zts-20121212/raphf-1.1.2
+# Build Deps: php-5.5.*, extensions/no-debug-non-zts-20121212/raphf-1.*
 
 source $(dirname $0)/pq

--- a/support/build/extensions/no-debug-non-zts-20121212/raphf-1.1.2
+++ b/support/build/extensions/no-debug-non-zts-20121212/raphf-1.1.2
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-5.5.38
+# Build Deps: php-5.5.*
 
 source $(dirname $0)/raphf

--- a/support/build/extensions/no-debug-non-zts-20121212/raphf-1.1.2
+++ b/support/build/extensions/no-debug-non-zts-20121212/raphf-1.1.2
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-5.5.*
 
 source $(dirname $0)/raphf

--- a/support/build/extensions/no-debug-non-zts-20121212/rdkafka-3.0.5
+++ b/support/build/extensions/no-debug-non-zts-20121212/rdkafka-3.0.5
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-5.5.38, libraries/librdkafka-0.11.6
+# Build Deps: php-5.5.*, libraries/librdkafka-0.*
 
 source $(dirname $0)/rdkafka

--- a/support/build/extensions/no-debug-non-zts-20121212/rdkafka-3.0.5
+++ b/support/build/extensions/no-debug-non-zts-20121212/rdkafka-3.0.5
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-5.5.*, libraries/librdkafka-0.*
 
 source $(dirname $0)/rdkafka

--- a/support/build/extensions/no-debug-non-zts-20121212/redis-3.1.6
+++ b/support/build/extensions/no-debug-non-zts-20121212/redis-3.1.6
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-5.5.38
+# Build Deps: php-5.5.*
 
 source $(dirname $0)/redis

--- a/support/build/extensions/no-debug-non-zts-20121212/redis-3.1.6
+++ b/support/build/extensions/no-debug-non-zts-20121212/redis-3.1.6
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-5.5.*
 
 source $(dirname $0)/redis

--- a/support/build/extensions/no-debug-non-zts-20121212/redis-4.3.0
+++ b/support/build/extensions/no-debug-non-zts-20121212/redis-4.3.0
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-5.5.38
+# Build Deps: php-5.5.*
 
 source $(dirname $0)/redis

--- a/support/build/extensions/no-debug-non-zts-20121212/redis-4.3.0
+++ b/support/build/extensions/no-debug-non-zts-20121212/redis-4.3.0
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-5.5.*
 
 source $(dirname $0)/redis

--- a/support/build/extensions/no-debug-non-zts-20131226/amqp-1.9.4
+++ b/support/build/extensions/no-debug-non-zts-20131226/amqp-1.9.4
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-5.6.40
+# Build Deps: php-5.6.*
 
 source $(dirname $0)/amqp

--- a/support/build/extensions/no-debug-non-zts-20131226/amqp-1.9.4
+++ b/support/build/extensions/no-debug-non-zts-20131226/amqp-1.9.4
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-5.6.*
 
 source $(dirname $0)/amqp

--- a/support/build/extensions/no-debug-non-zts-20131226/apcu-4.0.11
+++ b/support/build/extensions/no-debug-non-zts-20131226/apcu-4.0.11
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-5.6.40
+# Build Deps: php-5.6.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/apcu

--- a/support/build/extensions/no-debug-non-zts-20131226/apcu-4.0.11
+++ b/support/build/extensions/no-debug-non-zts-20131226/apcu-4.0.11
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-5.6.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/apcu

--- a/support/build/extensions/no-debug-non-zts-20131226/blackfire
+++ b/support/build/extensions/no-debug-non-zts-20131226/blackfire
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 
 source $(dirname $0)/../no-debug-non-zts-20121212/blackfire

--- a/support/build/extensions/no-debug-non-zts-20131226/blackfire-1.24.4
+++ b/support/build/extensions/no-debug-non-zts-20131226/blackfire-1.24.4
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 
 source $(dirname $0)/blackfire

--- a/support/build/extensions/no-debug-non-zts-20131226/cassandra-1.3.2
+++ b/support/build/extensions/no-debug-non-zts-20131226/cassandra-1.3.2
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-5.6.*, libraries/libcassandra-2.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/cassandra

--- a/support/build/extensions/no-debug-non-zts-20131226/cassandra-1.3.2
+++ b/support/build/extensions/no-debug-non-zts-20131226/cassandra-1.3.2
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-5.6.40, libraries/libcassandra-2.9.0
+# Build Deps: php-5.6.*, libraries/libcassandra-2.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/cassandra

--- a/support/build/extensions/no-debug-non-zts-20131226/ev-1.0.4
+++ b/support/build/extensions/no-debug-non-zts-20131226/ev-1.0.4
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-5.6.40
+# Build Deps: php-5.6.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/ev

--- a/support/build/extensions/no-debug-non-zts-20131226/ev-1.0.4
+++ b/support/build/extensions/no-debug-non-zts-20131226/ev-1.0.4
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-5.6.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/ev

--- a/support/build/extensions/no-debug-non-zts-20131226/event-2.4.3
+++ b/support/build/extensions/no-debug-non-zts-20131226/event-2.4.3
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-5.6.40
+# Build Deps: php-5.6.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/event

--- a/support/build/extensions/no-debug-non-zts-20131226/event-2.4.3
+++ b/support/build/extensions/no-debug-non-zts-20131226/event-2.4.3
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-5.6.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/event

--- a/support/build/extensions/no-debug-non-zts-20131226/imagick-3.4.3
+++ b/support/build/extensions/no-debug-non-zts-20131226/imagick-3.4.3
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-5.6.40
+# Build Deps: php-5.6.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/imagick

--- a/support/build/extensions/no-debug-non-zts-20131226/imagick-3.4.3
+++ b/support/build/extensions/no-debug-non-zts-20131226/imagick-3.4.3
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-5.6.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/imagick

--- a/support/build/extensions/no-debug-non-zts-20131226/memcached-2.2.0
+++ b/support/build/extensions/no-debug-non-zts-20131226/memcached-2.2.0
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-5.6.40, libraries/libmemcached-1.0.18
+# Build Deps: php-5.6.*, libraries/libmemcached-1.0.18
 
 source $(dirname $0)/../no-debug-non-zts-20121212/memcached

--- a/support/build/extensions/no-debug-non-zts-20131226/memcached-2.2.0
+++ b/support/build/extensions/no-debug-non-zts-20131226/memcached-2.2.0
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-5.6.*, libraries/libmemcached-1.0.18
 
 source $(dirname $0)/../no-debug-non-zts-20121212/memcached

--- a/support/build/extensions/no-debug-non-zts-20131226/mongo-1.6.16
+++ b/support/build/extensions/no-debug-non-zts-20131226/mongo-1.6.16
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-5.6.40
+# Build Deps: php-5.6.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/mongo

--- a/support/build/extensions/no-debug-non-zts-20131226/mongo-1.6.16
+++ b/support/build/extensions/no-debug-non-zts-20131226/mongo-1.6.16
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-5.6.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/mongo

--- a/support/build/extensions/no-debug-non-zts-20131226/mongodb-1.5.3
+++ b/support/build/extensions/no-debug-non-zts-20131226/mongodb-1.5.3
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-5.6.40
+# Build Deps: php-5.6.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/mongodb

--- a/support/build/extensions/no-debug-non-zts-20131226/mongodb-1.5.3
+++ b/support/build/extensions/no-debug-non-zts-20131226/mongodb-1.5.3
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-5.6.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/mongodb

--- a/support/build/extensions/no-debug-non-zts-20131226/newrelic-8.6.0.238
+++ b/support/build/extensions/no-debug-non-zts-20131226/newrelic-8.6.0.238
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 
 source $(dirname $0)/../no-debug-non-zts-20121212/newrelic

--- a/support/build/extensions/no-debug-non-zts-20131226/oauth-1.2.3
+++ b/support/build/extensions/no-debug-non-zts-20131226/oauth-1.2.3
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-5.6.40
+# Build Deps: php-5.6.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/oauth

--- a/support/build/extensions/no-debug-non-zts-20131226/oauth-1.2.3
+++ b/support/build/extensions/no-debug-non-zts-20131226/oauth-1.2.3
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-5.6.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/oauth

--- a/support/build/extensions/no-debug-non-zts-20131226/phalcon-2.0.13
+++ b/support/build/extensions/no-debug-non-zts-20131226/phalcon-2.0.13
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-5.6.40
+# Build Deps: php-5.6.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/phalcon

--- a/support/build/extensions/no-debug-non-zts-20131226/phalcon-2.0.13
+++ b/support/build/extensions/no-debug-non-zts-20131226/phalcon-2.0.13
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-5.6.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/phalcon

--- a/support/build/extensions/no-debug-non-zts-20131226/phalcon-3.4.3
+++ b/support/build/extensions/no-debug-non-zts-20131226/phalcon-3.4.3
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-5.6.40
+# Build Deps: php-5.6.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/phalcon

--- a/support/build/extensions/no-debug-non-zts-20131226/phalcon-3.4.3
+++ b/support/build/extensions/no-debug-non-zts-20131226/phalcon-3.4.3
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-5.6.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/phalcon

--- a/support/build/extensions/no-debug-non-zts-20131226/pq-1.1.1
+++ b/support/build/extensions/no-debug-non-zts-20131226/pq-1.1.1
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-5.6.40, extensions/no-debug-non-zts-20131226/raphf-1.1.2
+# Build Deps: php-5.6.*, extensions/no-debug-non-zts-20131226/raphf-1.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/pq

--- a/support/build/extensions/no-debug-non-zts-20131226/pq-1.1.1
+++ b/support/build/extensions/no-debug-non-zts-20131226/pq-1.1.1
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-5.6.*, extensions/no-debug-non-zts-20131226/raphf-1.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/pq

--- a/support/build/extensions/no-debug-non-zts-20131226/raphf-1.1.2
+++ b/support/build/extensions/no-debug-non-zts-20131226/raphf-1.1.2
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-5.6.40
+# Build Deps: php-5.6.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/raphf

--- a/support/build/extensions/no-debug-non-zts-20131226/raphf-1.1.2
+++ b/support/build/extensions/no-debug-non-zts-20131226/raphf-1.1.2
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-5.6.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/raphf

--- a/support/build/extensions/no-debug-non-zts-20131226/rdkafka-3.0.5
+++ b/support/build/extensions/no-debug-non-zts-20131226/rdkafka-3.0.5
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-5.6.40, libraries/librdkafka-0.11.6
+# Build Deps: php-5.6.*, libraries/librdkafka-0.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/rdkafka

--- a/support/build/extensions/no-debug-non-zts-20131226/rdkafka-3.0.5
+++ b/support/build/extensions/no-debug-non-zts-20131226/rdkafka-3.0.5
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-5.6.*, libraries/librdkafka-0.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/rdkafka

--- a/support/build/extensions/no-debug-non-zts-20131226/redis-3.1.6
+++ b/support/build/extensions/no-debug-non-zts-20131226/redis-3.1.6
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-5.6.40
+# Build Deps: php-5.6.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/redis

--- a/support/build/extensions/no-debug-non-zts-20131226/redis-3.1.6
+++ b/support/build/extensions/no-debug-non-zts-20131226/redis-3.1.6
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-5.6.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/redis

--- a/support/build/extensions/no-debug-non-zts-20131226/redis-4.3.0
+++ b/support/build/extensions/no-debug-non-zts-20131226/redis-4.3.0
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-5.6.40
+# Build Deps: php-5.6.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/redis

--- a/support/build/extensions/no-debug-non-zts-20131226/redis-4.3.0
+++ b/support/build/extensions/no-debug-non-zts-20131226/redis-4.3.0
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-5.6.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/redis

--- a/support/build/extensions/no-debug-non-zts-20151012/amqp-1.9.4
+++ b/support/build/extensions/no-debug-non-zts-20151012/amqp-1.9.4
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-7.0.33
+# Build Deps: php-7.0.*
 
 source $(dirname $0)/../no-debug-non-zts-20131226/amqp

--- a/support/build/extensions/no-debug-non-zts-20151012/amqp-1.9.4
+++ b/support/build/extensions/no-debug-non-zts-20151012/amqp-1.9.4
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-7.0.*
 
 source $(dirname $0)/../no-debug-non-zts-20131226/amqp

--- a/support/build/extensions/no-debug-non-zts-20151012/apcu-5.1.17
+++ b/support/build/extensions/no-debug-non-zts-20151012/apcu-5.1.17
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-7.0.33
+# Build Deps: php-7.0.*
 
 source $(dirname $0)/apcu

--- a/support/build/extensions/no-debug-non-zts-20151012/apcu-5.1.17
+++ b/support/build/extensions/no-debug-non-zts-20151012/apcu-5.1.17
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-7.0.*
 
 source $(dirname $0)/apcu

--- a/support/build/extensions/no-debug-non-zts-20151012/blackfire
+++ b/support/build/extensions/no-debug-non-zts-20151012/blackfire
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 
 source $(dirname $0)/../no-debug-non-zts-20121212/blackfire

--- a/support/build/extensions/no-debug-non-zts-20151012/blackfire-1.24.4
+++ b/support/build/extensions/no-debug-non-zts-20151012/blackfire-1.24.4
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 
 source $(dirname $0)/blackfire

--- a/support/build/extensions/no-debug-non-zts-20151012/cassandra-1.3.2
+++ b/support/build/extensions/no-debug-non-zts-20151012/cassandra-1.3.2
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-7.0.33, libraries/libcassandra-2.9.0
+# Build Deps: php-7.0.*, libraries/libcassandra-2.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/cassandra

--- a/support/build/extensions/no-debug-non-zts-20151012/cassandra-1.3.2
+++ b/support/build/extensions/no-debug-non-zts-20151012/cassandra-1.3.2
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-7.0.*, libraries/libcassandra-2.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/cassandra

--- a/support/build/extensions/no-debug-non-zts-20151012/ev-1.0.4
+++ b/support/build/extensions/no-debug-non-zts-20151012/ev-1.0.4
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-7.0.33
+# Build Deps: php-7.0.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/ev

--- a/support/build/extensions/no-debug-non-zts-20151012/ev-1.0.4
+++ b/support/build/extensions/no-debug-non-zts-20151012/ev-1.0.4
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-7.0.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/ev

--- a/support/build/extensions/no-debug-non-zts-20151012/event-2.4.3
+++ b/support/build/extensions/no-debug-non-zts-20151012/event-2.4.3
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-7.0.33
+# Build Deps: php-7.0.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/event

--- a/support/build/extensions/no-debug-non-zts-20151012/event-2.4.3
+++ b/support/build/extensions/no-debug-non-zts-20151012/event-2.4.3
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-7.0.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/event

--- a/support/build/extensions/no-debug-non-zts-20151012/imagick-3.4.3
+++ b/support/build/extensions/no-debug-non-zts-20151012/imagick-3.4.3
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-7.0.33
+# Build Deps: php-7.0.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/imagick

--- a/support/build/extensions/no-debug-non-zts-20151012/imagick-3.4.3
+++ b/support/build/extensions/no-debug-non-zts-20151012/imagick-3.4.3
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-7.0.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/imagick

--- a/support/build/extensions/no-debug-non-zts-20151012/memcached-3.1.3
+++ b/support/build/extensions/no-debug-non-zts-20151012/memcached-3.1.3
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-7.0.33, libraries/libmemcached-1.0.18
+# Build Deps: php-7.0.*, libraries/libmemcached-1.0.18
 
 source $(dirname $0)/../no-debug-non-zts-20121212/memcached

--- a/support/build/extensions/no-debug-non-zts-20151012/memcached-3.1.3
+++ b/support/build/extensions/no-debug-non-zts-20151012/memcached-3.1.3
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-7.0.*, libraries/libmemcached-1.0.18
 
 source $(dirname $0)/../no-debug-non-zts-20121212/memcached

--- a/support/build/extensions/no-debug-non-zts-20151012/mongodb-1.5.3
+++ b/support/build/extensions/no-debug-non-zts-20151012/mongodb-1.5.3
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-7.0.33
+# Build Deps: php-7.0.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/mongodb

--- a/support/build/extensions/no-debug-non-zts-20151012/mongodb-1.5.3
+++ b/support/build/extensions/no-debug-non-zts-20151012/mongodb-1.5.3
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-7.0.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/mongodb

--- a/support/build/extensions/no-debug-non-zts-20151012/newrelic-8.6.0.238
+++ b/support/build/extensions/no-debug-non-zts-20151012/newrelic-8.6.0.238
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 
 source $(dirname $0)/../no-debug-non-zts-20121212/newrelic

--- a/support/build/extensions/no-debug-non-zts-20151012/oauth-2.0.3
+++ b/support/build/extensions/no-debug-non-zts-20151012/oauth-2.0.3
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-7.0.33
+# Build Deps: php-7.0.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/oauth

--- a/support/build/extensions/no-debug-non-zts-20151012/oauth-2.0.3
+++ b/support/build/extensions/no-debug-non-zts-20151012/oauth-2.0.3
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-7.0.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/oauth

--- a/support/build/extensions/no-debug-non-zts-20151012/phalcon-3.4.3
+++ b/support/build/extensions/no-debug-non-zts-20151012/phalcon-3.4.3
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-7.0.33
+# Build Deps: php-7.0.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/phalcon

--- a/support/build/extensions/no-debug-non-zts-20151012/phalcon-3.4.3
+++ b/support/build/extensions/no-debug-non-zts-20151012/phalcon-3.4.3
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-7.0.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/phalcon

--- a/support/build/extensions/no-debug-non-zts-20151012/pq-2.1.5
+++ b/support/build/extensions/no-debug-non-zts-20151012/pq-2.1.5
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-7.0.33, extensions/no-debug-non-zts-20151012/raphf-2.0.0
+# Build Deps: php-7.0.*, extensions/no-debug-non-zts-20151012/raphf-2.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/pq

--- a/support/build/extensions/no-debug-non-zts-20151012/pq-2.1.5
+++ b/support/build/extensions/no-debug-non-zts-20151012/pq-2.1.5
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-7.0.*, extensions/no-debug-non-zts-20151012/raphf-2.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/pq

--- a/support/build/extensions/no-debug-non-zts-20151012/raphf-2.0.0
+++ b/support/build/extensions/no-debug-non-zts-20151012/raphf-2.0.0
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-7.0.33
+# Build Deps: php-7.0.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/raphf

--- a/support/build/extensions/no-debug-non-zts-20151012/raphf-2.0.0
+++ b/support/build/extensions/no-debug-non-zts-20151012/raphf-2.0.0
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-7.0.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/raphf

--- a/support/build/extensions/no-debug-non-zts-20151012/rdkafka-3.0.5
+++ b/support/build/extensions/no-debug-non-zts-20151012/rdkafka-3.0.5
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-7.0.33, libraries/librdkafka-0.11.6
+# Build Deps: php-7.0.*, libraries/librdkafka-0.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/rdkafka

--- a/support/build/extensions/no-debug-non-zts-20151012/rdkafka-3.0.5
+++ b/support/build/extensions/no-debug-non-zts-20151012/rdkafka-3.0.5
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-7.0.*, libraries/librdkafka-0.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/rdkafka

--- a/support/build/extensions/no-debug-non-zts-20151012/redis-3.1.6
+++ b/support/build/extensions/no-debug-non-zts-20151012/redis-3.1.6
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-7.0.33
+# Build Deps: php-7.0.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/redis

--- a/support/build/extensions/no-debug-non-zts-20151012/redis-3.1.6
+++ b/support/build/extensions/no-debug-non-zts-20151012/redis-3.1.6
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-7.0.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/redis

--- a/support/build/extensions/no-debug-non-zts-20151012/redis-4.3.0
+++ b/support/build/extensions/no-debug-non-zts-20151012/redis-4.3.0
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-7.0.33
+# Build Deps: php-7.0.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/redis

--- a/support/build/extensions/no-debug-non-zts-20151012/redis-4.3.0
+++ b/support/build/extensions/no-debug-non-zts-20151012/redis-4.3.0
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-7.0.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/redis

--- a/support/build/extensions/no-debug-non-zts-20160303/amqp-1.9.4
+++ b/support/build/extensions/no-debug-non-zts-20160303/amqp-1.9.4
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-7.1.27
+# Build Deps: php-7.1.*
 
 source $(dirname $0)/../no-debug-non-zts-20131226/amqp

--- a/support/build/extensions/no-debug-non-zts-20160303/amqp-1.9.4
+++ b/support/build/extensions/no-debug-non-zts-20160303/amqp-1.9.4
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-7.1.*
 
 source $(dirname $0)/../no-debug-non-zts-20131226/amqp

--- a/support/build/extensions/no-debug-non-zts-20160303/apcu-5.1.17
+++ b/support/build/extensions/no-debug-non-zts-20160303/apcu-5.1.17
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-7.1.27
+# Build Deps: php-7.1.*
 
 source $(dirname $0)/../no-debug-non-zts-20151012/apcu

--- a/support/build/extensions/no-debug-non-zts-20160303/apcu-5.1.17
+++ b/support/build/extensions/no-debug-non-zts-20160303/apcu-5.1.17
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-7.1.*
 
 source $(dirname $0)/../no-debug-non-zts-20151012/apcu

--- a/support/build/extensions/no-debug-non-zts-20160303/blackfire
+++ b/support/build/extensions/no-debug-non-zts-20160303/blackfire
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 
 source $(dirname $0)/../no-debug-non-zts-20121212/blackfire

--- a/support/build/extensions/no-debug-non-zts-20160303/blackfire-1.24.4
+++ b/support/build/extensions/no-debug-non-zts-20160303/blackfire-1.24.4
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 
 source $(dirname $0)/blackfire

--- a/support/build/extensions/no-debug-non-zts-20160303/cassandra-1.3.2
+++ b/support/build/extensions/no-debug-non-zts-20160303/cassandra-1.3.2
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-7.1.27, libraries/libcassandra-2.9.0
+# Build Deps: php-7.1.*, libraries/libcassandra-2.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/cassandra

--- a/support/build/extensions/no-debug-non-zts-20160303/cassandra-1.3.2
+++ b/support/build/extensions/no-debug-non-zts-20160303/cassandra-1.3.2
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-7.1.*, libraries/libcassandra-2.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/cassandra

--- a/support/build/extensions/no-debug-non-zts-20160303/ev-1.0.4
+++ b/support/build/extensions/no-debug-non-zts-20160303/ev-1.0.4
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-7.1.27
+# Build Deps: php-7.1.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/ev

--- a/support/build/extensions/no-debug-non-zts-20160303/ev-1.0.4
+++ b/support/build/extensions/no-debug-non-zts-20160303/ev-1.0.4
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-7.1.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/ev

--- a/support/build/extensions/no-debug-non-zts-20160303/event-2.4.3
+++ b/support/build/extensions/no-debug-non-zts-20160303/event-2.4.3
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-7.1.27
+# Build Deps: php-7.1.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/event

--- a/support/build/extensions/no-debug-non-zts-20160303/event-2.4.3
+++ b/support/build/extensions/no-debug-non-zts-20160303/event-2.4.3
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-7.1.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/event

--- a/support/build/extensions/no-debug-non-zts-20160303/imagick-3.4.3
+++ b/support/build/extensions/no-debug-non-zts-20160303/imagick-3.4.3
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-7.1.27
+# Build Deps: php-7.1.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/imagick

--- a/support/build/extensions/no-debug-non-zts-20160303/imagick-3.4.3
+++ b/support/build/extensions/no-debug-non-zts-20160303/imagick-3.4.3
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-7.1.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/imagick

--- a/support/build/extensions/no-debug-non-zts-20160303/memcached-3.1.3
+++ b/support/build/extensions/no-debug-non-zts-20160303/memcached-3.1.3
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-7.1.27, libraries/libmemcached-1.0.18
+# Build Deps: php-7.1.*, libraries/libmemcached-1.0.18
 
 source $(dirname $0)/../no-debug-non-zts-20121212/memcached

--- a/support/build/extensions/no-debug-non-zts-20160303/memcached-3.1.3
+++ b/support/build/extensions/no-debug-non-zts-20160303/memcached-3.1.3
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-7.1.*, libraries/libmemcached-1.0.18
 
 source $(dirname $0)/../no-debug-non-zts-20121212/memcached

--- a/support/build/extensions/no-debug-non-zts-20160303/mongodb-1.5.3
+++ b/support/build/extensions/no-debug-non-zts-20160303/mongodb-1.5.3
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-7.1.27
+# Build Deps: php-7.1.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/mongodb

--- a/support/build/extensions/no-debug-non-zts-20160303/mongodb-1.5.3
+++ b/support/build/extensions/no-debug-non-zts-20160303/mongodb-1.5.3
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-7.1.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/mongodb

--- a/support/build/extensions/no-debug-non-zts-20160303/newrelic-8.6.0.238
+++ b/support/build/extensions/no-debug-non-zts-20160303/newrelic-8.6.0.238
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 
 source $(dirname $0)/../no-debug-non-zts-20121212/newrelic

--- a/support/build/extensions/no-debug-non-zts-20160303/oauth-2.0.3
+++ b/support/build/extensions/no-debug-non-zts-20160303/oauth-2.0.3
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-7.1.27
+# Build Deps: php-7.1.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/oauth

--- a/support/build/extensions/no-debug-non-zts-20160303/oauth-2.0.3
+++ b/support/build/extensions/no-debug-non-zts-20160303/oauth-2.0.3
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-7.1.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/oauth

--- a/support/build/extensions/no-debug-non-zts-20160303/phalcon-3.4.3
+++ b/support/build/extensions/no-debug-non-zts-20160303/phalcon-3.4.3
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-7.1.27
+# Build Deps: php-7.1.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/phalcon

--- a/support/build/extensions/no-debug-non-zts-20160303/phalcon-3.4.3
+++ b/support/build/extensions/no-debug-non-zts-20160303/phalcon-3.4.3
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-7.1.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/phalcon

--- a/support/build/extensions/no-debug-non-zts-20160303/pq-2.1.5
+++ b/support/build/extensions/no-debug-non-zts-20160303/pq-2.1.5
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-7.1.27, extensions/no-debug-non-zts-20160303/raphf-2.0.0
+# Build Deps: php-7.1.*, extensions/no-debug-non-zts-20160303/raphf-2.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/pq

--- a/support/build/extensions/no-debug-non-zts-20160303/pq-2.1.5
+++ b/support/build/extensions/no-debug-non-zts-20160303/pq-2.1.5
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-7.1.*, extensions/no-debug-non-zts-20160303/raphf-2.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/pq

--- a/support/build/extensions/no-debug-non-zts-20160303/raphf-2.0.0
+++ b/support/build/extensions/no-debug-non-zts-20160303/raphf-2.0.0
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-7.1.27
+# Build Deps: php-7.1.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/raphf

--- a/support/build/extensions/no-debug-non-zts-20160303/raphf-2.0.0
+++ b/support/build/extensions/no-debug-non-zts-20160303/raphf-2.0.0
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-7.1.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/raphf

--- a/support/build/extensions/no-debug-non-zts-20160303/rdkafka-3.0.5
+++ b/support/build/extensions/no-debug-non-zts-20160303/rdkafka-3.0.5
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-7.1.*, libraries/librdkafka-0.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/rdkafka

--- a/support/build/extensions/no-debug-non-zts-20160303/rdkafka-3.0.5
+++ b/support/build/extensions/no-debug-non-zts-20160303/rdkafka-3.0.5
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-7.1.27, libraries/librdkafka-0.11.6
+# Build Deps: php-7.1.*, libraries/librdkafka-0.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/rdkafka

--- a/support/build/extensions/no-debug-non-zts-20160303/redis-3.1.6
+++ b/support/build/extensions/no-debug-non-zts-20160303/redis-3.1.6
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-7.1.27
+# Build Deps: php-7.1.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/redis

--- a/support/build/extensions/no-debug-non-zts-20160303/redis-3.1.6
+++ b/support/build/extensions/no-debug-non-zts-20160303/redis-3.1.6
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-7.1.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/redis

--- a/support/build/extensions/no-debug-non-zts-20160303/redis-4.3.0
+++ b/support/build/extensions/no-debug-non-zts-20160303/redis-4.3.0
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-7.1.27
+# Build Deps: php-7.1.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/redis

--- a/support/build/extensions/no-debug-non-zts-20160303/redis-4.3.0
+++ b/support/build/extensions/no-debug-non-zts-20160303/redis-4.3.0
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-7.1.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/redis

--- a/support/build/extensions/no-debug-non-zts-20170718/amqp-1.9.4
+++ b/support/build/extensions/no-debug-non-zts-20170718/amqp-1.9.4
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-7.2.16
+# Build Deps: php-7.2.*
 
 source $(dirname $0)/../no-debug-non-zts-20131226/amqp

--- a/support/build/extensions/no-debug-non-zts-20170718/amqp-1.9.4
+++ b/support/build/extensions/no-debug-non-zts-20170718/amqp-1.9.4
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-7.2.*
 
 source $(dirname $0)/../no-debug-non-zts-20131226/amqp

--- a/support/build/extensions/no-debug-non-zts-20170718/apcu-5.1.17
+++ b/support/build/extensions/no-debug-non-zts-20170718/apcu-5.1.17
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-7.2.16
+# Build Deps: php-7.2.*
 
 source $(dirname $0)/../no-debug-non-zts-20151012/apcu

--- a/support/build/extensions/no-debug-non-zts-20170718/apcu-5.1.17
+++ b/support/build/extensions/no-debug-non-zts-20170718/apcu-5.1.17
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-7.2.*
 
 source $(dirname $0)/../no-debug-non-zts-20151012/apcu

--- a/support/build/extensions/no-debug-non-zts-20170718/blackfire
+++ b/support/build/extensions/no-debug-non-zts-20170718/blackfire
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 
 source $(dirname $0)/../no-debug-non-zts-20121212/blackfire

--- a/support/build/extensions/no-debug-non-zts-20170718/blackfire-1.24.4
+++ b/support/build/extensions/no-debug-non-zts-20170718/blackfire-1.24.4
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 
 source $(dirname $0)/blackfire

--- a/support/build/extensions/no-debug-non-zts-20170718/cassandra-1.3.2
+++ b/support/build/extensions/no-debug-non-zts-20170718/cassandra-1.3.2
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-7.2.16, libraries/libcassandra-2.9.0
+# Build Deps: php-7.2.*, libraries/libcassandra-2.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/cassandra

--- a/support/build/extensions/no-debug-non-zts-20170718/cassandra-1.3.2
+++ b/support/build/extensions/no-debug-non-zts-20170718/cassandra-1.3.2
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-7.2.*, libraries/libcassandra-2.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/cassandra

--- a/support/build/extensions/no-debug-non-zts-20170718/ev-1.0.4
+++ b/support/build/extensions/no-debug-non-zts-20170718/ev-1.0.4
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-7.2.16
+# Build Deps: php-7.2.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/ev

--- a/support/build/extensions/no-debug-non-zts-20170718/ev-1.0.4
+++ b/support/build/extensions/no-debug-non-zts-20170718/ev-1.0.4
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-7.2.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/ev

--- a/support/build/extensions/no-debug-non-zts-20170718/event-2.4.3
+++ b/support/build/extensions/no-debug-non-zts-20170718/event-2.4.3
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-7.2.16
+# Build Deps: php-7.2.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/event

--- a/support/build/extensions/no-debug-non-zts-20170718/event-2.4.3
+++ b/support/build/extensions/no-debug-non-zts-20170718/event-2.4.3
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-7.2.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/event

--- a/support/build/extensions/no-debug-non-zts-20170718/imagick-3.4.3
+++ b/support/build/extensions/no-debug-non-zts-20170718/imagick-3.4.3
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-7.2.16
+# Build Deps: php-7.2.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/imagick

--- a/support/build/extensions/no-debug-non-zts-20170718/imagick-3.4.3
+++ b/support/build/extensions/no-debug-non-zts-20170718/imagick-3.4.3
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-7.2.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/imagick

--- a/support/build/extensions/no-debug-non-zts-20170718/memcached-3.1.3
+++ b/support/build/extensions/no-debug-non-zts-20170718/memcached-3.1.3
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-7.2.16, libraries/libmemcached-1.0.18
+# Build Deps: php-7.2.*, libraries/libmemcached-1.0.18
 
 source $(dirname $0)/../no-debug-non-zts-20121212/memcached

--- a/support/build/extensions/no-debug-non-zts-20170718/memcached-3.1.3
+++ b/support/build/extensions/no-debug-non-zts-20170718/memcached-3.1.3
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-7.2.*, libraries/libmemcached-1.0.18
 
 source $(dirname $0)/../no-debug-non-zts-20121212/memcached

--- a/support/build/extensions/no-debug-non-zts-20170718/mongodb-1.5.3
+++ b/support/build/extensions/no-debug-non-zts-20170718/mongodb-1.5.3
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-7.2.16
+# Build Deps: php-7.2.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/mongodb

--- a/support/build/extensions/no-debug-non-zts-20170718/mongodb-1.5.3
+++ b/support/build/extensions/no-debug-non-zts-20170718/mongodb-1.5.3
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-7.2.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/mongodb

--- a/support/build/extensions/no-debug-non-zts-20170718/newrelic-8.6.0.238
+++ b/support/build/extensions/no-debug-non-zts-20170718/newrelic-8.6.0.238
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 
 source $(dirname $0)/../no-debug-non-zts-20121212/newrelic

--- a/support/build/extensions/no-debug-non-zts-20170718/oauth-2.0.3
+++ b/support/build/extensions/no-debug-non-zts-20170718/oauth-2.0.3
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-7.2.16
+# Build Deps: php-7.2.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/oauth

--- a/support/build/extensions/no-debug-non-zts-20170718/oauth-2.0.3
+++ b/support/build/extensions/no-debug-non-zts-20170718/oauth-2.0.3
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-7.2.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/oauth

--- a/support/build/extensions/no-debug-non-zts-20170718/phalcon-3.4.3
+++ b/support/build/extensions/no-debug-non-zts-20170718/phalcon-3.4.3
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-7.2.16
+# Build Deps: php-7.2.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/phalcon

--- a/support/build/extensions/no-debug-non-zts-20170718/phalcon-3.4.3
+++ b/support/build/extensions/no-debug-non-zts-20170718/phalcon-3.4.3
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-7.2.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/phalcon

--- a/support/build/extensions/no-debug-non-zts-20170718/pq-2.1.5
+++ b/support/build/extensions/no-debug-non-zts-20170718/pq-2.1.5
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-7.2.*, extensions/no-debug-non-zts-20170718/raphf-2.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/pq

--- a/support/build/extensions/no-debug-non-zts-20170718/pq-2.1.5
+++ b/support/build/extensions/no-debug-non-zts-20170718/pq-2.1.5
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-7.2.16, extensions/no-debug-non-zts-20170718/raphf-2.0.0
+# Build Deps: php-7.2.*, extensions/no-debug-non-zts-20170718/raphf-2.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/pq

--- a/support/build/extensions/no-debug-non-zts-20170718/raphf-2.0.0
+++ b/support/build/extensions/no-debug-non-zts-20170718/raphf-2.0.0
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-7.2.16
+# Build Deps: php-7.2.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/raphf

--- a/support/build/extensions/no-debug-non-zts-20170718/raphf-2.0.0
+++ b/support/build/extensions/no-debug-non-zts-20170718/raphf-2.0.0
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-7.2.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/raphf

--- a/support/build/extensions/no-debug-non-zts-20170718/rdkafka-3.0.5
+++ b/support/build/extensions/no-debug-non-zts-20170718/rdkafka-3.0.5
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-7.2.*, libraries/librdkafka-0.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/rdkafka

--- a/support/build/extensions/no-debug-non-zts-20170718/rdkafka-3.0.5
+++ b/support/build/extensions/no-debug-non-zts-20170718/rdkafka-3.0.5
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-7.2.16, libraries/librdkafka-0.11.6
+# Build Deps: php-7.2.*, libraries/librdkafka-0.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/rdkafka

--- a/support/build/extensions/no-debug-non-zts-20170718/redis-3.1.6
+++ b/support/build/extensions/no-debug-non-zts-20170718/redis-3.1.6
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-7.2.16
+# Build Deps: php-7.2.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/redis

--- a/support/build/extensions/no-debug-non-zts-20170718/redis-3.1.6
+++ b/support/build/extensions/no-debug-non-zts-20170718/redis-3.1.6
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-7.2.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/redis

--- a/support/build/extensions/no-debug-non-zts-20170718/redis-4.3.0
+++ b/support/build/extensions/no-debug-non-zts-20170718/redis-4.3.0
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-7.2.16
+# Build Deps: php-7.2.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/redis

--- a/support/build/extensions/no-debug-non-zts-20170718/redis-4.3.0
+++ b/support/build/extensions/no-debug-non-zts-20170718/redis-4.3.0
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-7.2.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/redis

--- a/support/build/extensions/no-debug-non-zts-20180731/amqp-1.9.4
+++ b/support/build/extensions/no-debug-non-zts-20180731/amqp-1.9.4
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-7.3.3
+# Build Deps: php-7.3.*
 
 source $(dirname $0)/../no-debug-non-zts-20131226/amqp

--- a/support/build/extensions/no-debug-non-zts-20180731/amqp-1.9.4
+++ b/support/build/extensions/no-debug-non-zts-20180731/amqp-1.9.4
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-7.3.*
 
 source $(dirname $0)/../no-debug-non-zts-20131226/amqp

--- a/support/build/extensions/no-debug-non-zts-20180731/apcu-5.1.17
+++ b/support/build/extensions/no-debug-non-zts-20180731/apcu-5.1.17
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-7.3.3
+# Build Deps: php-7.3.*
 
 source $(dirname $0)/../no-debug-non-zts-20151012/apcu

--- a/support/build/extensions/no-debug-non-zts-20180731/apcu-5.1.17
+++ b/support/build/extensions/no-debug-non-zts-20180731/apcu-5.1.17
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-7.3.*
 
 source $(dirname $0)/../no-debug-non-zts-20151012/apcu

--- a/support/build/extensions/no-debug-non-zts-20180731/blackfire
+++ b/support/build/extensions/no-debug-non-zts-20180731/blackfire
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 
 source $(dirname $0)/../no-debug-non-zts-20121212/blackfire

--- a/support/build/extensions/no-debug-non-zts-20180731/blackfire-1.24.4
+++ b/support/build/extensions/no-debug-non-zts-20180731/blackfire-1.24.4
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 
 source $(dirname $0)/blackfire

--- a/support/build/extensions/no-debug-non-zts-20180731/cassandra-1.3.2
+++ b/support/build/extensions/no-debug-non-zts-20180731/cassandra-1.3.2
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-7.3.*, libraries/libcassandra-2.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/cassandra

--- a/support/build/extensions/no-debug-non-zts-20180731/cassandra-1.3.2
+++ b/support/build/extensions/no-debug-non-zts-20180731/cassandra-1.3.2
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-7.3.3, libraries/libcassandra-2.9.0
+# Build Deps: php-7.3.*, libraries/libcassandra-2.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/cassandra

--- a/support/build/extensions/no-debug-non-zts-20180731/ev-1.0.4
+++ b/support/build/extensions/no-debug-non-zts-20180731/ev-1.0.4
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-7.3.3
+# Build Deps: php-7.3.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/ev

--- a/support/build/extensions/no-debug-non-zts-20180731/ev-1.0.4
+++ b/support/build/extensions/no-debug-non-zts-20180731/ev-1.0.4
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-7.3.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/ev

--- a/support/build/extensions/no-debug-non-zts-20180731/event-2.4.3
+++ b/support/build/extensions/no-debug-non-zts-20180731/event-2.4.3
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-7.3.3
+# Build Deps: php-7.3.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/event

--- a/support/build/extensions/no-debug-non-zts-20180731/event-2.4.3
+++ b/support/build/extensions/no-debug-non-zts-20180731/event-2.4.3
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-7.3.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/event

--- a/support/build/extensions/no-debug-non-zts-20180731/imagick-3.4.3
+++ b/support/build/extensions/no-debug-non-zts-20180731/imagick-3.4.3
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-7.3.3
+# Build Deps: php-7.3.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/imagick

--- a/support/build/extensions/no-debug-non-zts-20180731/imagick-3.4.3
+++ b/support/build/extensions/no-debug-non-zts-20180731/imagick-3.4.3
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-7.3.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/imagick

--- a/support/build/extensions/no-debug-non-zts-20180731/memcached-3.1.3
+++ b/support/build/extensions/no-debug-non-zts-20180731/memcached-3.1.3
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-7.3.3, libraries/libmemcached-1.0.18
+# Build Deps: php-7.3.*, libraries/libmemcached-1.0.18
 
 source $(dirname $0)/../no-debug-non-zts-20121212/memcached

--- a/support/build/extensions/no-debug-non-zts-20180731/memcached-3.1.3
+++ b/support/build/extensions/no-debug-non-zts-20180731/memcached-3.1.3
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-7.3.*, libraries/libmemcached-1.0.18
 
 source $(dirname $0)/../no-debug-non-zts-20121212/memcached

--- a/support/build/extensions/no-debug-non-zts-20180731/mongodb-1.5.3
+++ b/support/build/extensions/no-debug-non-zts-20180731/mongodb-1.5.3
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-7.3.3
+# Build Deps: php-7.3.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/mongodb

--- a/support/build/extensions/no-debug-non-zts-20180731/mongodb-1.5.3
+++ b/support/build/extensions/no-debug-non-zts-20180731/mongodb-1.5.3
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-7.3.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/mongodb

--- a/support/build/extensions/no-debug-non-zts-20180731/newrelic-8.6.0.238
+++ b/support/build/extensions/no-debug-non-zts-20180731/newrelic-8.6.0.238
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 
 source $(dirname $0)/../no-debug-non-zts-20121212/newrelic

--- a/support/build/extensions/no-debug-non-zts-20180731/oauth-2.0.3
+++ b/support/build/extensions/no-debug-non-zts-20180731/oauth-2.0.3
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-7.3.3
+# Build Deps: php-7.3.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/oauth

--- a/support/build/extensions/no-debug-non-zts-20180731/oauth-2.0.3
+++ b/support/build/extensions/no-debug-non-zts-20180731/oauth-2.0.3
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-7.3.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/oauth

--- a/support/build/extensions/no-debug-non-zts-20180731/phalcon-3.4.3
+++ b/support/build/extensions/no-debug-non-zts-20180731/phalcon-3.4.3
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-7.3.3
+# Build Deps: php-7.3.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/phalcon

--- a/support/build/extensions/no-debug-non-zts-20180731/phalcon-3.4.3
+++ b/support/build/extensions/no-debug-non-zts-20180731/phalcon-3.4.3
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-7.3.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/phalcon

--- a/support/build/extensions/no-debug-non-zts-20180731/pq-2.1.5
+++ b/support/build/extensions/no-debug-non-zts-20180731/pq-2.1.5
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-7.3.3, extensions/no-debug-non-zts-20180731/raphf-2.0.0
+# Build Deps: php-7.3.*, extensions/no-debug-non-zts-20180731/raphf-2.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/pq

--- a/support/build/extensions/no-debug-non-zts-20180731/pq-2.1.5
+++ b/support/build/extensions/no-debug-non-zts-20180731/pq-2.1.5
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-7.3.*, extensions/no-debug-non-zts-20180731/raphf-2.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/pq

--- a/support/build/extensions/no-debug-non-zts-20180731/raphf-2.0.0
+++ b/support/build/extensions/no-debug-non-zts-20180731/raphf-2.0.0
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-7.3.3
+# Build Deps: php-7.3.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/raphf

--- a/support/build/extensions/no-debug-non-zts-20180731/raphf-2.0.0
+++ b/support/build/extensions/no-debug-non-zts-20180731/raphf-2.0.0
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-7.3.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/raphf

--- a/support/build/extensions/no-debug-non-zts-20180731/rdkafka-3.0.5
+++ b/support/build/extensions/no-debug-non-zts-20180731/rdkafka-3.0.5
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-7.3.*, libraries/librdkafka-0.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/rdkafka

--- a/support/build/extensions/no-debug-non-zts-20180731/rdkafka-3.0.5
+++ b/support/build/extensions/no-debug-non-zts-20180731/rdkafka-3.0.5
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-7.3.3, libraries/librdkafka-0.11.6
+# Build Deps: php-7.3.*, libraries/librdkafka-0.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/rdkafka

--- a/support/build/extensions/no-debug-non-zts-20180731/redis-4.3.0
+++ b/support/build/extensions/no-debug-non-zts-20180731/redis-4.3.0
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/php/
-# Build Deps: php-7.3.3
+# Build Deps: php-7.3.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/redis

--- a/support/build/extensions/no-debug-non-zts-20180731/redis-4.3.0
+++ b/support/build/extensions/no-debug-non-zts-20180731/redis-4.3.0
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: php-7.3.*
 
 source $(dirname $0)/../no-debug-non-zts-20121212/redis

--- a/support/build/hhvm
+++ b/support/build/hhvm
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 
 # fail hard
 set -o pipefail

--- a/support/build/hhvm
+++ b/support/build/hhvm
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php
 
 # fail hard
 set -o pipefail

--- a/support/build/hhvm-3.5.1
+++ b/support/build/hhvm-3.5.1
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 
 # Depends:
 #  binutils

--- a/support/build/libraries/libc-client
+++ b/support/build/libraries/libc-client
@@ -1,5 +1,4 @@
 #!/bin/bash
-# Build Path: /app/.heroku/php
 
 # fail hard
 set -o pipefail

--- a/support/build/libraries/libc-client
+++ b/support/build/libraries/libc-client
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 
 # fail hard
 set -o pipefail

--- a/support/build/libraries/libc-client-2007f
+++ b/support/build/libraries/libc-client-2007f
@@ -1,4 +1,4 @@
 #!/bin/bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 
 source $(dirname $0)/libc-client

--- a/support/build/libraries/libcassandra
+++ b/support/build/libraries/libcassandra
@@ -1,5 +1,4 @@
 #!/bin/bash
-# Build Path: /app/.heroku/php
 
 # fail hard
 set -o pipefail

--- a/support/build/libraries/libcassandra
+++ b/support/build/libraries/libcassandra
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 
 # fail hard
 set -o pipefail

--- a/support/build/libraries/libcassandra-2.9.0
+++ b/support/build/libraries/libcassandra-2.9.0
@@ -1,4 +1,4 @@
 #!/bin/bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 
 source $(dirname $0)/libcassandra

--- a/support/build/libraries/libmcrypt
+++ b/support/build/libraries/libmcrypt
@@ -1,5 +1,4 @@
 #!/bin/bash
-# Build Path: /app/.heroku/php
 
 # fail hard
 set -o pipefail

--- a/support/build/libraries/libmcrypt
+++ b/support/build/libraries/libmcrypt
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 
 # fail hard
 set -o pipefail

--- a/support/build/libraries/libmcrypt-2.5.8
+++ b/support/build/libraries/libmcrypt-2.5.8
@@ -1,4 +1,4 @@
 #!/bin/bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 
 source $(dirname $0)/libmcrypt

--- a/support/build/libraries/libmemcached
+++ b/support/build/libraries/libmemcached
@@ -1,5 +1,4 @@
 #!/bin/bash
-# Build Path: /app/.heroku/php
 
 # fail hard
 set -o pipefail

--- a/support/build/libraries/libmemcached
+++ b/support/build/libraries/libmemcached
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 
 # fail hard
 set -o pipefail

--- a/support/build/libraries/libmemcached-1.0.18
+++ b/support/build/libraries/libmemcached-1.0.18
@@ -1,4 +1,4 @@
 #!/bin/bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 
 source $(dirname $0)/libmemcached

--- a/support/build/libraries/librdkafka-0.11.6
+++ b/support/build/libraries/librdkafka-0.11.6
@@ -1,4 +1,4 @@
 #!/bin/bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 
 source $(dirname $0)/librdkafka

--- a/support/build/nginx
+++ b/support/build/nginx
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 
 # fail hard
 set -o pipefail

--- a/support/build/nginx
+++ b/support/build/nginx
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php
 
 # fail hard
 set -o pipefail

--- a/support/build/nginx-1.14.2
+++ b/support/build/nginx-1.14.2
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 
 source $(dirname $0)/nginx

--- a/support/build/php
+++ b/support/build/php
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 
 # fail hard
 set -o pipefail

--- a/support/build/php
+++ b/support/build/php
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php
 
 # fail hard
 set -o pipefail

--- a/support/build/php-5.5.38
+++ b/support/build/php-5.5.38
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: libraries/libmcrypt-2.5.8, libraries/libc-client-2007f
 
 source $(dirname $0)/php

--- a/support/build/php-5.6.40
+++ b/support/build/php-5.6.40
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: libraries/libmcrypt-2.5.8, libraries/libc-client-2007f
 
 source $(dirname $0)/php

--- a/support/build/php-7.0.33
+++ b/support/build/php-7.0.33
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: libraries/libmcrypt-2.5.8, libraries/libc-client-2007f
 
 source $(dirname $0)/php

--- a/support/build/php-7.1.27
+++ b/support/build/php-7.1.27
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: libraries/libmcrypt-2.5.8, libraries/libc-client-2007f
 
 source $(dirname $0)/php

--- a/support/build/php-7.2.16
+++ b/support/build/php-7.2.16
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: libraries/libc-client-2007f
 
 source $(dirname $0)/php

--- a/support/build/php-7.3.3
+++ b/support/build/php-7.3.3
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 # Build Deps: libraries/libc-client-2007f
 
 source $(dirname $0)/php

--- a/support/build/php-min
+++ b/support/build/php-min
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php-min/
+# Build Path: /app/.heroku/php-min
 
 # fail hard
 set -o pipefail

--- a/support/build/php-min
+++ b/support/build/php-min
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php-min
 
 # fail hard
 set -o pipefail

--- a/support/build/php-min-7.3.3
+++ b/support/build/php-min-7.3.3
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php
+# Build Path: /app/.heroku/php-min
 
 source $(dirname $0)/php-min

--- a/support/build/php-min-7.3.3
+++ b/support/build/php-min-7.3.3
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-# Build Path: /app/.heroku/php/
+# Build Path: /app/.heroku/php
 
 source $(dirname $0)/php-min


### PR DESCRIPTION
- upgrade to bob-builder/0.0.15
- use new bob wildcard feature in dependencies where possible
- drop redundant trailing slash from formulae (only a cosmetic change)
- correct build path for `php-min` (had no practical effect since the built archive contains only a single static binary and nothing else)