### PR TITLE
v163: pin heroku-18.Dockerfile to heroku/heroku:18-build.v16 for now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # heroku-buildpack-php CHANGELOG
 
+## v163 (2019-10-01)
+
+### CHG
+
+- Pin `heroku-18.Dockerfile` to use `heroku/heroku:18-build.v16` to ensure builds against libssl 1.1.0 until Private Spaces are fully upgraded [David Zuelke]
+
 ## v162 (2019-09-27)
 
 ### ADD

--- a/support/build/_docker/heroku-18.Dockerfile
+++ b/support/build/_docker/heroku-18.Dockerfile
@@ -1,4 +1,4 @@
-FROM heroku/heroku:18-build
+FROM heroku/heroku:18-build.v16
 
 WORKDIR /app
 ENV WORKSPACE_DIR=/app/support/build

--- a/support/build/_docker/heroku-18.Dockerfile
+++ b/support/build/_docker/heroku-18.Dockerfile
@@ -9,7 +9,9 @@ ENV S3_REGION=s3
 ENV STACK=heroku-18
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get install -y python-pip
+# pin to package versions from bionic-security for now so that the install doesn't bump libssl to 1.1.1
+# RUN apt-get update && apt-get install -y python-pip
+RUN apt-get update && apt-get install --no-install-recommends -y python-pip-whl=9.0.1-2 python-pip=9.0.1-2 python-setuptools python-wheel
 
 COPY requirements.txt /app/requirements.txt
 


### PR DESCRIPTION
Private Spaces aren't upgraded yet, so we need to ensure we build against OpenSSL 1.1.0 in case a program would explicitly use 1.1.1 features if built against it (Python does that, and so does Nginx).