### PR TITLE
Update Travis badge in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Heroku buildpack: PHP [![Build Status](https://travis-ci.org/heroku/heroku-buildpack-php.svg?branch=main)](https://travis-ci.org/heroku/heroku-buildpack-php)
+# Heroku buildpack: PHP [![Build Status](https://travis-ci.com/heroku/heroku-buildpack-php.svg?branch=main)](https://travis-ci.com/heroku/heroku-buildpack-php)
 
 ![php](https://cloud.githubusercontent.com/assets/51578/8882982/73ea501a-3219-11e5-8f87-311e6b8a86fc.jpg)
 


### PR DESCRIPTION
Travis migrated open source projects to their .com domain some time ago, causing the badge link in the README to be outdated. It's not broken but requires an additional click to get to the test repo on Travis.

For reference: https://docs.travis-ci.com/user/migrate/open-source-on-travis-ci-com/