### PR TITLE
Fix test flappiness

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ env:
   - HATCHET_RETRIES=3
   - IS_RUNNING_ON_CI=true
   - HATCHET_APP_LIMIT=200
+  - HATCHET_EXPENSIVE_MODE=1
   - HATCHET_DEPLOY_STRATEGY=git
   - HATCHET_BUILDPACK_BASE="https://github.com/heroku/heroku-buildpack-php"
   - HATCHET_APP_PREFIX="htcht-${TRAVIS_JOB_ID}-"

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,7 @@ env:
   global:
   - HATCHET_RETRIES=3
   - IS_RUNNING_ON_CI=true
-  - HATCHET_APP_LIMIT=80
-  - HEROKU_APP_LIMIT=9999
+  - HATCHET_APP_LIMIT=200
   - HATCHET_DEPLOY_STRATEGY=git
   - HATCHET_BUILDPACK_BASE="https://github.com/heroku/heroku-buildpack-php"
   - HATCHET_APP_PREFIX="htcht-${TRAVIS_JOB_ID}-"

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem 'heroku_hatchet', "~> 6.0"
+gem 'heroku_hatchet', "~> 7.0"
 gem 'rspec-retry'
 gem 'rspec-expectations'
 gem 'sem_version'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,44 +1,31 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.0.3.2)
-      concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (>= 0.7, < 2)
-      minitest (~> 5.1)
-      tzinfo (~> 1.1)
-      zeitwerk (~> 2.2, >= 2.2.2)
-    concurrent-ruby (1.1.6)
     diff-lcs (1.4.4)
     erubis (2.7.0)
-    excon (0.75.0)
+    excon (0.76.0)
     heroics (0.1.1)
       erubis (~> 2.0)
       excon
       moneta
       multi_json (>= 1.9.2)
-    heroku_hatchet (6.0.0)
+    heroku_hatchet (7.1.3)
       excon (~> 0)
-      platform-api (= 3.0.0.pre.1)
-      repl_runner (~> 0.0.3)
+      platform-api (~> 3)
       rrrretry (~> 1)
       thor (~> 0)
       threaded (~> 0)
-    i18n (1.8.3)
-      concurrent-ruby (~> 1.0)
-    minitest (5.14.1)
     moneta (1.0.0)
-    multi_json (1.14.1)
+    multi_json (1.15.0)
     parallel (1.19.2)
-    parallel_tests (3.0.0)
+    parallel_tests (3.2.0)
       parallel
-    platform-api (3.0.0.pre.1)
+    platform-api (3.0.0)
       heroics (~> 0.1.1)
       moneta (~> 1.0.0)
       rate_throttle_client (~> 0.1.0)
     rake (13.0.1)
     rate_throttle_client (0.1.2)
-    repl_runner (0.0.3)
-      activesupport
     rrrretry (1.0.0)
     rspec-core (3.9.2)
       rspec-support (~> 3.9.3)
@@ -50,17 +37,13 @@ GEM
     rspec-support (3.9.3)
     sem_version (2.0.1)
     thor (0.20.3)
-    thread_safe (0.3.6)
     threaded (0.0.4)
-    tzinfo (1.2.7)
-      thread_safe (~> 0.1)
-    zeitwerk (2.3.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  heroku_hatchet (~> 6.0)
+  heroku_hatchet (~> 7.0)
   parallel_tests
   rake
   rspec-expectations
@@ -68,4 +51,4 @@ DEPENDENCIES
   sem_version
 
 BUNDLED WITH
-   1.16.1
+   1.17.3

--- a/test/spec/php_shared.rb
+++ b/test/spec/php_shared.rb
@@ -128,6 +128,9 @@ shared_examples "A PHP application with a composer.json" do |series|
 			0 => [
 				"heroku-php-apache2"
 			],
+			'--verbose' => [
+				true
+			],
 			'-C' => [
 				nil,
 				"conf/apache2.server.include.conf",
@@ -149,6 +152,9 @@ shared_examples "A PHP application with a composer.json" do |series|
 		"nginx" => {
 			0 => [
 				"heroku-php-nginx"
+			],
+			'--verbose' => [
+				true
 			],
 			'-C' => [
 				nil,
@@ -208,24 +214,24 @@ shared_examples "A PHP application with a composer.json" do |series|
 			
 			# we don't want to test all possible combinations of all arguments, as that'd be thousands
 			interesting = Array.new
-			interesting << [0, 1] # with and without document root
-			interesting << [0, '-C']
-			interesting << [0, '-F']
+			interesting << [0, '--verbose', 1] # with and without document root
+			interesting << [0, '--verbose', '-C']
+			interesting << [0, '--verbose', '-F']
 			combinations = interesting.map {|v| genmatrix(matrix, v)}.flatten(1).uniq
 			# # a few more "manual" cases
-			combinations << {0 => "heroku-php-#{server}", "-C" => "conf/#{server}.server.include.conf", "-F" => "conf/fpm.include.conf"}
+			combinations << {0 => "heroku-php-#{server}", "--verbose" => true, "-C" => "conf/#{server}.server.include.conf", "-F" => "conf/fpm.include.conf"}
 			combinations.each do | combination |
 				cmd = gencmd(combination)
 				context "launching using `#{cmd}'" do
 					if combination.value?(false) or cmd.match("broken")
 						it "does not boot" do
 							# check if "timeout" exited with a status other than 124, which means the process exited (due to the expected error) before "timeout" stepped in after the given duration (five seconds) and terminated it
-							expect_exit(expect: :not_to, code: 124) { @app.run("timeout 5 #{cmd}") }
+							expect_exit(expect: :not_to, code: 124) { @app.run("timeout 15 #{cmd}") }
 						end
 					else
 						it "boots" do
-							# check if "timeout" exited with status 124, which means the process was still alive after the given duration (five seconds) and "timeout" terminated it as a result
-							expect_exit(expect: :to, code: 124) { @app.run("timeout 5 #{cmd}") }
+							# check if "waitforit" exited with status 0, which means the process successfully output the expected message
+							expect_exit(expect: :to, code: 0) { @app.run("./waitforit.sh 15 'ready for connections' #{cmd}") }
 						end
 					end
 				end
@@ -233,29 +239,29 @@ shared_examples "A PHP application with a composer.json" do |series|
 			
 			context "launching using too many arguments" do
 				it "fails to boot" do
-					expect_exit(expect: :not_to, code: 124) { @app.run("timeout 5 heroku-php-#{server} docroot/ anotherarg") }
+					expect_exit(expect: :to, code: 2) { @app.run("timeout 10 heroku-php-#{server} docroot/ anotherarg") }
 				end
 			end
 			
 			context "launching using unknown options" do
 				it "fails to boot" do
-					expect_exit(expect: :not_to, code: 124) { @app.run("timeout 5 heroku-php-#{server} --what -u erp") }
+					expect_exit(expect: :to, code: 2) { @app.run("timeout 10 heroku-php-#{server} --what -u erp") }
 				end
 			end
 			
 			context "setting concurrency via .user.ini memory_limit" do
 				it "calculates concurrency correctly" do
-					expect(expect_exit(code: 124) { @app.run("timeout 5 heroku-php-#{server} docroot/") })
+					expect(expect_exit(code: 0) { @app.run("./waitforit.sh 15 'ready for connections' heroku-php-#{server} --verbose docroot/") })
 						 .to match("PHP memory_limit is 32M Bytes")
 						.and match("Starting php-fpm with 16 workers...")
 				end
 				it "always launches at least one worker" do
-					expect(expect_exit(code: 124) { @app.run("timeout 5 heroku-php-#{server} docroot/onegig/") })
+					expect(expect_exit(code: 0) { @app.run("./waitforit.sh 15 'ready for connections' heroku-php-#{server} --verbose docroot/onegig/") })
 						 .to match("PHP memory_limit is 1024M Bytes")
 						.and match("Starting php-fpm with 1 workers...")
 				end
 				it "is only done for a .user.ini directly in the document root" do
-					expect(expect_exit(code: 124) { @app.run("timeout 5 heroku-php-#{server}") })
+					expect(expect_exit(code: 0) { @app.run("./waitforit.sh 15 'ready for connections' heroku-php-#{server} --verbose") })
 						 .to match("PHP memory_limit is 128M Bytes")
 						.and match("Starting php-fpm with 4 workers...")
 				end
@@ -263,17 +269,17 @@ shared_examples "A PHP application with a composer.json" do |series|
 			
 			context "setting concurrency via FPM config memory_limit" do
 				it "calculates concurrency correctly" do
-					expect(expect_exit(code: 124) { @app.run("timeout 5 heroku-php-#{server} -F conf/fpm.include.conf") })
+					expect(expect_exit(code: 0) { @app.run("./waitforit.sh 15 'ready for connections' heroku-php-#{server} --verbose -F conf/fpm.include.conf") })
 						 .to match("PHP memory_limit is 32M Bytes")
 						.and match("Starting php-fpm with 16 workers...")
 				end
 				it "always launches at least one worker" do
-					expect(expect_exit(code: 124) { @app.run("timeout 5 heroku-php-#{server} -F conf/fpm.onegig.conf") })
+					expect(expect_exit(code: 0) { @app.run("./waitforit.sh 15 'ready for connections' heroku-php-#{server} --verbose -F conf/fpm.onegig.conf") })
 						 .to match("PHP memory_limit is 1024M Bytes")
 						.and match("Starting php-fpm with 1 workers...")
 				end
 				it "takes precedence over a .user.ini memory_limit" do
-					expect(expect_exit(code: 124) { @app.run("timeout 5 heroku-php-#{server} -F conf/fpm.include.conf docroot/onegig/") })
+					expect(expect_exit(code: 0) { @app.run("./waitforit.sh 15 'ready for connections' heroku-php-#{server} --verbose -F conf/fpm.include.conf docroot/onegig/") })
 						 .to match("PHP memory_limit is 32M Bytes")
 						.and match("Starting php-fpm with 16 workers...")
 				end
@@ -281,17 +287,17 @@ shared_examples "A PHP application with a composer.json" do |series|
 			
 			context "setting WEB_CONCURRENCY explicitly" do
 				it "uses the explicit value" do
-					expect(expect_exit(code: 124) { @app.run("timeout 5 heroku-php-#{server}", :heroku => {:env => "WEB_CONCURRENCY=22"}) })
+					expect(expect_exit(code: 0) { @app.run("./waitforit.sh 15 'ready for connections' heroku-php-#{server} --verbose", :heroku => {:env => "WEB_CONCURRENCY=22"}) })
 						 .to match("\\$WEB_CONCURRENCY env var is set, skipping automatic calculation")
 						.and match("Starting php-fpm with 22 workers...")
 				end
 				it "overrides a .user.ini memory_limit" do
-					expect(expect_exit(code: 124) { @app.run("timeout 5 heroku-php-#{server} docroot/onegig/", :heroku => {:env => "WEB_CONCURRENCY=22"}) })
+					expect(expect_exit(code: 0) { @app.run("./waitforit.sh 15 'ready for connections' heroku-php-#{server} --verbose docroot/onegig/", :heroku => {:env => "WEB_CONCURRENCY=22"}) })
 						 .to match("\\$WEB_CONCURRENCY env var is set, skipping automatic calculation")
 						.and match("Starting php-fpm with 22 workers...")
 				end
 				it "overrides an FPM config memory_limit" do
-					expect(expect_exit(code: 124) { @app.run("timeout 5 heroku-php-#{server} -F conf/fpm.onegig.conf", :heroku => {:env => "WEB_CONCURRENCY=22"}) })
+					expect(expect_exit(code: 0) { @app.run("./waitforit.sh 15 'ready for connections' heroku-php-#{server} --verbose -F conf/fpm.onegig.conf", :heroku => {:env => "WEB_CONCURRENCY=22"}) })
 						 .to match("\\$WEB_CONCURRENCY env var is set, skipping automatic calculation")
 						.and match("Starting php-fpm with 22 workers...")
 				end
@@ -299,14 +305,14 @@ shared_examples "A PHP application with a composer.json" do |series|
 			
 			context "running on a Performance-L dyno" do
 				it "restricts the app to 6 GB of RAM", :if => series < "7.4" do
-					expect(expect_exit(code: 124) { @app.run("timeout 5 heroku-php-#{server}", :heroku => {:size => "Performance-L"}) })
+					expect(expect_exit(code: 0) { @app.run("./waitforit.sh 15 'ready for connections' heroku-php-#{server} --verbose", :heroku => {:size => "Performance-L"}) })
 						 .to match("Detected 15032385536 Bytes of RAM")
 						.and match("Limiting to 6G Bytes of RAM usage")
 						.and match("Starting php-fpm with 48 workers...")
 				end
 				
 				it "uses all available RAM for PHP-FPM workers", :unless => series < "7.4" do
-					expect(expect_exit(code: 124) { @app.run("timeout 5 heroku-php-#{server}", :heroku => {:size => "Performance-L"}) })
+					expect(expect_exit(code: 0) { @app.run("./waitforit.sh 15 'ready for connections' heroku-php-#{server} --verbose", :heroku => {:size => "Performance-L"}) })
 						 .to match("Detected 15032385536 Bytes of RAM")
 						.and match("Starting php-fpm with 112 workers...")
 				end

--- a/test/spec/php_shared.rb
+++ b/test/spec/php_shared.rb
@@ -4,17 +4,13 @@ shared_examples "A PHP application with a composer.json" do |series|
 	context "requiring PHP #{series}" do
 		before(:all) do
 			@app = new_app_with_stack_and_platrepo('test/fixtures/default',
-				before_deploy: -> { system("composer require --quiet --ignore-platform-reqs php '#{series}.*'") or raise "Failed to require PHP version" }
+				before_deploy: -> { system("composer require --quiet --ignore-platform-reqs php '#{series}.*'") or raise "Failed to require PHP version" },
+				run_multi: true
 			)
 			@app.deploy
-			# so we don't have to worry about overlapping dynos causing test failures because only one free is allowed at a time
-			@app.api_rate_limit.call.formation.update(@app.name, "web", {"size" => "Standard-1X"})
 		end
 		
 		after(:all) do
-			# scale back down when we're done
-			# we should do this, because teardown! doesn't remove the app unless we're over the app limit
-			@app.api_rate_limit.call.formation.update(@app.name, "web", {"size" => "free"})
 			@app.teardown!
 		end
 		
@@ -198,17 +194,13 @@ shared_examples "A PHP application with a composer.json" do |series|
 		context "running PHP #{series} and the #{server} web server" do
 			before(:all) do
 				@app = new_app_with_stack_and_platrepo('test/fixtures/bootopts',
-					before_deploy: -> { system("composer require --quiet --ignore-platform-reqs php '#{series}.*'") or raise "Failed to require PHP version" }
+					before_deploy: -> { system("composer require --quiet --ignore-platform-reqs php '#{series}.*'") or raise "Failed to require PHP version" },
+					run_multi: true
 				)
 				@app.deploy
-				# so we don't have to worry about overlapping dynos causing test failures because only one free is allowed at a time
-				@app.api_rate_limit.call.formation.update(@app.name, "web", {"size" => "Standard-1X"})
 			end
 			
 			after(:all) do
-				# scale back down when we're done
-				# we should do this, because teardown! doesn't remove the app unless we're over the app limit
-				@app.api_rate_limit.call.formation.update(@app.name, "web", {"size" => "free"})
 				@app.teardown!
 			end
 			

--- a/test/spec/spec_helper.rb
+++ b/test/spec/spec_helper.rb
@@ -24,7 +24,7 @@ RSpec.configure do |config|
 	
 	config.verbose_retry       = true # show retry status in spec process
 	config.default_retry_count = 2 if ENV['IS_RUNNING_ON_CI'] # retry all tests that fail again...
-	config.exceptions_to_retry = [Excon::Errors::Timeout] #... if they're caused by these exception types
+	# config.exceptions_to_retry = [Excon::Errors::Timeout] #... if they're caused by these exception types
 	config.fail_fast = 1 if ENV['IS_RUNNING_ON_CI']
 	
 	config.expect_with :rspec do |c|

--- a/test/spec/spec_helper.rb
+++ b/test/spec/spec_helper.rb
@@ -69,6 +69,21 @@ def php_on_stack?(series)
 	available.include?(series)
 end
 
+module HatchetAppExtensions
+	def setup!
+		super
+		local_cmd_exec!("cp #{__dir__}/../utils/waitforit.sh .")
+		commit!
+		self
+	end
+end
+
+module Hatchet
+	class App
+		prepend HatchetAppExtensions
+	end
+end
+
 def new_app_with_stack_and_platrepo(*args, **kwargs)
 	kwargs[:stack] ||= ENV["STACK"]
 	kwargs[:config] ||= {}

--- a/test/utils/waitforit.sh
+++ b/test/utils/waitforit.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+
+# fail harder
+set -u
+
+if ! type -p "timeout" > /dev/null; then
+	echo "This program requires 'timeout'." >&2
+	exit 1
+fi
+
+print_help() {
+	cat >&2 <<-EOF
+		
+		${1:-Execute a given program and terminate after timeout or line match.}
+		
+		Usage:
+		  waitforit [options] <DURATION> <TEXT_TO_MATCH> <COMMAND...>
+		
+		The given COMMAND will be terminated after the given number of seconds, or the
+		given TEXT_TO_MATCH has matched, whichever comes first.
+		
+		The exit status of 'waitforit' will be the exit status of 'timeout' if the
+		given TEXT_TO_MATCH did not match, or 0 otherwise.
+		
+		DURATION is a floating point number with an optional suffix:
+		's' for seconds (the default), 'm' for minutes, 'h' for hours or 'd' for days.
+		It can also be a string of 'timeout' options and duration; the argument is
+		passed to 'timeout' unquoted.
+		
+		TEXT_TO_MATCH is a 'grep -E' expression.
+		
+		One particularly useful aspect of this program is that if stdout is a pipe,
+		the program behaves so that it writes the matched text to stdout, and will
+		then wait for the receiving end of the pipe to close before terminating the
+		program. This can be used to perform another operation once the given text has
+		matched, e.g.:
+		
+		waitforit 15 "ready for connections" start-web-server.sh | \
+			{ read && curl http://localhost:8080/test | grep "hello world"; }
+		
+		The 'read' statement waits for the matched text to occur and thus blocks the
+		execution of the curl/grep test operation until the server has started. It is
+		important to chain the commands following 'read' using '&&', as 'read' will
+		have a non-zero exit status if the 'waitforit' invocation timed out or did
+		not match the desired string.
+	EOF
+}
+
+if [[ "$#" -lt "3" ]]; then
+	print_help
+	exit 2
+fi
+
+duration=$1; shift
+text=$1; shift
+
+pipeout=
+# check if stdout is a pipeline, in which case we'll behave differently
+[[ -p /dev/stdout ]] && pipeout=1
+
+if [[ $pipeout ]]; then
+	grepargs="-m1"
+else
+	grepargs="-q"
+fi
+
+# this handler will fire if a program reading from us (to kick off e.g. a test) exits
+# in that event, we want the child process to terminate
+# trap 'trap - PIPE; echo "SIGPIPE received, shutting down..." >&2; cleanup TERM; kill -PIPE $$' PIPE
+
+# TODO: have option to suppress output to stderr
+teedest="/dev/stderr"
+(
+	# trap 'echo "finished" >&3;' EXIT
+
+	trap 'trap - PIPE; kill -TERM $pid 2> /dev/null || true; wait $pid; exit 0' PIPE
+
+	# we redirect stderr to stdout so it can be captured as well...
+	# ... and redirect stdout to a tee that also writes to stderr (so the output is visible) - this is done so that $! is still the pid of the timeout command
+	timeout $duration "$@" > >(tee "$teedest") 2>&1 & pid=$!
+	
+	while kill -0 $pid 2>/dev/null; do echo "." 2>/dev/null; sleep 0.1; done;
+	
+	wait $pid || exit $?
+	
+	exec 1>&-;
+) | { grep --line-buffered $grepargs -E -e "$text" && while test $pipeout; do echo "." 2>/dev/null; sleep 0.1; done; exec 1>&-; }
+
+exit ${PIPESTATUS[0]}


### PR DESCRIPTION
Many intermittent test failures are due to timing problems - often, a dyno will be a bit slow during startup, so a web server doesn't finish initializing (or finish crashing) during a given timeout (and we need to have a timeout so that the tests would eventually be aborted), or isn't ready yet when a `curl` tests something against it etc.

This adds a util `waitforit.sh` (will spin off into separate repo sometime) which can wait until a given timeout, or until a specified text has matched in the program's output, after which the program can terminate, or a pipeline unblocks and e.g. a `curl` can be performed against the now-ready web server.

Also upgrade to Hatchet 7, which enables `run_multi` so we no longer have to scale to Standard-1X by hand to prevent race conditions with many consecutive `run` calls ("you can only run one free dyno at a time").