### PR TITLE
Write stdlib to a tmp dir instead of the bpdir 

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -28,17 +28,17 @@ trap 'err_trap' ERR
 
 # stdlib
 # download to a file first, as the function restarts the entire download on code 18 connection reset (not all servers support -C)
-curl_retry_on_18 --fail --silent --location -o $bp_dir/bin/util/stdlib.sh https://lang-common.s3.amazonaws.com/buildpack-stdlib/v8/stdlib.sh || {
+curl_retry_on_18 --fail --silent --location -o ${TMPDIR:-/tmp}/stdlib.sh https://lang-common.s3.amazonaws.com/buildpack-stdlib/v8/stdlib.sh || {
 	error <<-EOF
 		Failed to download standard library for bootstrapping!
-		
+
 		This is most likely a temporary internal error. If the problem
 		persists, make sure that you are not running a custom or forked
 		version of the Heroku PHP buildpack which may need updating.
 	EOF
 }
-source $bp_dir/bin/util/stdlib.sh
-rm $bp_dir/bin/util/stdlib.sh
+source ${TMPDIR:-/tmp}/stdlib.sh
+rm ${TMPDIR:-/tmp}/stdlib.sh
 
 # failure counting
 source $bp_dir/bin/util/failures.sh


### PR DESCRIPTION
In Cloud Native Buildpacks, the buildpack dir is read-only. This change fixes a failure on https://github.com/heroku/pack-images/pull/65