### PR TITLE
Add support for `gzip_static` directive

### DIFF
--- a/support/build/nginx
+++ b/support/build/nginx
@@ -43,6 +43,7 @@ VAR=${OUT_PREFIX}/var
 	--http-scgi-temp-path=${VAR}/run/nginx/scgi_temp \
 	--http-log-path=${VAR}/log/nginx/access.log \
 	--error-log-path=${VAR}/log/nginx/error.log \
+	--with-http_gzip_static_module \
 	--with-http_realip_module \
 	--with-http_ssl_module
 make -s -j 9


### PR DESCRIPTION
This PR adds support for the `gzip_static` directive and allow nginx to serve precompressed static files. 