### PR TITLE
Refactor APM startup prevention

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ dist: xenial
 sudo: false
 before_install:
 - gem install bundler
+- composer self-update
 install:
 - bundle install
 before_script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 - Enable zend.assertions on Heroku CI [David Zuelke]
 
+### FIX
+
+- Boot scripts no longer use `php -n` to prevent APM extensions from booting, but instead add an INI file that contains disabling directives for common extensions (#345, #348, #349) [David Zuelke]
+
 ## v158 (2019-07-04)
 
 ### ADD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Enable zend.assertions on Heroku CI [David Zuelke]
 - Boot scripts now prefer a `composer` binary on `$PATH` over a `composer.phar` in the CWD [David Zuelke]
+- Refactor logic used to prevent APM extensions such as `ext-newrelic` or `ext-blackfire` from starting up during during boot preparations or builds [David Zuelke]
 
 ### FIX
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### CHG
 
 - Enable zend.assertions on Heroku CI [David Zuelke]
+- Boot scripts now prefer a `composer` binary on `$PATH` over a `composer.phar` in the CWD [David Zuelke]
 
 ### FIX
 

--- a/bin/compile
+++ b/bin/compile
@@ -490,7 +490,11 @@ unset COMPOSER_bak
 rm -rf /app/.heroku/php-min $build_dir/.heroku/php-min
 unset -f composer
 
-# earlier we wrote at least one $PATH entry that we'll need now, and installed packages will likely have added to it too
+# export our "do not auto.start APM extensions" magic INI directory to PHP_INI_SCAN_DIR for ourself and for later buildpacks (but not for runtime)
+export_env_dir "$env_dir" '^PHP_INI_SCAN_DIR$'
+echo "export PHP_INI_SCAN_DIR=\${PHP_INI_SCAN_DIR-}:$bp_dir/conf/php/apm-nostart-overrides/" >> $bp_dir/export
+
+# earlier we wrote at least one $PATH entry that we'll need now (and just above we added a PHP_INI_SCAN_DIR export), and installed packages will likely have added to it too
 source $bp_dir/export
 
 composer() {
@@ -622,7 +626,7 @@ fi
 unset COMPOSER_GITHUB_OAUTH_TOKEN
 
 # install dependencies unless composer.json is completely empty (in which case it'd talk to packagist.org which may be slow and is unnecessary)
-export_env_dir "$env_dir" '^[A-Z_][A-Z0-9_]*$' '^(HOME|PATH|GIT_DIR|CPATH|CPPATH|LD_PRELOAD|LIBRARY_PATH|LD_LIBRARY_PATH|STACK|REQUEST_ID|IFS|HEROKU_PHP_INSTALL_DEV|BPLOG_PREFIX|BUILDPACK_LOG_FILE)$'
+export_env_dir "$env_dir" '^[A-Z_][A-Z0-9_]*$' '^(HOME|PATH|GIT_DIR|CPATH|CPPATH|LD_PRELOAD|LIBRARY_PATH|LD_LIBRARY_PATH|STACK|REQUEST_ID|IFS|HEROKU_PHP_INSTALL_DEV|BPLOG_PREFIX|BUILDPACK_LOG_FILE|PHP_INI_SCAN_DIR)$'
 if cat "$COMPOSER" | python -c 'import sys,json; sys.exit(not json.load(sys.stdin));'; then
 	install_log=$(mktemp -t heroku-buildpack-php-composer-install-log-XXXX)
 	composer install ${HEROKU_PHP_INSTALL_DEV-"--no-dev"} --prefer-dist --optimize-autoloader --no-interaction 2>&1 | tee "$install_log" | indent || {

--- a/bin/heroku-hhvm-apache2
+++ b/bin/heroku-hhvm-apache2
@@ -231,15 +231,16 @@ hhvm --php -r 'exit((int)version_compare(HHVM_VERSION, "3.0.1", "<"));' || { ech
 hhvm_version="$(hhvm --php -r 'echo HHVM_VERSION;')"
 httpd_version="$(httpd -v | hhvm --php -r 'echo preg_replace("#^Server version: Apache/(\S+).+$#sm", "\\1", file_get_contents("php://stdin"));')"
 
-# make sure we run a local composer.phar if present, or global composer if not
+# make sure we try a local composer.phar if no global installation is available
+composer_bin=$(command -v composer ./composer.phar) || { echo "This program requires 'composer' on \$PATH or a 'composer.phar' in the CWD." >&2; exit 1; }
+composer_bin=$(head -n1 <<< "$composer_bin") # if both were there, we'd have two lines of output, no good for invoking something :)
 composer() {
-	local composer_bin=$(which ./composer.phar composer | head -n1)
-	# check if we the composer binary is executable by PHP
-	if file --brief --dereference $composer_bin | grep -e "shell" -e "bash" > /dev/null ; then # newer versions of file return "data" for .phar
+	# check if the composer binary is executable by HHVM
+	if file --brief --dereference "$composer_bin" | grep -e "shell" -e "bash" > /dev/null ; then # newer versions of file return "data" for .phar
 		# run it directly; it's probably a bash script or similar (homebrew-php does this)
-		$composer_bin "$@"
+		"$composer_bin" "$@"
 	else
-		hhvm $composer_bin "$@"
+		hhvm "$composer_bin" "$@"
 	fi
 }
 # these exports are used in default web server configs to lock down access to composer directories

--- a/bin/heroku-hhvm-nginx
+++ b/bin/heroku-hhvm-nginx
@@ -229,15 +229,16 @@ hhvm --php -r 'exit((int)version_compare(HHVM_VERSION, "3.0.1", "<"));' || { ech
 hhvm_version="$(hhvm --php -r 'echo HHVM_VERSION;')"
 nginx_version="$(nginx -v 2>&1 | hhvm --php -r 'echo preg_replace("#.*nginx/([\d\.]+)$#sm", "\\1", file_get_contents("php://stdin"));')"
 
-# make sure we run a local composer.phar if present, or global composer if not
+# make sure we try a local composer.phar if no global installation is available
+composer_bin=$(command -v composer ./composer.phar) || { echo "This program requires 'composer' on \$PATH or a 'composer.phar' in the CWD." >&2; exit 1; }
+composer_bin=$(head -n1 <<< "$composer_bin") # if both were there, we'd have two lines of output, no good for invoking something :)
 composer() {
-	local composer_bin=$(which ./composer.phar composer | head -n1)
-	# check if we the composer binary is executable by HHVM
-	if file --brief --dereference $composer_bin | grep -e "shell" -e "bash" > /dev/null ; then # newer versions of file return "data" for .phar
+	# check if the composer binary is executable by HHVM
+	if file --brief --dereference "$composer_bin" | grep -e "shell" -e "bash" > /dev/null ; then # newer versions of file return "data" for .phar
 		# run it directly; it's probably a bash script or similar (homebrew-php does this)
-		$composer_bin "$@"
+		"$composer_bin" "$@"
 	else
-		hhvm $composer_bin "$@"
+		hhvm "$composer_bin" "$@"
 	fi
 }
 # these exports are used in default web server configs to lock down access to composer directories

--- a/bin/heroku-php-apache2
+++ b/bin/heroku-php-apache2
@@ -30,7 +30,7 @@ php_passthrough() {
 	if [[ "$out" != "$file" ]]; then
 		[[ $verbose ]] && echo "Interpreting ${1#$HEROKU_APP_DIR/} to $out" >&2
 		out="$dir/$out"
-		php -n "$1" > "$out"
+		php "$1" > "$out"
 		echo "$out"
 	else
 		echo "$1"
@@ -137,6 +137,30 @@ export DOCUMENT_ROOT="$HEROKU_APP_DIR"
 # set a default port if none is given
 export PORT=${PORT:-$(( $RANDOM+1024 ))}
 
+# add conf/php/apm-nostart-overrides/ to end of list of PHP INI scan dirs
+# that way our special extra INI which prevents startup of a possible newrelic etc is loaded for all the PHP and Composer calls that follow
+# an empty value for PHP_INI_SCAN_DIR means nothing is scanned at all, not even compile time default scan dirs
+# the variable can hold a list of paths delimited by colon, and if one segment is empty (e.g. "/foo::/bar" or just "/foo:" or ":/foo"), then the compile time default scan dir is used there
+if [[ -z ${PHP_INI_SCAN_DIR-} && ${PHP_INI_SCAN_DIR+x} ]]; then
+	# PHP_INI_SCAN_DIR was defined, but empty
+	# this means the user wants no scan dir, so we have to just place our own value into the variable, without a path separator
+	_PHP_INI_SCAN_DIR=
+	PHP_INI_SCAN_DIR=
+elif [[ -z ${PHP_INI_SCAN_DIR-} ]]; then
+	# PHP_INI_SCAN_DIR was not defined at all
+	# this means we want to load the compile time default scan dir first, then our special INIs
+	# we don't back up to _PHP_INI_SCAN_DIR; that way, we will know to unset it later and won't export an empty string
+	unset _PHP_INI_SCAN_DIR # just in case it's around
+	PHP_INI_SCAN_DIR=":" # leading empty segment will cause compile time default scan dir to be used
+else
+	# PHP_INI_SCAN_DIR was defined and not empty
+	# we want to append our path to the end of the list, or, if not defined at all, have the first list item be blank, which causes the default scan dir to be used
+	_PHP_INI_SCAN_DIR=$PHP_INI_SCAN_DIR
+	PHP_INI_SCAN_DIR+=":" # leading empty segment will cause compile time default scan dir to be used
+fi
+# now append
+export PHP_INI_SCAN_DIR="${PHP_INI_SCAN_DIR}${bp_dir}/conf/php/apm-nostart-overrides/"
+
 # init logs array here as empty before parsing options; -l could append to it, but the default list gets added later since we use $PORT in there and that can be set using -p
 declare -a logs
 
@@ -233,12 +257,12 @@ fi
 logs+=( "/tmp/heroku.php-fpm.$PORT.log" "/tmp/heroku.php-fpm.www.$PORT.log" "/tmp/heroku.php-fpm.$PORT.www.slowlog" "/tmp/heroku.apache2_error.$PORT.log" "/tmp/heroku.apache2_access.$PORT.log" )
 
 # a bunch of checks; don't load any INIs to prevent newrelic etc from loading, we don't need all that stuff
-php -n -r 'exit((int)version_compare(PHP_VERSION, "5.5.11", "<"));' || { echo "This program requires PHP 5.5.11 or newer; check your 'php' command." >&2; exit 1; }
-{ php-fpm -n -v | php -n -r 'exit((int)version_compare(preg_replace("#PHP (\S+) \(fpm-fcgi\).+$#sm", "\\1", file_get_contents("php://stdin")), "5.5.11", "<"));'; } || { echo "This program requires PHP 5.5.11 or newer; check your 'php-fpm' command." >&2; exit 1; }
-{ { httpd -v | php -n -r 'exit((int)version_compare(preg_replace("#^Server version: Apache/(\S+).+$#sm", "\\1", file_get_contents("php://stdin")), "2.4.10", "<"));'; } && { httpd -t -D DUMP_MODULES | grep 'proxy_fcgi_module' > /dev/null; }; } || { echo "This program requires Apache 2.4.10 or newer with mod_proxy and mod_proxy_fcgi enabled; check your 'httpd' command." >&2; exit 1; }
+php -r 'exit((int)version_compare(PHP_VERSION, "5.5.11", "<"));' || { echo "This program requires PHP 5.5.11 or newer; check your 'php' command." >&2; exit 1; }
+{ php-fpm -n -v | php -r 'exit((int)version_compare(preg_replace("#PHP (\S+) \(fpm-fcgi\).+$#sm", "\\1", file_get_contents("php://stdin")), "5.5.11", "<"));'; } || { echo "This program requires PHP 5.5.11 or newer; check your 'php-fpm' command." >&2; exit 1; }
+{ { httpd -v | php -r 'exit((int)version_compare(preg_replace("#^Server version: Apache/(\S+).+$#sm", "\\1", file_get_contents("php://stdin")), "2.4.10", "<"));'; } && { httpd -t -D DUMP_MODULES | grep 'proxy_fcgi_module' > /dev/null; }; } || { echo "This program requires Apache 2.4.10 or newer with mod_proxy and mod_proxy_fcgi enabled; check your 'httpd' command." >&2; exit 1; }
 
-php_version="$(php-fpm -n -v | php -n -r 'echo preg_replace("#PHP (\S+) \(fpm-fcgi\).+$#sm", "\\1", file_get_contents("php://stdin"));')"
-httpd_version="$(httpd -v | php -n -r 'echo preg_replace("#^Server version: Apache/(\S+).+$#sm", "\\1", file_get_contents("php://stdin"));')"
+php_version="$(php-fpm -n -v | php -r 'echo preg_replace("#PHP (\S+) \(fpm-fcgi\).+$#sm", "\\1", file_get_contents("php://stdin"));')"
+httpd_version="$(httpd -v | php -r 'echo preg_replace("#^Server version: Apache/(\S+).+$#sm", "\\1", file_get_contents("php://stdin"));')"
 
 # make sure we run a local composer.phar if present, or global composer if not
 composer() {
@@ -248,7 +272,7 @@ composer() {
 		# run it directly; it's probably a bash script or similar (homebrew-php does this)
 		$composer_bin "$@"
 	else
-		php -n $composer_bin "$@"
+		php $composer_bin "$@"
 	fi
 }
 # these exports are used in default web server configs to lock down access to composer directories
@@ -317,8 +341,7 @@ if [[ -z ${WEB_CONCURRENCY:-} ]]; then
 	fi
 
 	# determine number of FPM processes to run
-	# prevent loading of extension INIs (and thus e.g. newrelic) using empty PHP_INI_SCAN_DIR
-	read WEB_CONCURRENCY php_memory_limit <<<$(PHP_INI_SCAN_DIR= php ${php_config:+-c "$php_config"} "$bp_dir/bin/util/autotune.php" -y "$fpm_config" -t "$DOCUMENT_ROOT" "$ram")
+	read WEB_CONCURRENCY php_memory_limit <<<$(php ${php_config:+-c "$php_config"} "$bp_dir/bin/util/autotune.php" -y "$fpm_config" -t "$DOCUMENT_ROOT" "$ram")
 	[[ $WEB_CONCURRENCY -lt 1 ]] && WEB_CONCURRENCY=1
 	export WEB_CONCURRENCY
 
@@ -412,6 +435,16 @@ echo "Starting php-fpm..." >&2
 	trap 'echo "php-fpm" >&3;' EXIT
 	trap 'trap - TERM; kill -TERM $pid 2> /dev/null || true & wait $pid 2> /dev/null || true; [[ ${BASHPID:-} ]] && kill -TERM $BASHPID' TERM
 	trap 'trap - USR1 EXIT; kill -TERM $pid 2> /dev/null || true & wait $pid 2> /dev/null || true; [[ ${BASHPID:-} ]] && kill -USR1 $BASHPID' USR1
+
+	# earlier, we added special INIs that prevent newrelic etc from starting to the scan dir
+	# we do not want that to apply to php-fpm, which uses the same scan dir for its configs as the regular PHP CLI SAPI
+	# we now restore the original env var from the backup variable, if it existed (important, because empty string and unset are different)
+	# doing this in this subshell means any later code can still invoke PHP CLI with the special INIs applied
+	unset PHP_INI_SCAN_DIR
+	if [[ -n ${_PHP_INI_SCAN_DIR+x} ]]; then
+		echo "XXXXXXDEBUG: restoring original PHP_INI_SCAN_DIR=${_PHP_INI_SCAN_DIR}" >&2
+		export PHP_INI_SCAN_DIR=$_PHP_INI_SCAN_DIR
+	fi
 
 	php-fpm --nodaemonize -y "$fpm_config" ${php_config:+-c "$php_config"} & pid=$!
 

--- a/bin/heroku-php-apache2
+++ b/bin/heroku-php-apache2
@@ -443,7 +443,6 @@ echo "Starting php-fpm..." >&2
 	# doing this in this subshell means any later code can still invoke PHP CLI with the special INIs applied
 	unset PHP_INI_SCAN_DIR
 	if [[ -n ${_PHP_INI_SCAN_DIR+x} ]]; then
-		echo "XXXXXXDEBUG: restoring original PHP_INI_SCAN_DIR=${_PHP_INI_SCAN_DIR}" >&2
 		export PHP_INI_SCAN_DIR=$_PHP_INI_SCAN_DIR
 	fi
 

--- a/bin/heroku-php-apache2
+++ b/bin/heroku-php-apache2
@@ -264,15 +264,16 @@ php -r 'exit((int)version_compare(PHP_VERSION, "5.5.11", "<"));' || { echo "This
 php_version="$(php-fpm -n -v | php -r 'echo preg_replace("#PHP (\S+) \(fpm-fcgi\).+$#sm", "\\1", file_get_contents("php://stdin"));')"
 httpd_version="$(httpd -v | php -r 'echo preg_replace("#^Server version: Apache/(\S+).+$#sm", "\\1", file_get_contents("php://stdin"));')"
 
-# make sure we run a local composer.phar if present, or global composer if not
+# make sure we try a local composer.phar if no global installation is available
+composer_bin=$(command -v composer ./composer.phar) || { echo "This program requires 'composer' on \$PATH or a 'composer.phar' in the CWD." >&2; exit 1; }
+composer_bin=$(head -n1 <<< "$composer_bin") # if both were there, we'd have two lines of output, no good for invoking something :)
 composer() {
-	local composer_bin=$(which ./composer.phar composer | head -n1)
-	# check if we the composer binary is executable by PHP
-	if file --brief --dereference $composer_bin | grep -e "shell" -e "bash" > /dev/null ; then # newer versions of file return "data" for .phar
+	# check if the composer binary is executable by PHP
+	if file --brief --dereference "$composer_bin" | grep -e "shell" -e "bash" > /dev/null ; then # newer versions of file return "data" for .phar
 		# run it directly; it's probably a bash script or similar (homebrew-php does this)
-		$composer_bin "$@"
+		"$composer_bin" "$@"
 	else
-		php $composer_bin "$@"
+		php "$composer_bin" "$@"
 	fi
 }
 # these exports are used in default web server configs to lock down access to composer directories

--- a/bin/heroku-php-nginx
+++ b/bin/heroku-php-nginx
@@ -30,7 +30,7 @@ php_passthrough() {
 	if [[ "$out" != "$file" ]]; then
 		[[ $verbose ]] && echo "Interpreting ${1#$HEROKU_APP_DIR/} to $out" >&2
 		out="$dir/$out"
-		php -n "$1" > "$out"
+		php "$1" > "$out"
 		echo "$out"
 	else
 		echo "$1"
@@ -136,6 +136,30 @@ export DOCUMENT_ROOT="$HEROKU_APP_DIR"
 # set a default port if none is given
 export PORT=${PORT:-$(( $RANDOM+1024 ))}
 
+# add conf/php/apm-nostart-overrides/ to end of list of PHP INI scan dirs
+# that way our special extra INI which prevents startup of a possible newrelic etc is loaded for all the PHP and Composer calls that follow
+# an empty value for PHP_INI_SCAN_DIR means nothing is scanned at all, not even compile time default scan dirs
+# the variable can hold a list of paths delimited by colon, and if one segment is empty (e.g. "/foo::/bar" or just "/foo:" or ":/foo"), then the compile time default scan dir is used there
+if [[ -z ${PHP_INI_SCAN_DIR-} && ${PHP_INI_SCAN_DIR+x} ]]; then
+	# PHP_INI_SCAN_DIR was defined, but empty
+	# this means the user wants no scan dir, so we have to just place our own value into the variable, without a path separator
+	_PHP_INI_SCAN_DIR=
+	PHP_INI_SCAN_DIR=
+elif [[ -z ${PHP_INI_SCAN_DIR-} ]]; then
+	# PHP_INI_SCAN_DIR was not defined at all
+	# this means we want to load the compile time default scan dir first, then our special INIs
+	# we don't back up to _PHP_INI_SCAN_DIR; that way, we will know to unset it later and won't export an empty string
+	unset _PHP_INI_SCAN_DIR # just in case it's around
+	PHP_INI_SCAN_DIR=":" # leading empty segment will cause compile time default scan dir to be used
+else
+	# PHP_INI_SCAN_DIR was defined and not empty
+	# we want to append our path to the end of the list, or, if not defined at all, have the first list item be blank, which causes the default scan dir to be used
+	_PHP_INI_SCAN_DIR=$PHP_INI_SCAN_DIR
+	PHP_INI_SCAN_DIR+=":" # leading empty segment will cause compile time default scan dir to be used
+fi
+# now append
+export PHP_INI_SCAN_DIR="${PHP_INI_SCAN_DIR}${bp_dir}/conf/php/apm-nostart-overrides/"
+
 # init logs array here as empty before parsing options; -l could append to it, but the default list gets added later since we use $PORT in there and that can be set using -p
 declare -a logs
 
@@ -232,11 +256,11 @@ fi
 logs+=( "/tmp/heroku.php-fpm.$PORT.log" "/tmp/heroku.php-fpm.www.$PORT.log" "/tmp/heroku.php-fpm.$PORT.www.slowlog" "/tmp/heroku.nginx_access.$PORT.log" )
 
 # a bunch of checks; don't load any INIs to prevent newrelic etc from loading, we don't need all that stuff
-php -n -r 'exit((int)version_compare(PHP_VERSION, "5.5.11", "<"));' || { echo "This program requires PHP 5.5.11 or newer; check your 'php' command." >&2; exit 1; }
-{ php-fpm -n -v | php -n -r 'exit((int)version_compare(preg_replace("#PHP (\S+) \(fpm-fcgi\).+$#sm", "\\1", file_get_contents("php://stdin")), "5.5.11", "<"));'; } || { echo "This program requires PHP 5.5.11 or newer; check your 'php-fpm' command." >&2; exit 1; }
+php -r 'exit((int)version_compare(PHP_VERSION, "5.5.11", "<"));' || { echo "This program requires PHP 5.5.11 or newer; check your 'php' command." >&2; exit 1; }
+{ php-fpm -n -v | php -r 'exit((int)version_compare(preg_replace("#PHP (\S+) \(fpm-fcgi\).+$#sm", "\\1", file_get_contents("php://stdin")), "5.5.11", "<"));'; } || { echo "This program requires PHP 5.5.11 or newer; check your 'php-fpm' command." >&2; exit 1; }
 
-php_version="$(php-fpm -n -v | php -n -r 'echo preg_replace("#PHP (\S+) \(fpm-fcgi\).+$#sm", "\\1", file_get_contents("php://stdin"));')"
-nginx_version="$(nginx -v 2>&1 | php -n -r 'echo preg_replace("#.*nginx/([\d\.]+)$#sm", "\\1", file_get_contents("php://stdin"));')"
+php_version="$(php-fpm -n -v | php -r 'echo preg_replace("#PHP (\S+) \(fpm-fcgi\).+$#sm", "\\1", file_get_contents("php://stdin"));')"
+nginx_version="$(nginx -v 2>&1 | php -r 'echo preg_replace("#.*nginx/([\d\.]+)$#sm", "\\1", file_get_contents("php://stdin"));')"
 
 # make sure we run a local composer.phar if present, or global composer if not
 composer() {
@@ -246,7 +270,7 @@ composer() {
 		# run it directly; it's probably a bash script or similar (homebrew-php does this)
 		$composer_bin "$@"
 	else
-		php -n $composer_bin "$@"
+		php $composer_bin "$@"
 	fi
 }
 # these exports are used in default web server configs to lock down access to composer directories
@@ -317,8 +341,7 @@ if [[ -z ${WEB_CONCURRENCY:-} ]]; then
 	fi
 
 	# determine number of FPM processes to run
-	# prevent loading of extension INIs (and thus e.g. newrelic) using empty PHP_INI_SCAN_DIR
-	read WEB_CONCURRENCY php_memory_limit <<<$(PHP_INI_SCAN_DIR= php ${php_config:+-c "$php_config"} "$bp_dir/bin/util/autotune.php" -y "$fpm_config" -t "$DOCUMENT_ROOT" "$ram")
+	read WEB_CONCURRENCY php_memory_limit <<<$(php ${php_config:+-c "$php_config"} "$bp_dir/bin/util/autotune.php" -y "$fpm_config" -t "$DOCUMENT_ROOT" "$ram")
 	[[ $WEB_CONCURRENCY -lt 1 ]] && WEB_CONCURRENCY=1
 	export WEB_CONCURRENCY
 
@@ -412,6 +435,16 @@ echo "Starting php-fpm..." >&2
 	trap 'echo "php-fpm" >&3;' EXIT
 	trap 'trap - TERM; kill -TERM $pid 2> /dev/null || true & wait $pid 2> /dev/null || true; [[ ${BASHPID:-} ]] && kill -TERM $BASHPID' TERM
 	trap 'trap - USR1 EXIT; kill -TERM $pid 2> /dev/null || true & wait $pid 2> /dev/null || true; [[ ${BASHPID:-} ]] && kill -USR1 $BASHPID' USR1
+
+	# earlier, we added special INIs that prevent newrelic etc from starting to the scan dir
+	# we do not want that to apply to php-fpm, which uses the same scan dir for its configs as the regular PHP CLI SAPI
+	# we now restore the original env var from the backup variable, if it existed (important, because empty string and unset are different)
+	# doing this in this subshell means any later code can still invoke PHP CLI with the special INIs applied
+	unset PHP_INI_SCAN_DIR
+	if [[ -n ${_PHP_INI_SCAN_DIR+x} ]]; then
+		echo "XXXXXXDEBUG: restoring original PHP_INI_SCAN_DIR=${_PHP_INI_SCAN_DIR}" >&2
+		export PHP_INI_SCAN_DIR=$_PHP_INI_SCAN_DIR
+	fi
 
 	php-fpm --nodaemonize -y "$fpm_config" ${php_config:+-c "$php_config"} & pid=$!
 

--- a/bin/heroku-php-nginx
+++ b/bin/heroku-php-nginx
@@ -443,7 +443,6 @@ echo "Starting php-fpm..." >&2
 	# doing this in this subshell means any later code can still invoke PHP CLI with the special INIs applied
 	unset PHP_INI_SCAN_DIR
 	if [[ -n ${_PHP_INI_SCAN_DIR+x} ]]; then
-		echo "XXXXXXDEBUG: restoring original PHP_INI_SCAN_DIR=${_PHP_INI_SCAN_DIR}" >&2
 		export PHP_INI_SCAN_DIR=$_PHP_INI_SCAN_DIR
 	fi
 

--- a/bin/heroku-php-nginx
+++ b/bin/heroku-php-nginx
@@ -262,15 +262,16 @@ php -r 'exit((int)version_compare(PHP_VERSION, "5.5.11", "<"));' || { echo "This
 php_version="$(php-fpm -n -v | php -r 'echo preg_replace("#PHP (\S+) \(fpm-fcgi\).+$#sm", "\\1", file_get_contents("php://stdin"));')"
 nginx_version="$(nginx -v 2>&1 | php -r 'echo preg_replace("#.*nginx/([\d\.]+)$#sm", "\\1", file_get_contents("php://stdin"));')"
 
-# make sure we run a local composer.phar if present, or global composer if not
+# make sure we try a local composer.phar if no global installation is available
+composer_bin=$(command -v composer ./composer.phar) || { echo "This program requires 'composer' on \$PATH or a 'composer.phar' in the CWD." >&2; exit 1; }
+composer_bin=$(head -n1 <<< "$composer_bin") # if both were there, we'd have two lines of output, no good for invoking something :)
 composer() {
-	local composer_bin=$(which ./composer.phar composer | head -n1)
-	# check if we the composer binary is executable by PHP
-	if file --brief --dereference $composer_bin | grep -e "shell" -e "bash" > /dev/null ; then # newer versions of file return "data" for .phar
+	# check if the composer binary is executable by PHP
+	if file --brief --dereference "$composer_bin" | grep -e "shell" -e "bash" > /dev/null ; then # newer versions of file return "data" for .phar
 		# run it directly; it's probably a bash script or similar (homebrew-php does this)
-		$composer_bin "$@"
+		"$composer_bin" "$@"
 	else
-		php $composer_bin "$@"
+		php "$composer_bin" "$@"
 	fi
 }
 # these exports are used in default web server configs to lock down access to composer directories

--- a/conf/php/apm-nostart-overrides/README.md
+++ b/conf/php/apm-nostart-overrides/README.md
@@ -1,0 +1,7 @@
+This directory is used by boot scripts as an additional config scan dir until the actual web server process is launched; it gets set (or appended) into `PHP_INI_SCAN_DIR`.
+
+The purpose is to have directives in this config that should only apply during the various `php` and `composer` calls that happen before the actual web server process is launched.
+
+The common use case is to prevent APM extensions such as new relic from instrumenting the many `php` and `composer` calls in boot scripts, and to avoid the associated startup messages from cluttering the logs.
+
+The alternative approach, `php -n`, does not work, since many environments load even default extensions such as `ext-json` as shared libraries through their INIs, or otherwise would be stripped of necessary settings (e.g. a global `pcre.jit=0`, needed for Composer to work on certain platforms).

--- a/conf/php/apm-nostart-overrides/README.md
+++ b/conf/php/apm-nostart-overrides/README.md
@@ -5,3 +5,5 @@ The purpose is to have directives in this config that should only apply during t
 The common use case is to prevent APM extensions such as new relic from instrumenting the many `php` and `composer` calls in boot scripts, and to avoid the associated startup messages from cluttering the logs.
 
 The alternative approach, `php -n`, does not work, since many environments load even default extensions such as `ext-json` as shared libraries through their INIs, or otherwise would be stripped of necessary settings (e.g. a global `pcre.jit=0`, needed for Composer to work on certain platforms).
+
+This directory is also used by bin/compile to prevent the same APM startup, and a suitable `PHP_INI_SCAN_DIR` value is written into the `export` script, so that other buildpacks running after this one can call `php` or `composer` without getting the APM extension startup as well.

--- a/conf/php/apm-nostart-overrides/apm-nostart-overrides.ini
+++ b/conf/php/apm-nostart-overrides/apm-nostart-overrides.ini
@@ -1,0 +1,15 @@
+; AppDynamics
+agent.auto_launch_proxy = 0
+agent.cli_enabled = 0
+
+; New Relic
+newrelic.daemon.dont_launch = 3
+newrelic.enabled = 0
+
+; Sqreen
+sqreen.launch_daemon = 0
+sqreen.disable = 1
+
+; Tideways
+tideways.auto_start = 0
+tideways.enable_cli = 0

--- a/test/spec/php_shared.rb
+++ b/test/spec/php_shared.rb
@@ -33,6 +33,74 @@ shared_examples "A PHP application with a composer.json" do |series|
 		end
 	end
 	
+	context "requiring PHP #{series} and using New Relic" do
+		["explicitly", "without NEW_RELIC_LICENSE_KEY", "implicitly"].each do |mode|
+			context "#{mode}" do
+				before(:all) do
+					if mode == "explicitly"
+						# ext-newrelic is listed as a dependency in composer.json, and a NEW_RELIC_LICENSE_KEY is provided
+						@app = new_app_with_stack_and_platrepo('test/fixtures/bootopts',
+							config: { "NEW_RELIC_LOG_LEVEL" => "info", "NEW_RELIC_LICENSE_KEY" => "somethingfake" },
+							before_deploy: -> { system("composer require --quiet --ignore-platform-reqs 'php:#{series}.*' 'ext-newrelic:*'") or raise "Failed to require PHP/ext-newrelic" }
+						)
+					elsif mode == "without NEW_RELIC_LICENSE_KEY"
+						# ext-newrelic is listed as a dependency in composer.json, but a NEW_RELIC_LICENSE_KEY is missing
+						@app = new_app_with_stack_and_platrepo('test/fixtures/bootopts',
+							config: { "NEW_RELIC_LOG_LEVEL" => "info" },
+							before_deploy: -> { system("composer require --quiet --ignore-platform-reqs 'php:#{series}.*' 'ext-newrelic:*'") or raise "Failed to require PHP/ext-newrelic" }
+						)
+					else
+						# a NEW_RELIC_LICENSE_KEY triggers the automatic installation of ext-newrelic at the end of the build
+						@app = new_app_with_stack_and_platrepo('test/fixtures/bootopts',
+							config: { "NEW_RELIC_LOG_LEVEL" => "info", "NEW_RELIC_LICENSE_KEY" => "this willtriggernewrelic" },
+							before_deploy: -> { system("composer require --quiet --ignore-platform-reqs 'php:#{series}.*'") or raise "Failed to require PHP version" }
+						)
+					end
+					@app.deploy
+					@app.api_rate_limit.call.formation.update(@app.name, "web", {"size" => "Standard-1X"})
+				end
+				
+				after(:all) do
+					# scale back down when we're done
+					# we should do this, because teardown! doesn't remove the app unless we're over the app limit
+					@app.api_rate_limit.call.formation.update(@app.name, "web", {"size" => "free"})
+					@app.teardown!
+				end
+				
+				it "installs New Relic" do
+					if mode == "implicitly"
+						expect(@app.output).not_to match(/New Relic PHP Agent globally disabled/) # NR daemon should never start, since NR is installed at the very end
+						expect(@app.output).to match(/New Relic detected, installed ext-newrelic/) # auto-install at the end
+					else
+						expect(@app.output).to match(/- ext-newrelic/)
+						expect(@app.output).to match(/New Relic PHP Agent globally disabled/) # NR daemon will throw this during composer install
+					end
+				end
+				
+				it "does not start New Relic during build" do
+					expect(@app.output).not_to match(/listen="@newrelic-daemon".*?startup=init/) # NR daemon does not start during build
+					expect(@app.output).not_to match(/daemon='@newrelic-daemon'.*?startup=agent/) # no extension connects during build
+				end
+				
+				['heroku-php-apache2', 'heroku-php-nginx'].each do |script|
+					it "launches newrelic-daemon, but not the extension, during boot preparations, with #{script}" do
+						out = @app.run("#{script} -F conf/fpm.include.broken") # prevent FPM from starting up using an invalid config, that way we don't have to wrap the server start in a `timeout` call
+						
+						expect(out).not_to match(/spawned daemon child/) unless mode.include? "without NEW_RELIC_LICENSE_KEY" # extension does not spawn its own daemon
+						
+						out_before_fpm, out_after_fpm = out.split("Starting php-fpm", 2)
+						
+						expect(out_before_fpm).to match(/listen="@newrelic-daemon"[^\n]+?startup=init/) unless mode.include? "without NEW_RELIC_LICENSE_KEY" # NR daemon starts on boot
+						expect(out_before_fpm).not_to match(/daemon='@newrelic-daemon'[^\n]+?startup=agent/) # extension does not connect to daemon before FPM starts
+						expect(out_before_fpm).to match(/New Relic PHP Agent globally disabled/) # NR extension reports itself disabled
+						
+						expect(out_after_fpm).to match(/daemon='@newrelic-daemon'[^\n]+?startup=agent/m) # extension connects to daemon when FPM starts
+					end
+				end
+			end
+		end
+	end
+	
 	# the matrix of options and arguments to test
 	# we will generate relevant combinations of these using a helper
 	# numeric keys mean the values are passed as an argument and not as key/value options

--- a/test/spec/php_shared.rb
+++ b/test/spec/php_shared.rb
@@ -4,7 +4,7 @@ shared_examples "A PHP application with a composer.json" do |series|
 	context "requiring PHP #{series}" do
 		before(:all) do
 			@app = new_app_with_stack_and_platrepo('test/fixtures/default',
-				before_deploy: -> { system("composer require --quiet --no-update php '#{series}.*' && composer update --quiet --ignore-platform-reqs") or raise "Failed to require PHP version" }
+				before_deploy: -> { system("composer require --quiet --ignore-platform-reqs php '#{series}.*'") or raise "Failed to require PHP version" }
 			)
 			@app.deploy
 			# so we don't have to worry about overlapping dynos causing test failures because only one free is allowed at a time
@@ -109,7 +109,7 @@ shared_examples "A PHP application with a composer.json" do |series|
 		context "running PHP #{series} and the #{server} web server" do
 			before(:all) do
 				@app = new_app_with_stack_and_platrepo('test/fixtures/bootopts',
-					before_deploy: -> { system("composer require --quiet --no-update php '#{series}.*' && composer update --quiet --ignore-platform-reqs") or raise "Failed to require PHP version" }
+					before_deploy: -> { system("composer require --quiet --ignore-platform-reqs php '#{series}.*'") or raise "Failed to require PHP version" }
 				)
 				@app.deploy
 				# so we don't have to worry about overlapping dynos causing test failures because only one free is allowed at a time


### PR DESCRIPTION
Right now, we use `php -n` to disable all INI scanning in many places (at build time, or during app boot preparations) to prevent e.g. New Relic from getting loaded and trying to instrument the run (which at boot time would fail because the daemon isn't running, and at runtime would clutter app telemetry from the many simple `php` and `composer` calls we make to get the app started).

The problem is that this doesn't always work (e.g. when the NR extension is explicitly required in `composer.json`,  then the main dependency `composer install` will see `ext-newrelic` trying to start and connect), and breaks people's Fedora etc setups at startup time, where disabling all INI scanning via `php -n` prevents their default configs which load essential extensions or settings from getting used (see e.g. #345 or #348).

This PR refactors all of that to instead use a [`PHP_INI_SCAN_DIR`](https://www.php.net/manual/en/configuration.file.php) entry that contains an INI file which prevents boot for common extensions.

That solves both the previously impossible to prevent boot time `ext-newrelic` startups if that one was explicitly `require`d in `composer.json`, and ensures that the server boot scripts at runtime work no matter what a user's local PHP setup looks like.

Also adds a bunch of tests around this behavior, and `ext-newrelic` in general.