### PR TITLE
Fix flappy tests for good

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ install:
 before_script:
 - bundle exec hatchet ci:setup
 - heroku update
-script: bundle exec parallel_rspec -n 7 --runtime-log "test/var/log/parallel_runtime_rspec.${STACK}.log" --verbose-process-command --combine-stderr --prefix-output-with-test-env-number test/spec/
+script: bundle exec parallel_rspec -n 7 --group-by runtime --unknown-runtime 1 --runtime-log "test/var/log/parallel_runtime_rspec.${STACK}.log" --verbose-process-command --combine-stderr --prefix-output-with-test-env-number test/spec/
 after_script:
 - bundle exec hatchet destroy --all
 - cat parallel_runtime_rspec.log | grep -E '^test/spec/[a-z0-9_/\.-]+\.rb:[0-9]+\.[0-9]+$' | sort

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem 'heroku_hatchet', ">=4.0.8"
+gem 'heroku_hatchet', ">=4.1.0"
 gem 'rspec-retry'
 gem 'rspec-expectations'
 gem 'sem_version'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,13 +10,13 @@ GEM
     concurrent-ruby (1.1.5)
     diff-lcs (1.3)
     erubis (2.7.0)
-    excon (0.71.1)
+    excon (0.72.0)
     heroics (0.0.25)
       erubis (~> 2.0)
       excon
       moneta
       multi_json (>= 1.9.2)
-    heroku_hatchet (4.0.13)
+    heroku_hatchet (4.1.0)
       excon (~> 0)
       minitest-retry (~> 0.1.9)
       platform-api (~> 2)
@@ -24,15 +24,15 @@ GEM
       rrrretry (~> 1)
       thor (~> 0)
       threaded (~> 0)
-    i18n (1.7.0)
+    i18n (1.8.2)
       concurrent-ruby (~> 1.0)
-    minitest (5.13.0)
+    minitest (5.14.0)
     minitest-retry (0.1.9)
       minitest (>= 5.0)
     moneta (1.0.0)
     multi_json (1.14.1)
     parallel (1.19.1)
-    parallel_tests (2.30.0)
+    parallel_tests (2.30.1)
       parallel
     platform-api (2.2.0)
       heroics (~> 0.0.25)
@@ -41,19 +41,19 @@ GEM
     repl_runner (0.0.3)
       activesupport
     rrrretry (1.0.0)
-    rspec-core (3.9.0)
-      rspec-support (~> 3.9.0)
+    rspec-core (3.9.1)
+      rspec-support (~> 3.9.1)
     rspec-expectations (3.9.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-retry (0.6.2)
       rspec-core (> 3.3)
-    rspec-support (3.9.0)
+    rspec-support (3.9.2)
     sem_version (2.0.1)
     thor (0.20.3)
     thread_safe (0.3.6)
     threaded (0.0.4)
-    tzinfo (1.2.5)
+    tzinfo (1.2.6)
       thread_safe (~> 0.1)
     zeitwerk (2.2.2)
 
@@ -61,7 +61,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  heroku_hatchet (>= 4.0.8)
+  heroku_hatchet (>= 4.1.0)
   parallel_tests
   rake
   rspec-expectations

--- a/test/var/log/parallel_runtime_rspec.cedar-14.log
+++ b/test/var/log/parallel_runtime_rspec.cedar-14.log
@@ -9,4 +9,3 @@ test/spec/php_7.2_spec.rb:527.555128419
 test/spec/php_7.3_spec.rb:531.493362414
 test/spec/php_default_spec.rb:40.35018732699996
 test/spec/sigterm_spec.rb:54.528619442
-test/spec/bugs_spec.rb:1.616908664

--- a/test/var/log/parallel_runtime_rspec.heroku-16.log
+++ b/test/var/log/parallel_runtime_rspec.heroku-16.log
@@ -7,6 +7,3 @@ test/spec/php_7.2_spec.rb:533.483751735
 test/spec/php_7.3_spec.rb:531.949388258
 test/spec/php_default_spec.rb:37.577302651000025
 test/spec/sigterm_spec.rb:54.842822989
-test/spec/bugs_spec.rb:1.616908664
-test/spec/hhvm_spec.rb:1.616908664
-test/spec/php_5.5_spec.rb:1.616908664

--- a/test/var/log/parallel_runtime_rspec.heroku-18.log
+++ b/test/var/log/parallel_runtime_rspec.heroku-18.log
@@ -6,7 +6,3 @@ test/spec/php_7.2_spec.rb:536.272335398
 test/spec/php_7.3_spec.rb:554.4528700789999
 test/spec/php_default_spec.rb:38.073168747000004
 test/spec/sigterm_spec.rb:53.837582215000005
-test/spec/hhvm_spec.rb:1.616908664
-test/spec/php_5.5_spec.rb:1.616908664
-test/spec/php_5.6_spec.rb:1.616908664
-test/spec/php_7.0_spec.rb:1.616908664


### PR DESCRIPTION
Update Hatchet to 4.1.0, which fixes two race conditions in pipeline tests, and includes features we've been monkey patching until now.