### PR TITLE
Add support for Heroku-20

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,13 @@ matrix:
         if: branch = master OR tag IS present
       - env: STACK=heroku-18
         if: branch = master OR tag IS present
+      - env: STACK=heroku-20
+        if: branch = master OR tag IS present
       - env: STACK=cedar-14 HEROKU_PHP_PLATFORM_REPOSITORIES="- https://lang-php.s3.amazonaws.com/dist-cedar-14-develop/"
         if: branch != master AND tag IS blank
       - env: STACK=heroku-16 HEROKU_PHP_PLATFORM_REPOSITORIES="- https://lang-php.s3.amazonaws.com/dist-heroku-16-develop/"
         if: branch != master AND tag IS blank
       - env: STACK=heroku-18 HEROKU_PHP_PLATFORM_REPOSITORIES="- https://lang-php.s3.amazonaws.com/dist-heroku-18-develop/"
+        if: branch != master AND tag IS blank
+      - env: STACK=heroku-20 HEROKU_PHP_PLATFORM_REPOSITORIES="- https://lang-php.s3.amazonaws.com/dist-heroku-20-develop/"
         if: branch != master AND tag IS blank

--- a/bin/compile
+++ b/bin/compile
@@ -471,9 +471,9 @@ else
 		they are available on your app's stack ($STACK), and select
 		a different stack if needed after consulting the article below.
 		$(
-			[[ "$STACK" == "heroku-18" ]] && cat <<-EOF2
+			[[ "$STACK" == "heroku-18" || "$STACK" == "heroku-20" ]] && cat <<-EOF2
 				$(echo -e "\033[1;33m")
-				Be advised that the heroku-18 stack you're currently using only
+				Be advised that the $STACK stack you're currently using only
 				supports PHP version 7.1 and later.
 				$(echo -e "\033[1;31m")
 			EOF2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-bob-builder>=0.0.15
-s3cmd>=1.6.0
+bob-builder>=0.0.18
+s3cmd>=2.1.0

--- a/support/build/README.md
+++ b/support/build/README.md
@@ -157,7 +157,7 @@ The following environment variables are required:
 - `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` with credentials for the S3 bucket
 - `S3_BUCKET` with the name of the S3 bucket to use for builds
 - `S3_PREFIX` (just a slash, or a prefix directory name **with a trailing, but no leading, slash**)
-- `STACK` (currently, only "`cedar-14`", "`heroku-16`" or "`heroku-18`" make any sense)
+- `STACK` (currently, only "`cedar-14`", "`heroku-16`", "`heroku-18`" or "`heroku-20`" make any sense)
 
 The following environment variables are highly recommended (see section *Understanding Upstream Buckets*):
 
@@ -166,6 +166,7 @@ The following environment variables are highly recommended (see section *Underst
   - "`dist-cedar-14-stable/`", the official Heroku stable repository prefix for the [cedar-14 stack](https://devcenter.heroku.com/articles/stack).
   - "`dist-heroku-16-stable/`", the official Heroku stable repository prefix for the [heroku-16 stack](https://devcenter.heroku.com/articles/stack).
   - "`dist-heroku-18-stable/`", the official Heroku stable repository prefix for the [heroku-18 stack](https://devcenter.heroku.com/articles/stack).
+  - "`dist-heroku-20-stable/`", the official Heroku stable repository prefix for the [heroku-20 stack](https://devcenter.heroku.com/articles/stack).
 
 The following environment variables are optional:
 
@@ -313,7 +314,7 @@ The `require` key must contain dependencies on at least the following packages:
 
 If a package is built against a specific (or multiple) stacks, there must be a dependency on the following packages:
 
-- `heroku-sys/heroku`, version "16" for `heroku-16` or version "18" for `heroku-18` (use version selectors `^16.0.0` or `^18.0.0`, or a valid Composer combination)
+- `heroku-sys/heroku`, version "16" for `heroku-16`, "18" for `heroku-18` and "20" for `heroku-20` (use version selectors `^16.0.0`, `^18.0.0` or `^20.0.0`, or a valid Composer combination)
 
 *Example: `curl -s https://lang-php.s3.amazonaws.com/dist-heroku-18-stable/packages.json | jq '[ .packages[][] | select(.type == "heroku-sys-php") ][0] | {require}'`*
 
@@ -563,7 +564,7 @@ Unless the `--no-publish` option is given, the repository will be re-generated i
 
 In this example, you will fork the buildpack and add your own formula to it. **The fork is only used for building the package and publishing the repository, it is not used to build and run applications.**
 
-Both the `heroku-16` and the `heroku-18` stack variants of the package will be hosted in the same repository.
+All of the `heroku-16`, `heroku-18` and `heroku-20` stack variants of the package will be hosted in the same repository.
 
 A development and a stable S3 bucket prefix are used for the repository, and helpers are used for synchronization between them.
 
@@ -602,6 +603,7 @@ The versions in the example above may have to be updated to reflect newer releas
 
 Finally, build the containers for each stack:
 
+    $ docker build --pull --tag heroku-php-build-heroku-20 --file $(pwd)/support/build/_docker/heroku-20.Dockerfile .
     $ docker build --pull --tag heroku-php-build-heroku-18 --file $(pwd)/support/build/_docker/heroku-18.Dockerfile .
     $ docker build --pull --tag heroku-php-build-heroku-16 --file $(pwd)/support/build/_docker/heroku-16.Dockerfile .
 
@@ -609,17 +611,19 @@ Finally, build the containers for each stack:
 
 Verify that the build works:
 
+    $ docker run --rm -ti --env-file=../heroku-php-s3.dockerenv heroku-php-build-heroku-20 bob build nginx-1.15.4
     $ docker run --rm -ti --env-file=../heroku-php-s3.dockerenv heroku-php-build-heroku-18 bob build nginx-1.15.4
     $ docker run --rm -ti --env-file=../heroku-php-s3.dockerenv heroku-php-build-heroku-16 bob build nginx-1.15.4
 
 If all went well, deploy it using the helper script:
 
+    $ docker run --rm -ti --env-file=../heroku-php-s3.dockerenv heroku-php-build-heroku-20 deploy.sh nginx-1.15.4
     $ docker run --rm -ti --env-file=../heroku-php-s3.dockerenv heroku-php-build-heroku-18 deploy.sh nginx-1.15.4
     $ docker run --rm -ti --env-file=../heroku-php-s3.dockerenv heroku-php-build-heroku-16 deploy.sh nginx-1.15.4
 
 #### Repository Creation
 
-From the two manifests that are now in your S3 bucket, make a repository:
+From the three manifests that are now in your S3 bucket, make a repository:
 
     $ docker run --rm -ti --env-file=../heroku-php-s3.dockerenv heroku-php-build-heroku-18 mkrepo.sh --upload
 
@@ -645,7 +649,7 @@ You can then use that repository:
 
 The Heroku PHP buildpack will be pulled in as a Composer dependency. Its build `Dockerfile`s are built and tagged locally, and a custom `Dockerfile` for each targeted stack builds upon those tagged images.
 
-Both the `heroku-16` and the `heroku-18` stack variants of the package will be hosted in the same repository.
+All of the `heroku-16`, `heroku-18` and `heroku-20` stack variants of the package will be hosted in the same repository.
 
 The package in this example is the Xdebug extension. The extension formula can re-use an existing buildpack base formula for PECL extensions.
 
@@ -663,14 +667,23 @@ Pull in the buildpack as a Composer dependency:
 
     $ composer require heroku/heroku-buildpack-php:*
 
-Build the base Docker images from the buildpack for stacks `heroku-16` and `heroku-18`:
+Build the base Docker images from the buildpack each stack:
 
     $ cd vendor/heroku/heroku-buildpack-php
+    $ docker build --pull --tag php-heroku-20 --file $(pwd)/support/build/_docker/heroku-20.Dockerfile .
     $ docker build --pull --tag php-heroku-18 --file $(pwd)/support/build/_docker/heroku-18.Dockerfile .
     $ docker build --pull --tag php-heroku-16 --file $(pwd)/support/build/_docker/heroku-16.Dockerfile .
     $ cd -
 
 #### Creating Custom Dockerfiles
+
+Create a `heroku-20.Dockerfile` with the following contents:
+
+    FROM formulatest-heroku-20:latest
+    ENV WORKSPACE_DIR=/app
+    ENV UPSTREAM_S3_BUCKET=lang-php
+    ENV UPSTREAM_S3_PREFIX=dist-heroku-20-stable/
+    COPY . /app
 
 Create a `heroku-18.Dockerfile` with the following contents:
 
@@ -717,6 +730,7 @@ The `php-7.3.*` dependency will not be found in the current S3 bucket and prefix
 
 Build one Docker image for each stack:
 
+    $ docker build --tag xdebug-heroku-20 --file heroku-20.Dockerfile .
     $ docker build --tag xdebug-heroku-18 --file heroku-18.Dockerfile .
     $ docker build --tag xdebug-heroku-16 --file heroku-16.Dockerfile .
 
@@ -724,11 +738,13 @@ Build one Docker image for each stack:
 
 Verify that the build works by building a specific formula for a specific PHP version:
 
+    $ docker run --rm -ti --env-file=../heroku-php-s3.dockerenv xdebug-heroku-20 bob build php-7.3/xdebug-2.7.0
     $ docker run --rm -ti --env-file=../heroku-php-s3.dockerenv xdebug-heroku-18 bob build php-7.3/xdebug-2.7.0
     $ docker run --rm -ti --env-file=../heroku-php-s3.dockerenv xdebug-heroku-16 bob build php-7.3/xdebug-2.7.0
 
 If all went well, deploy it using the helper script:
 
+    $ docker run --rm -ti --env-file=../heroku-php-s3.dockerenv xdebug-heroku-20 deploy.sh php-7.3/xdebug-2.7.0
     $ docker run --rm -ti --env-file=../heroku-php-s3.dockerenv xdebug-heroku-18 deploy.sh php-7.3/xdebug-2.7.0
     $ docker run --rm -ti --env-file=../heroku-php-s3.dockerenv xdebug-heroku-16 deploy.sh php-7.3/xdebug-2.7.0
 

--- a/support/build/_docker/README.md
+++ b/support/build/_docker/README.md
@@ -7,6 +7,7 @@
     $ docker build --pull --tag heroku-php-build-cedar-14 --file $(pwd)/support/build/_docker/cedar-14.Dockerfile .
     $ docker build --pull --tag heroku-php-build-heroku-16 --file $(pwd)/support/build/_docker/heroku-16.Dockerfile .
     $ docker build --pull --tag heroku-php-build-heroku-18 --file $(pwd)/support/build/_docker/heroku-18.Dockerfile .
+    $ docker build --pull --tag heroku-php-build-heroku-20 --file $(pwd)/support/build/_docker/heroku-20.Dockerfile .
 
 ## Configuration
 
@@ -21,6 +22,7 @@ From the root of the Git repository (not from `support/build/_docker/`), you can
     docker run --rm -ti heroku-php-build-cedar-14 bash
     docker run --rm -ti heroku-php-build-heroku-16 bash
     docker run --rm -ti heroku-php-build-heroku-18 bash
+    docker run --rm -ti heroku-php-build-heroku-20 bash
 
 You then have a shell where you can run `bob build`, `deploy.sh` and so forth. You can of course also invoke these programs directly with `docker run`.
 

--- a/support/build/_docker/heroku-20.Dockerfile
+++ b/support/build/_docker/heroku-20.Dockerfile
@@ -1,0 +1,18 @@
+FROM heroku/heroku:20-build.v27
+
+WORKDIR /app
+ENV WORKSPACE_DIR=/app/support/build
+ENV PATH=/app/support/build/_util:$PATH
+ENV S3_BUCKET=lang-php
+ENV S3_PREFIX=dist-heroku-20-develop/
+ENV S3_REGION=s3
+ENV STACK=heroku-20
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends python3-pip
+
+COPY requirements.txt /app/requirements.txt
+
+RUN pip3 install -r /app/requirements.txt
+
+COPY . /app

--- a/support/build/php
+++ b/support/build/php
@@ -51,11 +51,16 @@ elif [[ $STACK == "heroku-16" ]]; then
 	needed+=( libonig2 )
 	needed+=( libsodium18 )
 	needed+=( libzip4 )
-else
+elif [[ $STACK == "heroku-18" ]]; then
 	needed+=( libicu60 )
 	needed+=( libonig4 )
 	needed+=( libsodium23 )
 	needed+=( libzip4 )
+else
+	needed+=( libicu66 )
+	needed+=( libonig5 )
+	needed+=( libsodium23 )
+	needed+=( libzip5 )
 fi
 if [[ $dep_version == 5.* || $dep_version == 7.[0-1].* ]]; then
 	needed+=( libmcrypt4 )

--- a/test/var/log/parallel_runtime_rspec.heroku-20.log
+++ b/test/var/log/parallel_runtime_rspec.heroku-20.log
@@ -1,0 +1,9 @@
+test/spec/bugs_spec.rb:21.392229270999998
+test/spec/ci_spec.rb:290.153758084
+test/spec/nginx_spec.rb:18.944300572999992
+test/spec/php_7.1_spec.rb:538.2099019990001
+test/spec/php_7.2_spec.rb:536.272335398
+test/spec/php_7.3_spec.rb:554.4528700789999
+test/spec/php_7.4_spec.rb:718.0634715900001
+test/spec/php_default_spec.rb:38.073168747000004
+test/spec/sigterm_spec.rb:53.837582215000005


### PR DESCRIPTION
This adds support for generating binaries for the upcoming Heroku-20 stack, and testing them in CI.

The upgrade of `bob-builder` is to pick up Python 3 fixes, so that it can be run using Python 3 inside the `support/build/_docker/heroku-20.Dockerfile` image.

Before CI will pass:
* #404 will need to be merged, and this rebased on top of it
* the binaries will need to be built/uploaded using the steps here:
  https://github.com/heroku/heroku-buildpack-php/blob/master/support/build/README.md

Refs [W-7491249](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008NqBgIAK/view).