### PR TITLE
use heroku CLI installed from Hatchet instead of Heroku CLI installed by Travis CI base image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,16 @@ install:
 - bundle install
 before_script:
 - bundle exec hatchet ci:setup
-- heroku update
+# Heroku CLI's .deb installs to /usr/bin/heroku
+# Travis CI _also installs Heroku CLI_ in its base image to /usr/local/bin/heroku
+# On Travis CI, /usr/local/bin comes _before_ /usr/bin in the $PATH.
+# So even though we are installing the latest via hatchet, the Travis CI heroku
+# is winning out due to the /usr/local/bin coming first in the PATH.
+# Create a shim in /home/travis/bin (which comes before /usr/local/bin and /usr/bin)
+# to get the Heroku CLI installed from hatchet first in the PATH
+- ln -s /usr/bin/heroku /home/travis/bin/heroku
+- which heroku
+- heroku -v
 script: bundle exec parallel_rspec -n 7 --group-by runtime --unknown-runtime 1 --runtime-log "test/var/log/parallel_runtime_rspec.${STACK}.log" --verbose-process-command --combine-stderr --prefix-output-with-test-env-number test/spec/
 after_script:
 - bundle exec hatchet destroy --all


### PR DESCRIPTION
Hatchet uses the `https://cli-assets.heroku.com/install-ubuntu.sh | sh` command to [install Heroku CLI][1]. The debian package built by oclif-dev [installs the CLI to `/usr/bin/heroku`][2]. However, Travis CI _also installs Heroku CLI in its base image_ to `/usr/local/bin/heroku`. The default PATH on Travis CI puts the `/usr/local/bin` directory _before_ the `/usr/bin` directory, which means that the Heroku CLI installed from Hatchet never actually gets used.

This change puts a symbolic link to `/usr/bin/heroku` (the one installed from Hatchet) in `/home/travis/bin`, which comes first in the PATH on Travis CI to give the Hatchet-installed Heroku CLI precedence in the PATH. The change also removes the `heroku update` command from the Travis CI config file, since ratchet will always install the latest CLI available.

Bug report link for compliance: https://heroku.slack.com/archives/C1RU5S0G2/p1602004048014000

[1]: https://github.com/heroku/hatchet/blob/2878ddb3e6993ebbd3a66388b5744ae4fc204759/etc/setup_heroku.sh#L4
[2]: https://github.com/oclif/dev-cli/blob/37101e3f8e37b9d7cf546410498ec01d7939612c/src/commands/pack/deb.ts#L81
