### PR TITLE
User platform composer correctly when file utility says "executable"

### DIFF
--- a/bin/heroku-hhvm-apache2
+++ b/bin/heroku-hhvm-apache2
@@ -235,7 +235,7 @@ httpd_version="$(httpd -v | hhvm --php -r 'echo preg_replace("#^Server version: 
 composer() {
 	local composer_bin=$(which ./composer.phar composer | head -n1)
 	# check if we the composer binary is executable by PHP
-	if file --brief --dereference $composer_bin | grep -e "shell" -e "bash" > /dev/null ; then # newer versions of file return "data" for .phar
+	if file --brief --dereference $composer_bin | grep -e "shell" -e "bash" -e "executable" > /dev/null ; then # newer versions of file return "data" for .phar
 		# run it directly; it's probably a bash script or similar (homebrew-php does this)
 		$composer_bin "$@"
 	else

--- a/bin/heroku-hhvm-nginx
+++ b/bin/heroku-hhvm-nginx
@@ -233,7 +233,7 @@ nginx_version="$(nginx -v 2>&1 | hhvm --php -r 'echo preg_replace("#.*nginx/([\d
 composer() {
 	local composer_bin=$(which ./composer.phar composer | head -n1)
 	# check if we the composer binary is executable by HHVM
-	if file --brief --dereference $composer_bin | grep -e "shell" -e "bash" > /dev/null ; then # newer versions of file return "data" for .phar
+	if file --brief --dereference $composer_bin | grep -e "shell" -e "bash" -e "executable" > /dev/null ; then # newer versions of file return "data" for .phar
 		# run it directly; it's probably a bash script or similar (homebrew-php does this)
 		$composer_bin "$@"
 	else

--- a/bin/heroku-php-apache2
+++ b/bin/heroku-php-apache2
@@ -244,7 +244,7 @@ httpd_version="$(httpd -v | php -n -r 'echo preg_replace("#^Server version: Apac
 composer() {
 	local composer_bin=$(which ./composer.phar composer | head -n1)
 	# check if we the composer binary is executable by PHP
-	if file --brief --dereference $composer_bin | grep -e "shell" -e "bash" > /dev/null ; then # newer versions of file return "data" for .phar
+	if file --brief --dereference $composer_bin | grep -e "shell" -e "bash" -e "executable" > /dev/null ; then # newer versions of file return "data" for .phar
 		# run it directly; it's probably a bash script or similar (homebrew-php does this)
 		$composer_bin "$@"
 	else

--- a/bin/heroku-php-nginx
+++ b/bin/heroku-php-nginx
@@ -242,7 +242,7 @@ nginx_version="$(nginx -v 2>&1 | php -n -r 'echo preg_replace("#.*nginx/([\d\.]+
 composer() {
 	local composer_bin=$(which ./composer.phar composer | head -n1)
 	# check if we the composer binary is executable by PHP
-	if file --brief --dereference $composer_bin | grep -e "shell" -e "bash" > /dev/null ; then # newer versions of file return "data" for .phar
+	if file --brief --dereference $composer_bin | grep -e "shell" -e "bash" -e "executable" > /dev/null ; then # newer versions of file return "data" for .phar
 		# run it directly; it's probably a bash script or similar (homebrew-php does this)
 		$composer_bin "$@"
 	else


### PR DESCRIPTION
Addresses #348 --

On Fedora 29
```
$ file $(which composer) 
/usr/bin/composer: a /usr/bin/env php script, ASCII text executable

```