### PR TITLE
Support `python` not being symlinked to `python2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # heroku-buildpack-php CHANGELOG
 
+## Unreleased
+
+### CHG
+
+- Support `python` not being symlinked to `python2` [Ed Morley]
+
 ## v174 (2020-04-30)
 
 ### ADD

--- a/bin/compile
+++ b/bin/compile
@@ -94,7 +94,7 @@ composer_lock_parse_error=$(
 
 # a bunch of sanity checks first
 if [[ -s "$COMPOSER" ]]; then
-	cat "$COMPOSER" | python -mjson.tool &> /dev/null || {
+	cat "$COMPOSER" | python2 -mjson.tool &> /dev/null || {
 		mcount "failures.composer_json.lint"
 		error <<-EOF
 			Basic validation for '$COMPOSER' failed!
@@ -112,7 +112,7 @@ if [[ -s "$COMPOSER" ]]; then
 		EOF
 	}
 	if [[ ! -f "$COMPOSER_LOCK" ]]; then
-		cat "$COMPOSER" | python -c 'import sys, json; sys.exit(bool(json.load(sys.stdin).get("require", {})))' 2> /dev/null || {
+		cat "$COMPOSER" | python2 -c 'import sys, json; sys.exit(bool(json.load(sys.stdin).get("require", {})))' 2> /dev/null || {
 			mcount "failures.composer_lock.missing"
 			error <<-EOF
 				No '$COMPOSER_LOCK' found!
@@ -144,7 +144,7 @@ if [[ -s "$COMPOSER" ]]; then
 			EOF
 		}
 	else
-		cat "$COMPOSER_LOCK" | python -mjson.tool &> /dev/null || {
+		cat "$COMPOSER_LOCK" | python2 -mjson.tool &> /dev/null || {
 			mcount "failures.composer_lock.lint"
 			error "$composer_lock_parse_error"
 		}
@@ -310,7 +310,7 @@ composer validate --no-plugins --no-check-publish --no-check-all --quiet "$COMPO
 }
 
 # if prefer-stable is false and minimum-stability is not stable, warn about potential unstable platform installs
-[[ ! -f "$COMPOSER_LOCK" ]] || minimum_stability=$(cat "$COMPOSER_LOCK" | python -c 'import sys, json; l = json.load(sys.stdin); print(l.get("minimum-stability")); sys.exit(l.get("minimum-stability", "stable") != "stable" and l.get("prefer-stable", False) == False);' 2> /dev/null) || {
+[[ ! -f "$COMPOSER_LOCK" ]] || minimum_stability=$(cat "$COMPOSER_LOCK" | python2 -c 'import sys, json; l = json.load(sys.stdin); print(l.get("minimum-stability")); sys.exit(l.get("minimum-stability", "stable") != "stable" and l.get("prefer-stable", False) == False);' 2> /dev/null) || {
 	possible_stabilities="dev, alpha, beta, or RC"
 	case $minimum_stability in
 		alpha)
@@ -639,7 +639,7 @@ unset COMPOSER_GITHUB_OAUTH_TOKEN
 
 # install dependencies unless composer.json is completely empty (in which case it'd talk to packagist.org which may be slow and is unnecessary)
 export_env_dir "$env_dir" '^[A-Z_][A-Z0-9_]*$' '^(HOME|PATH|GIT_DIR|CPATH|CPPATH|LD_PRELOAD|LIBRARY_PATH|LD_LIBRARY_PATH|STACK|REQUEST_ID|IFS|HEROKU_PHP_INSTALL_DEV|BPLOG_PREFIX|BUILDPACK_LOG_FILE|PHP_INI_SCAN_DIR)$'
-if cat "$COMPOSER" | python -c 'import sys,json; sys.exit(not json.load(sys.stdin));'; then
+if cat "$COMPOSER" | python2 -c 'import sys,json; sys.exit(not json.load(sys.stdin));'; then
 	install_log=$(mktemp -t heroku-buildpack-php-composer-install-log-XXXX)
 	composer install ${HEROKU_PHP_INSTALL_DEV-"--no-dev"} --prefer-dist --optimize-autoloader --no-interaction 2>&1 | tee "$install_log" | indent || {
 		code=$?
@@ -697,7 +697,7 @@ fi
 # log number of installed dependencies
 mmeasure "dependencies.count" $(composer show --installed 2> /dev/null | wc -l)
 
-if cat "$COMPOSER" | python -c 'import sys,json; sys.exit("compile" not in json.load(sys.stdin).get("scripts", {}));'; then
+if cat "$COMPOSER" | python2 -c 'import sys,json; sys.exit("compile" not in json.load(sys.stdin).get("scripts", {}));'; then
 	status "Running 'composer compile'..."
 	composer run-script ${HEROKU_PHP_INSTALL_DEV-"--no-dev"} --no-interaction compile 2>&1 | indent || {
 		mcount "failures.compile_step"
@@ -725,15 +725,15 @@ status "Preparing runtime environment..."
 # TODO: warn if require-dev has the package using a different branch
 shopt -u dotglob # we don't want .git, .gitignore et al
 # figure out the package dir name to write to and copy to it
-hbpdir="$composer_vendordir/$(cat $bp_dir/composer.json | python -c 'import sys, json; print(json.load(sys.stdin)["name"])')"
+hbpdir="$composer_vendordir/$(cat $bp_dir/composer.json | python2 -c 'import sys, json; print(json.load(sys.stdin)["name"])')"
 mkdir -p "$build_dir/$hbpdir"
 cp -r "$bp_dir"/* "$build_dir/$hbpdir/"
 # make bin dir, just in case
 mkdir -p "$build_dir/$composer_bindir"
 # figure out shortest relative path from vendor/heroku/heroku-buildpack-php to vendor/bin (or whatever the bin dir is)
-relbin=$(python -c "import os.path; print(os.path.relpath('$hbpdir', '$composer_bindir'))")
+relbin=$(python2 -c "import os.path; print(os.path.relpath('$hbpdir', '$composer_bindir'))")
 # collect bin names from composer.json
-relbins=$(cat $bp_dir/composer.json | python -c 'from __future__ import print_function; import sys, json; { print(sys.argv[1]+"/"+bin) for bin in json.load(sys.stdin)["bin"] }' $relbin)
+relbins=$(cat $bp_dir/composer.json | python2 -c 'from __future__ import print_function; import sys, json; { print(sys.argv[1]+"/"+bin) for bin in json.load(sys.stdin)["bin"] }' $relbin)
 # link to bins
 cd $build_dir/$composer_bindir
 ln -fs $relbins .

--- a/bin/heroku-hhvm-apache2
+++ b/bin/heroku-hhvm-apache2
@@ -14,7 +14,11 @@ if ! type -p "realpath" > /dev/null; then
 	# readlink is not an option because BSD readlink does not have the GNU -f option
 	# must be a function so subshells, including $(…), can use it
 	realpath() {
-		python -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$@"
+		# Required since OS X's Python 2 binary is named `python` not `python2`,
+		# and on newer Ubuntu `python` no longer exists.
+		python_bin=$(command -v python2 python) || { echo "This program requires 'python2' or 'python' to be on \$PATH." >&2; exit 1; }
+		python_bin=$(head -n1 <<< "$python_bin") # Only use the first path if both were present
+		$python_bin -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$@"
 	}
 fi
 

--- a/bin/heroku-hhvm-nginx
+++ b/bin/heroku-hhvm-nginx
@@ -14,7 +14,11 @@ if ! type -p "realpath" > /dev/null; then
 	# readlink is not an option because BSD readlink does not have the GNU -f option
 	# must be a function so subshells, including $(…), can use it
 	realpath() {
-		python -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$@"
+		# Required since OS X's Python 2 binary is named `python` not `python2`,
+		# and on newer Ubuntu `python` no longer exists.
+		python_bin=$(command -v python2 python) || { echo "This program requires 'python2' or 'python' to be on \$PATH." >&2; exit 1; }
+		python_bin=$(head -n1 <<< "$python_bin") # Only use the first path if both were present
+		$python_bin -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$@"
 	}
 fi
 

--- a/bin/heroku-php-apache2
+++ b/bin/heroku-php-apache2
@@ -14,7 +14,11 @@ if ! type -p "realpath" > /dev/null; then
 	# readlink is not an option because BSD readlink does not have the GNU -f option
 	# must be a function so subshells, including $(…), can use it
 	realpath() {
-		python -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$@"
+		# Required since OS X's Python 2 binary is named `python` not `python2`,
+		# and on newer Ubuntu `python` no longer exists.
+		python_bin=$(command -v python2 python) || { echo "This program requires 'python2' or 'python' to be on \$PATH." >&2; exit 1; }
+		python_bin=$(head -n1 <<< "$python_bin") # Only use the first path if both were present
+		$python_bin -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$@"
 	}
 fi
 

--- a/bin/heroku-php-nginx
+++ b/bin/heroku-php-nginx
@@ -14,7 +14,11 @@ if ! type -p "realpath" > /dev/null; then
 	# readlink is not an option because BSD readlink does not have the GNU -f option
 	# must be a function so subshells, including $(…), can use it
 	realpath() {
-		python -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$@"
+		# Required since OS X's Python 2 binary is named `python` not `python2`,
+		# and on newer Ubuntu `python` no longer exists.
+		python_bin=$(command -v python2 python) || { echo "This program requires 'python2' or 'python' to be on \$PATH." >&2; exit 1; }
+		python_bin=$(head -n1 <<< "$python_bin") # Only use the first path if both were present
+		$python_bin -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$@"
 	}
 fi
 

--- a/support/build/README.md
+++ b/support/build/README.md
@@ -283,7 +283,7 @@ For example, the Apache HTTPD web server is built roughly as follows:
     export PATH="$HOME/.heroku/php/bin:$HOME/.heroku/php/sbin:$PATH"
     EOF
     
-    python $(dirname $BASH_SOURCE)/_util/include/manifest.py "heroku-sys-webserver" "heroku-sys/${dep_name}" "$dep_version" "${dep_formula}.tar.gz" "$MANIFEST_REQUIRE" "$MANIFEST_CONFLICT" "$MANIFEST_REPLACE" "$MANIFEST_PROVIDE" "$MANIFEST_EXTRA" > $dep_manifest
+    python2 $(dirname $BASH_SOURCE)/_util/include/manifest.py "heroku-sys-webserver" "heroku-sys/${dep_name}" "$dep_version" "${dep_formula}.tar.gz" "$MANIFEST_REQUIRE" "$MANIFEST_CONFLICT" "$MANIFEST_REPLACE" "$MANIFEST_PROVIDE" "$MANIFEST_EXTRA" > $dep_manifest
     
     print_or_export_manifest_cmd "$(generate_manifest_cmd "$dep_manifest")"
 

--- a/support/build/_util/mkrepo.sh
+++ b/support/build/_util/mkrepo.sh
@@ -86,7 +86,7 @@ if $upload || [[ -t 1 ]]; then
 fi
 
 # sort so that packages with the same name and version (e.g. ext-memcached 2.2.0) show up with their hhvm or php requirement in descending order - otherwise a Composer limitation means that a simple "ext-memcached: * + php: ^5.5.17" request would install 5.5.latest and not 5.6.latest, as it finds the 5.5.* requirement extension first and sticks to that instead of 5.6. For packages with identical names and versions (but different e.g. requirements), Composer basically treats them as equal and picks as a winner whatever it finds first. The requirements have to be written like "x.y.*" for this to work of course.
-python -c 'import sys, json; from distutils import version; json.dump({"packages": [ sorted([json.load(open(item)) for item in sys.argv[1:] if json.load(open(item)).get("type", "") != "heroku-sys-package"], key=lambda package: version.LooseVersion(package.get("require", {}).get("heroku-sys/hhvm", package.get("require", {}).get("heroku-sys/php", "0.0.0"))), reverse=True) ] }, sys.stdout, sort_keys=True)' $manifests
+python2 -c 'import sys, json; from distutils import version; json.dump({"packages": [ sorted([json.load(open(item)) for item in sys.argv[1:] if json.load(open(item)).get("type", "") != "heroku-sys-package"], key=lambda package: version.LooseVersion(package.get("require", {}).get("heroku-sys/hhvm", package.get("require", {}).get("heroku-sys/php", "0.0.0"))), reverse=True) ] }, sys.stdout, sort_keys=True)' $manifests
 
 # restore stdout
 # note that 'exec >$(tty)' does not work as FD 1 may have been a pipe originally and not a tty

--- a/support/build/_util/remove.sh
+++ b/support/build/_util/remove.sh
@@ -92,7 +92,7 @@ echo "" >&2
 remove_files=()
 for manifest in "${manifests[@]}"; do
 	echo "Removing $(basename $manifest ".composer.json"):" >&2
-	if filename=$(cat $manifests_tmp/$(basename $manifest) | python <(cat <<-'PYTHON' # beware of single quotes in body
+	if filename=$(cat $manifests_tmp/$(basename $manifest) | python2 <(cat <<-'PYTHON' # beware of single quotes in body
 		import sys, json, re;
 		manifest=json.load(sys.stdin)
 		url=manifest.get("dist",{}).get("url","").partition("https://"+sys.argv[1]+"."+sys.argv[2]+".amazonaws.com/"+sys.argv[3])

--- a/support/build/_util/sync.sh
+++ b/support/build/_util/sync.sh
@@ -88,7 +88,7 @@ echo "" >&2
 
 # this mkrepo.sh call won't actually download, but use the given *.composer.json, and echo a generated packages.json
 # we use this to compare to the downloaded packages.json
-$here/mkrepo.sh $src_bucket $src_prefix ${src_tmp}/*.composer.json 2>/dev/null | python -c 'import sys, json; sys.exit(json.load(open(sys.argv[1])) != json.load(sys.stdin))' ${src_tmp}/packages.json || {
+$here/mkrepo.sh $src_bucket $src_prefix ${src_tmp}/*.composer.json 2>/dev/null | python2 -c 'import sys, json; sys.exit(json.load(open(sys.argv[1])) != json.load(sys.stdin))' ${src_tmp}/packages.json || {
 	cat >&2 <<-EOF
 		WARNING: packages.json from source does not match its list of manifests!
 		 You should run 'mkrepo.sh' to update, or ask the bucket maintainers to do so.
@@ -113,7 +113,7 @@ update_manifests=()
 ignore_manifests=()
 for filename in $common; do
 	result=0
-	python <(cat <<-'PYTHON' # beware of single quotes in body
+	python2 <(cat <<-'PYTHON' # beware of single quotes in body
 		from __future__ import print_function
 		import sys, json, os, datetime
 		# for python 2+3 compat
@@ -204,7 +204,7 @@ echo "" >&2
 copied_files=()
 for manifest in $add_manifests ${update_manifests[@]:-}; do
 	echo "Copying ${manifest%.composer.json}:" >&2
-	if filename=$(cat ${src_tmp}/${manifest} | python <(cat <<-'PYTHON' # beware of single quotes in body
+	if filename=$(cat ${src_tmp}/${manifest} | python2 <(cat <<-'PYTHON' # beware of single quotes in body
 		import sys, json;
 		manifest=json.load(sys.stdin)
 		url=manifest.get("dist",{}).get("url","").partition("https://"+sys.argv[1]+"."+sys.argv[2]+".amazonaws.com/"+sys.argv[3])
@@ -239,7 +239,7 @@ done
 remove_files=()
 for manifest in $remove_manifests; do
 	echo "Removing ${manifest%.composer.json}:" >&2
-	if filename=$(cat ${dst_tmp}/${manifest} | python <(cat <<-'PYTHON' # beware of single quotes in body
+	if filename=$(cat ${dst_tmp}/${manifest} | python2 <(cat <<-'PYTHON' # beware of single quotes in body
 		import sys, json;
 		manifest=json.load(sys.stdin)
 		url=manifest.get("dist",{}).get("url","").partition("https://"+sys.argv[1]+"."+sys.argv[2]+".amazonaws.com/"+sys.argv[3])

--- a/support/build/apache
+++ b/support/build/apache
@@ -71,6 +71,6 @@ cat > ${OUT_PREFIX}/bin/profile.apache2.sh <<'EOF'
 export PATH="$HOME/.heroku/php/bin:$HOME/.heroku/php/sbin:$PATH"
 EOF
 
-python $(dirname $BASH_SOURCE)/_util/include/manifest.py "heroku-sys-webserver" "heroku-sys/${dep_name}" "$dep_version" "${dep_formula}.tar.gz" "$MANIFEST_REQUIRE" "$MANIFEST_CONFLICT" "$MANIFEST_REPLACE" "$MANIFEST_PROVIDE" "$MANIFEST_EXTRA" > $dep_manifest
+python2 $(dirname $BASH_SOURCE)/_util/include/manifest.py "heroku-sys-webserver" "heroku-sys/${dep_name}" "$dep_version" "${dep_formula}.tar.gz" "$MANIFEST_REQUIRE" "$MANIFEST_CONFLICT" "$MANIFEST_REPLACE" "$MANIFEST_PROVIDE" "$MANIFEST_EXTRA" > $dep_manifest
 
 print_or_export_manifest_cmd "$(generate_manifest_cmd "$dep_manifest")"

--- a/support/build/composer
+++ b/support/build/composer
@@ -36,6 +36,6 @@ mkdir -p ${OUT_PREFIX}/bin
 
 mv composer.phar ${OUT_PREFIX}/bin/composer
 
-python $(dirname $BASH_SOURCE)/_util/include/manifest.py "heroku-sys-package" "heroku-sys/pkg-${dep_name}" "$dep_version" "${dep_formula}.tar.gz" > $dep_manifest
+python2 $(dirname $BASH_SOURCE)/_util/include/manifest.py "heroku-sys-package" "heroku-sys/pkg-${dep_name}" "$dep_version" "${dep_formula}.tar.gz" > $dep_manifest
 
 print_or_export_manifest_cmd "$(generate_manifest_cmd "$dep_manifest")"

--- a/support/build/extensions/no-debug-non-zts-20121212/blackfire
+++ b/support/build/extensions/no-debug-non-zts-20121212/blackfire
@@ -124,7 +124,7 @@ MANIFEST_REPLACE="${MANIFEST_REPLACE:-"{}"}"
 MANIFEST_PROVIDE="${MANIFEST_PROVIDE:-"{}"}"
 MANIFEST_EXTRA="${MANIFEST_EXTRA:-"{\"config\":\"etc/php/conf.d/blackfire.ini-dist\",\"profile\":\"bin/profile.blackfire.sh\"}"}"
 
-python $(dirname $BASH_SOURCE)/../../_util/include/manifest.py "heroku-sys-php-extension" "heroku-sys/ext-${dep_name}" "$dep_version" "${dep_formula}.tar.gz" "$MANIFEST_REQUIRE" "$MANIFEST_CONFLICT" "$MANIFEST_REPLACE" "$MANIFEST_PROVIDE" "$MANIFEST_EXTRA" > $dep_manifest
+python2 $(dirname $BASH_SOURCE)/../../_util/include/manifest.py "heroku-sys-php-extension" "heroku-sys/ext-${dep_name}" "$dep_version" "${dep_formula}.tar.gz" "$MANIFEST_REQUIRE" "$MANIFEST_CONFLICT" "$MANIFEST_REPLACE" "$MANIFEST_PROVIDE" "$MANIFEST_EXTRA" > $dep_manifest
 
 print_or_export_manifest_cmd "$(generate_manifest_cmd "$dep_manifest")"
 

--- a/support/build/extensions/no-debug-non-zts-20121212/newrelic
+++ b/support/build/extensions/no-debug-non-zts-20121212/newrelic
@@ -123,6 +123,6 @@ MANIFEST_REPLACE="${MANIFEST_REPLACE:-"{}"}"
 MANIFEST_PROVIDE="${MANIFEST_PROVIDE:-"{}"}"
 MANIFEST_EXTRA="${MANIFEST_EXTRA:-"{\"config\":\"etc/php/conf.d/newrelic.ini-dist\",\"profile\":\"bin/profile.newrelic.sh\"}"}"
 
-python $(dirname $BASH_SOURCE)/../../_util/include/manifest.py "heroku-sys-php-extension" "heroku-sys/ext-${dep_name}" "$dep_version" "${dep_formula}.tar.gz" "$MANIFEST_REQUIRE" "$MANIFEST_CONFLICT" "$MANIFEST_REPLACE" "$MANIFEST_PROVIDE" "$MANIFEST_EXTRA" > $dep_manifest
+python2 $(dirname $BASH_SOURCE)/../../_util/include/manifest.py "heroku-sys-php-extension" "heroku-sys/ext-${dep_name}" "$dep_version" "${dep_formula}.tar.gz" "$MANIFEST_REQUIRE" "$MANIFEST_CONFLICT" "$MANIFEST_REPLACE" "$MANIFEST_PROVIDE" "$MANIFEST_EXTRA" > $dep_manifest
 
 print_or_export_manifest_cmd "$(generate_manifest_cmd "$dep_manifest")"

--- a/support/build/extensions/no-debug-non-zts-20121212/phalcon
+++ b/support/build/extensions/no-debug-non-zts-20121212/phalcon
@@ -63,6 +63,6 @@ case "$dep_version" in
 esac
 MANIFEST_CONFLICT="${MANIFEST_CONFLICT:-"{\"heroku-sys/hhvm\":\"*\"}"}"
 
-python $(dirname $BASH_SOURCE)/../../_util/include/manifest.py "heroku-sys-php-extension" "heroku-sys/ext-${dep_name}" "$dep_version" "${dep_formula}.tar.gz" "$MANIFEST_REQUIRE" "$MANIFEST_CONFLICT" > $dep_manifest
+python2 $(dirname $BASH_SOURCE)/../../_util/include/manifest.py "heroku-sys-php-extension" "heroku-sys/ext-${dep_name}" "$dep_version" "${dep_formula}.tar.gz" "$MANIFEST_REQUIRE" "$MANIFEST_CONFLICT" > $dep_manifest
 
 print_or_export_manifest_cmd "$(generate_manifest_cmd "$dep_manifest")"

--- a/support/build/extensions/no-debug-non-zts-20151012/apcu
+++ b/support/build/extensions/no-debug-non-zts-20151012/apcu
@@ -74,6 +74,6 @@ MANIFEST_REPLACE="${MANIFEST_REPLACE:-"{\"heroku-sys/ext-apc\":\"self.version\"}
 MANIFEST_PROVIDE="${MANIFEST_PROVIDE:-"{}"}"
 MANIFEST_EXTRA="${MANIFEST_EXTRA:-"{\"config\":\"etc/php/conf.d/apcu-apc.ini-dist\"}"}"
 
-python $(dirname $BASH_SOURCE)/../../_util/include/manifest.py "heroku-sys-php-extension" "heroku-sys/ext-${dep_name}" "$dep_version" "${dep_formula}.tar.gz" "$MANIFEST_REQUIRE" "$MANIFEST_CONFLICT" "$MANIFEST_REPLACE" "$MANIFEST_PROVIDE" "$MANIFEST_EXTRA" > $dep_manifest
+python2 $(dirname $BASH_SOURCE)/../../_util/include/manifest.py "heroku-sys-php-extension" "heroku-sys/ext-${dep_name}" "$dep_version" "${dep_formula}.tar.gz" "$MANIFEST_REQUIRE" "$MANIFEST_CONFLICT" "$MANIFEST_REPLACE" "$MANIFEST_PROVIDE" "$MANIFEST_EXTRA" > $dep_manifest
 
 print_or_export_manifest_cmd "$(generate_manifest_cmd "$dep_manifest")"

--- a/support/build/extensions/pecl
+++ b/support/build/extensions/pecl
@@ -42,6 +42,6 @@ MANIFEST_REPLACE="${MANIFEST_REPLACE:-"{}"}"
 MANIFEST_PROVIDE="${MANIFEST_PROVIDE:-"{}"}"
 MANIFEST_EXTRA="${MANIFEST_EXTRA:-"{}"}"
 
-python $(dirname $BASH_SOURCE)/../_util/include/manifest.py "heroku-sys-php-extension" "heroku-sys/ext-${dep_name}" "$dep_version" "${dep_formula}.tar.gz" "$MANIFEST_REQUIRE" "$MANIFEST_CONFLICT" "$MANIFEST_REPLACE" "$MANIFEST_PROVIDE" "$MANIFEST_EXTRA" > $dep_manifest
+python2 $(dirname $BASH_SOURCE)/../_util/include/manifest.py "heroku-sys-php-extension" "heroku-sys/ext-${dep_name}" "$dep_version" "${dep_formula}.tar.gz" "$MANIFEST_REQUIRE" "$MANIFEST_CONFLICT" "$MANIFEST_REPLACE" "$MANIFEST_PROVIDE" "$MANIFEST_EXTRA" > $dep_manifest
 
 print_or_export_manifest_cmd "$(generate_manifest_cmd "$dep_manifest")"

--- a/support/build/hhvm
+++ b/support/build/hhvm
@@ -73,7 +73,7 @@ curl -sS https://getcomposer.org/installer | hhvm --php
 
 MANIFEST_REQUIRE="${MANIFEST_REQUIRE:-"{}"}"
 MANIFEST_CONFLICT="${MANIFEST_CONFLICT:-"{\"heroku-sys/php\":\"*\"}"}"
-MANIFEST_REPLACE=$(hhvm --php composer.phar show --platform | grep -E '^(ext-\S+|php-64bit\b|php\b)' | tr -s " " | cut -d " " -f1,2 | sed -e "s/ $dep_version\$/ self.version/" -e 's/^/heroku-sys\//' | python -c 'import sys, json; json.dump(dict(item.split() for item in sys.stdin), sys.stdout)')
+MANIFEST_REPLACE=$(hhvm --php composer.phar show --platform | grep -E '^(ext-\S+|php-64bit\b|php\b)' | tr -s " " | cut -d " " -f1,2 | sed -e "s/ $dep_version\$/ self.version/" -e 's/^/heroku-sys\//' | python2 -c 'import sys, json; json.dump(dict(item.split() for item in sys.stdin), sys.stdout)')
 MANIFEST_PROVIDE="${MANIFEST_PROVIDE:-"{}"}"
 MANIFEST_EXTRA="${MANIFEST_EXTRA:-"{\"export\":\"bin/export.hhvm.sh\",\"profile\":\"bin/profile.hhvm.sh\"}"}"
 
@@ -95,6 +95,6 @@ composer() { hhvm $(which composer) "$@"; }
 export -f composer
 EOF
 
-python $(dirname $BASH_SOURCE)/_util/include/manifest.py "heroku-sys-hhvm" "heroku-sys/${dep_name}" "$dep_version" "${dep_formula}.tar.gz" "$MANIFEST_REQUIRE" "$MANIFEST_CONFLICT" "$MANIFEST_REPLACE" "$MANIFEST_PROVIDE" "$MANIFEST_EXTRA" > $dep_manifest
+python2 $(dirname $BASH_SOURCE)/_util/include/manifest.py "heroku-sys-hhvm" "heroku-sys/${dep_name}" "$dep_version" "${dep_formula}.tar.gz" "$MANIFEST_REQUIRE" "$MANIFEST_CONFLICT" "$MANIFEST_REPLACE" "$MANIFEST_PROVIDE" "$MANIFEST_EXTRA" > $dep_manifest
 
 print_or_export_manifest_cmd "$(generate_manifest_cmd "$dep_manifest")"

--- a/support/build/libraries/libcassandra
+++ b/support/build/libraries/libcassandra
@@ -41,6 +41,6 @@ echo
 echo "ABI version is: ${ABI_VERSION}"
 echo
 
-python $(dirname $BASH_SOURCE)/../_util/include/manifest.py "heroku-sys-library" "heroku-sys/${dep_name}" "$dep_version" "${dep_formula}.tar.gz" "{}" "{}" "{}" "{\"heroku-sys/libcassandra-abi\":\"${ABI_VERSION}\"}" > $dep_manifest
+python2 $(dirname $BASH_SOURCE)/../_util/include/manifest.py "heroku-sys-library" "heroku-sys/${dep_name}" "$dep_version" "${dep_formula}.tar.gz" "{}" "{}" "{}" "{\"heroku-sys/libcassandra-abi\":\"${ABI_VERSION}\"}" > $dep_manifest
 
 print_or_export_manifest_cmd "$(generate_manifest_cmd "$dep_manifest")"

--- a/support/build/libraries/libmemcached
+++ b/support/build/libraries/libmemcached
@@ -61,6 +61,6 @@ echo
 echo "ABI version is: ${ABI_VERSION}"
 echo
 
-python $(dirname $BASH_SOURCE)/../_util/include/manifest.py "$type" "heroku-sys/${dep_name}" "$dep_version" "${dep_formula}.tar.gz" "{}" "{}" "{}" "{\"heroku-sys/libmemcached-abi\":\"${ABI_VERSION}\"}" > $dep_manifest
+python2 $(dirname $BASH_SOURCE)/../_util/include/manifest.py "$type" "heroku-sys/${dep_name}" "$dep_version" "${dep_formula}.tar.gz" "{}" "{}" "{}" "{\"heroku-sys/libmemcached-abi\":\"${ABI_VERSION}\"}" > $dep_manifest
 
 print_or_export_manifest_cmd "$(generate_manifest_cmd "$dep_manifest")"

--- a/support/build/libraries/librdkafka
+++ b/support/build/libraries/librdkafka
@@ -42,6 +42,6 @@ echo
 echo "ABI version is: ${ABI_VERSION}"
 echo
 
-python $(dirname $BASH_SOURCE)/../_util/include/manifest.py "heroku-sys-library" "heroku-sys/${dep_name}" "$dep_version" "${dep_formula}.tar.gz" "{}" "{}" "{}" "{\"heroku-sys/librdkafka-abi\":\"${ABI_VERSION}\"}" > $dep_manifest
+python2 $(dirname $BASH_SOURCE)/../_util/include/manifest.py "heroku-sys-library" "heroku-sys/${dep_name}" "$dep_version" "${dep_formula}.tar.gz" "{}" "{}" "{}" "{\"heroku-sys/librdkafka-abi\":\"${ABI_VERSION}\"}" > $dep_manifest
 
 print_or_export_manifest_cmd "$(generate_manifest_cmd "$dep_manifest")"

--- a/support/build/nginx
+++ b/support/build/nginx
@@ -69,6 +69,6 @@ cat > ${OUT_PREFIX}/bin/profile.nginx.sh <<'EOF'
 export PATH="$HOME/.heroku/php/sbin:$PATH"
 EOF
 
-python $(dirname $BASH_SOURCE)/_util/include/manifest.py "heroku-sys-webserver" "heroku-sys/${dep_name}" "$dep_version" "${dep_formula}.tar.gz" "$MANIFEST_REQUIRE" "$MANIFEST_CONFLICT" "$MANIFEST_REPLACE" "$MANIFEST_PROVIDE" "$MANIFEST_EXTRA" > $dep_manifest
+python2 $(dirname $BASH_SOURCE)/_util/include/manifest.py "heroku-sys-webserver" "heroku-sys/${dep_name}" "$dep_version" "${dep_formula}.tar.gz" "$MANIFEST_REQUIRE" "$MANIFEST_CONFLICT" "$MANIFEST_REPLACE" "$MANIFEST_PROVIDE" "$MANIFEST_EXTRA" > $dep_manifest
 
 print_or_export_manifest_cmd "$(generate_manifest_cmd "$dep_manifest")"

--- a/support/build/php
+++ b/support/build/php
@@ -208,11 +208,11 @@ for f in ${OUT_PREFIX}/lib/php/extensions/*/*.so; do
 	echo "extension=$(basename $f)" >> ${OUT_PREFIX}/etc/php/php.ini
 done
 
-extra=$(echo "${shared[@]}" | python -c 'import sys, json; json.dump({"shared": dict([item.split(":") if ":" in item else (item, True) for item in sys.stdin.read().split()]), "export": "bin/export.php.sh", "profile": "bin/profile.php.sh"}, sys.stdout)')
+extra=$(echo "${shared[@]}" | python2 -c 'import sys, json; json.dump({"shared": dict([item.split(":") if ":" in item else (item, True) for item in sys.stdin.read().split()]), "export": "bin/export.php.sh", "profile": "bin/profile.php.sh"}, sys.stdout)')
 
 MANIFEST_REQUIRE="${MANIFEST_REQUIRE:-"{}"}"
 MANIFEST_CONFLICT="${MANIFEST_CONFLICT:-"{\"heroku-sys/hhvm\":\"*\"}"}"
-MANIFEST_REPLACE=$(php composer.phar show --platform | grep -E '^(ext-\S+|php-64bit\b|hhvm\b)' | tr -s " " | cut -d " " -f1,2 | sed -e "s/ $dep_version\$/ self.version/" -e 's/^/heroku-sys\//' | python -c 'import sys, json; json.dump(dict(item.split() for item in sys.stdin), sys.stdout)')
+MANIFEST_REPLACE=$(php composer.phar show --platform | grep -E '^(ext-\S+|php-64bit\b|hhvm\b)' | tr -s " " | cut -d " " -f1,2 | sed -e "s/ $dep_version\$/ self.version/" -e 's/^/heroku-sys\//' | python2 -c 'import sys, json; json.dump(dict(item.split() for item in sys.stdin), sys.stdout)')
 MANIFEST_PROVIDE="${MANIFEST_PROVIDE:-"{}"}"
 MANIFEST_EXTRA="${MANIFEST_EXTRA:-"$extra"}"
 
@@ -261,6 +261,6 @@ fi
 
 EOF
 
-python $(dirname $BASH_SOURCE)/_util/include/manifest.py "heroku-sys-php" "heroku-sys/${dep_name}" "$dep_version" "${dep_formula}.tar.gz" "$MANIFEST_REQUIRE" "$MANIFEST_CONFLICT" "$MANIFEST_REPLACE" "$MANIFEST_PROVIDE" "$MANIFEST_EXTRA" > $dep_manifest
+python2 $(dirname $BASH_SOURCE)/_util/include/manifest.py "heroku-sys-php" "heroku-sys/${dep_name}" "$dep_version" "${dep_formula}.tar.gz" "$MANIFEST_REQUIRE" "$MANIFEST_CONFLICT" "$MANIFEST_REPLACE" "$MANIFEST_PROVIDE" "$MANIFEST_EXTRA" > $dep_manifest
 
 print_or_export_manifest_cmd "$(generate_manifest_cmd "$dep_manifest")"

--- a/support/build/php-min
+++ b/support/build/php-min
@@ -62,6 +62,6 @@ popd
 echo "-----> Stripping..."
 strip ${OUT_PREFIX}/bin/php
 
-python $(dirname $BASH_SOURCE)/_util/include/manifest.py "heroku-sys-package" "heroku-sys/pkg-${dep_name}" "$dep_version" "${dep_formula}.tar.gz" > $dep_manifest
+python2 $(dirname $BASH_SOURCE)/_util/include/manifest.py "heroku-sys-package" "heroku-sys/pkg-${dep_name}" "$dep_version" "${dep_formula}.tar.gz" > $dep_manifest
 
 print_or_export_manifest_cmd "$(generate_manifest_cmd "$dep_manifest")"


### PR DESCRIPTION
Historically the Ubuntu `python2.7` package has symlinked `python` to `python2`. However starting in Ubuntu 20.04, this symlink is no longer created, and one must explicitly call `python2` (or `python3`) instead.

Unfortunately we cannot just `s/python/python2/` throughout, since this buildpack aims to also support OS X for local development workflows, and on OS X system Python (which is Python 2) is only available as `python` and not also as `python2`. Whilst homebrew Python does have `python{2,3}` binaries, we don't want to require use of it.

As such, for the scripts that may be run locally (`bin/heroku_*`), they must now check for the presence of either `python2` or `python`. 

This change is a no-op for current stacks, but is landing now to reduce the size of the Heroku-20 support PR.

In the future we'll want to convert these usages to Python 3, however we are explicitly not doing so for now, since:
* this work is holding up the Heroku-20 release, and a no-op change is safer to land quickly than changing to start using Python 3 for the first time
* Python 3 is not available out of the box on OS X, so we'd still have to use Python 2 there, which would mean needing to test against multiple Python versions in CI to ensure continued Python 2 compatibility
* all current stacks using the same version of Python 2 (2.7) but for Python 3 their version differs (3.4 on cedar-14, 3.5 on heroku-16, 3.6 on heroku-18 and 3.7 on heroku-20)

Refs [W-7491249](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008NqBgIAK/view).