### PR TITLE
[changelog skip] Hatchet v7.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem 'heroku_hatchet', "~> 6.0"
+gem 'heroku_hatchet', "~> 7.0"
 gem 'rspec-retry'
 gem 'rspec-expectations'
 gem 'sem_version'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,44 +1,31 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.0.3.2)
-      concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (>= 0.7, < 2)
-      minitest (~> 5.1)
-      tzinfo (~> 1.1)
-      zeitwerk (~> 2.2, >= 2.2.2)
-    concurrent-ruby (1.1.6)
     diff-lcs (1.4.4)
     erubis (2.7.0)
-    excon (0.75.0)
+    excon (0.76.0)
     heroics (0.1.1)
       erubis (~> 2.0)
       excon
       moneta
       multi_json (>= 1.9.2)
-    heroku_hatchet (6.0.0)
+    heroku_hatchet (7.0.0)
       excon (~> 0)
-      platform-api (= 3.0.0.pre.1)
-      repl_runner (~> 0.0.3)
+      platform-api (~> 3)
       rrrretry (~> 1)
       thor (~> 0)
       threaded (~> 0)
-    i18n (1.8.3)
-      concurrent-ruby (~> 1.0)
-    minitest (5.14.1)
     moneta (1.0.0)
-    multi_json (1.14.1)
+    multi_json (1.15.0)
     parallel (1.19.2)
     parallel_tests (3.0.0)
       parallel
-    platform-api (3.0.0.pre.1)
+    platform-api (3.0.0)
       heroics (~> 0.1.1)
       moneta (~> 1.0.0)
       rate_throttle_client (~> 0.1.0)
     rake (13.0.1)
     rate_throttle_client (0.1.2)
-    repl_runner (0.0.3)
-      activesupport
     rrrretry (1.0.0)
     rspec-core (3.9.2)
       rspec-support (~> 3.9.3)
@@ -50,17 +37,13 @@ GEM
     rspec-support (3.9.3)
     sem_version (2.0.1)
     thor (0.20.3)
-    thread_safe (0.3.6)
     threaded (0.0.4)
-    tzinfo (1.2.7)
-      thread_safe (~> 0.1)
-    zeitwerk (2.3.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  heroku_hatchet (~> 6.0)
+  heroku_hatchet (~> 7.0)
   parallel_tests
   rake
   rspec-expectations
@@ -68,4 +51,4 @@ DEPENDENCIES
   sem_version
 
 BUNDLED WITH
-   1.16.1
+   1.17.3

--- a/test/spec/spec_helper.rb
+++ b/test/spec/spec_helper.rb
@@ -24,7 +24,6 @@ RSpec.configure do |config|
 	
 	config.verbose_retry       = true # show retry status in spec process
 	config.default_retry_count = 2 if ENV['IS_RUNNING_ON_CI'] # retry all tests that fail again...
-	config.exceptions_to_retry = [Excon::Errors::Timeout] #... if they're caused by these exception types
 	config.fail_fast = 1 if ENV['IS_RUNNING_ON_CI']
 	
 	config.expect_with :rspec do |c|

--- a/test/spec/spec_helper.rb
+++ b/test/spec/spec_helper.rb
@@ -21,18 +21,18 @@ RSpec.configure do |config|
 	config.alias_example_to :fit, focused: true
 	config.filter_run_excluding :requires_php_on_stack => lambda { |series| !php_on_stack?(series) }
 	config.filter_run_excluding :stack => lambda { |stack| ENV['STACK'] != stack }
-	
+
 	config.verbose_retry       = true # show retry status in spec process
 	config.default_retry_count = 2 if ENV['IS_RUNNING_ON_CI'] # retry all tests that fail again...
 	config.fail_fast = 1 if ENV['IS_RUNNING_ON_CI']
-	
+
 	config.expect_with :rspec do |c|
 		c.syntax = :expect
 	end
 end
 
 def successful_body(app, options = {})
-	retry_limit = options[:retry_limit] || 100 
+	retry_limit = options[:retry_limit] || 100
 	path = options[:path] ? "/#{options[:path]}" : ''
 	Excon.get("http://#{app.name}.herokuapp.com#{path}", :idempotent => true, :expects => 200, :retry_limit => retry_limit).body
 end


### PR DESCRIPTION
- ActiveSupport's Object#blank? and Object#present? are no longer provided by default (https://github.com/heroku/hatchet/pull/107)
- Remove deprecated support for passing a block to `App#run` (https://github.com/heroku/hatchet/pull/105)
- Ignore  403 on app delete due to race condition (https://github.com/heroku/hatchet/pull/101)
- The hatchet.lock file can now be locked to "main" in addition to "master" (https://github.com/heroku/hatchet/pull/86)
- Allow concurrent one-off dyno runs with the `run_multi: true` flag on apps (https://github.com/heroku/hatchet/pull/94)
- Apps are now marked as being "finished" by enabling maintenance mode on them when `teardown!` is called. Finished apps can be reaped immediately (https://github.com/heroku/hatchet/pull/97)
- Applications that are not marked as "finished" will be allowed to live for a HATCHET_ALIVE_TTL_MINUTES duration before they're deleted by the reaper to protect against deleting an app mid-deploy, default is seven minutes (https://github.com/heroku/hatchet/pull/97)
- The HEROKU_APP_LIMIT env var no longer does anything, instead hatchet application reaping is manually executed if an app cannot be created (https://github.com/heroku/hatchet/pull/97)
- App#deploy without a block will no longer run `teardown!` automatically (https://github.com/heroku/hatchet/pull/97)
- Calls to `git push heroku` are now rate throttled (https://github.com/heroku/hatchet/pull/98)
- Calls to `app.run` are now rate throttled (https://github.com/heroku/hatchet/pull/99)
- Deployment now raises and error when the release failed (https://github.com/heroku/hatchet/pull/93)