### PR TITLE
Fix execution of composer.phar

### DIFF
--- a/bin/heroku-php-apache2
+++ b/bin/heroku-php-apache2
@@ -243,12 +243,11 @@ httpd_version="$(httpd -v | php -n -r 'echo preg_replace("#^Server version: Apac
 # make sure we run a local composer.phar if present, or global composer if not
 composer() {
 	local composer_bin=$(which ./composer.phar composer | head -n1)
-	# check if we the composer binary is executable by PHP
-	if file --brief --dereference $composer_bin | grep -e "shell" -e "bash" > /dev/null ; then # newer versions of file return "data" for .phar
-		# run it directly; it's probably a bash script or similar (homebrew-php does this)
-		$composer_bin "$@"
-	else
+	# execute composer.phar using php
+	if [[ "$composer_bin" == *phar ]]; then
 		php -n $composer_bin "$@"
+	else
+		$composer_bin "$@"
 	fi
 }
 # these exports are used in default web server configs to lock down access to composer directories


### PR DESCRIPTION
Executing `php -n /usr/local/bin/composer` installed with Homebrew on OSX has problems:

```
bash-3.2$ composer_bin=$(which ./composer.phar composer | head -n1)
bash-3.2$ echo $composer_bin
/usr/local/bin/composer
bash-3.2$ php -n $composer_bin

Fatal error: Uncaught ErrorException: preg_match_all(): JIT compilation failed: no more memory in phar:///usr/local/Cellar/composer/1.8.5/bin/composer/vendor/symfony/console/Formatter/OutputFormatter.php:137
Stack trace:
#0 [internal function]: Composer\Util\ErrorHandler::handle(2, 'preg_match_all(...', 'phar:///usr/loc...', 137, Array)
#1 phar:///usr/local/Cellar/composer/1.8.5/bin/composer/vendor/symfony/console/Formatter/OutputFormatter.php(137): preg_match_all('#<(([a-z][a-z0-...', '', Array, 256)
#2 phar:///usr/local/Cellar/composer/1.8.5/bin/composer/vendor/symfony/console/Output/Output.php(155): Symfony\Component\Console\Formatter\OutputFormatter->format('')
#3 phar:///usr/local/Cellar/composer/1.8.5/bin/composer/vendor/symfony/console/Output/Output.php(132): Symfony\Component\Console\Output\Output->write(Array, true, 16)
#4 phar:///usr/local/Cellar/composer/1.8.5/bin/composer/vendor/symfony/console/Application.php(641): Symfony\Component\Console\Output\Output->writeln('', 16)
#5 phar:///usr/local/Cellar/composer/1 in phar:///usr/local/Cellar/composer/1.8.5/bin/composer/vendor/symfony/console/Formatter/OutputFormatter.php on line 137
```

This is caused by running `php -n` which disables `php.ini`, which disables `pcre.jit=0`, which is required for OSX as per composer/composer#7836

Refs #55