### PR TITLE
Allow ignoring of SIGTERM in FPM, Apache & Nginx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - PHP/8.0.0RC4 (heroku-20 stack only) [David Zuelke]
 - ext-mongodb/1.9.0RC1 (PHP 8 only) [David Zuelke]
 
+### CHG
+
+- Patches to optionally ignore SIGTERM in Apache, Nginx and PHP builds (not yet implemented by the buildpack) [David Zuelke]
+
 ### FIX
 
 - Explicit ext-newrelic require outputs info messages during builds [David Zuelke]

--- a/support/build/apache
+++ b/support/build/apache
@@ -31,6 +31,9 @@ mkdir -p ${dep_dirname}/srclib/apr-util
 curl -L ${aprutil_url} | tar xz --strip-components=1 -C ${dep_dirname}/srclib/apr-util
 
 pushd ${dep_dirname}
+
+patch -p1 < $(dirname $BASH_SOURCE)/patches/httpd-ignoresigterm.patch
+
 ./configure \
 	--enable-layout=GNU \
 	--prefix=${OUT_PREFIX} \

--- a/support/build/nginx
+++ b/support/build/nginx
@@ -29,6 +29,8 @@ if dpkg --compare-versions "$dep_version" "lt" 1.13.1; then
 	curl -L https://github.com/nginx/nginx/commit/8449f750e62cd229026e9df3bd023ec7e073a7d4.patch | patch -p1
 fi
 
+patch -p1 < $(dirname $BASH_SOURCE)/patches/nginx-ignoresigterm.patch
+
 ETC=${OUT_PREFIX}/etc
 VAR=${OUT_PREFIX}/var
 ./configure \

--- a/support/build/patches/httpd-ignoresigterm.patch
+++ b/support/build/patches/httpd-ignoresigterm.patch
@@ -1,0 +1,43 @@
+diff --git a/os/unix/unixd.c b/os/unix/unixd.c
+index 0245720aa0..b7333c5e32 100644
+--- a/os/unix/unixd.c
++++ b/os/unix/unixd.c
+@@ -51,6 +51,7 @@
+ #ifdef HAVE_SYS_PRCTL_H
+ #include <sys/prctl.h>
+ #endif
++#include <stdlib.h>
+ 
+ unixd_config_rec ap_unixd_config;
+ 
+@@ -522,6 +523,7 @@ AP_DECLARE(void) ap_unixd_mpm_set_signals(apr_pool_t *pconf, int one_process)
+ #ifndef NO_USE_SIGACTION
+     struct sigaction sa;
+ #endif
++    char* ignore_sigterm = getenv("HEROKU_PHP_GRACEFUL_SIGTERM");
+ 
+     if (!one_process) {
+         ap_fatal_signal_setup(ap_server_conf, pconf);
+@@ -566,10 +568,12 @@ AP_DECLARE(void) ap_unixd_mpm_set_signals(apr_pool_t *pconf, int one_process)
+                      "sigaction(SIGXFSZ)");
+ #endif
+ 
+-    sa.sa_handler = sig_term;
++    sa.sa_handler = (ignore_sigterm && atoi(ignore_sigterm)) ? SIG_IGN : sig_term;
+     if (sigaction(SIGTERM, &sa, NULL) < 0)
+         ap_log_error(APLOG_MARK, APLOG_WARNING, errno, ap_server_conf, APLOGNO(00264)
+                      "sigaction(SIGTERM)");
++
++    sa.sa_handler = sig_term;
+ #ifdef SIGINT
+     if (sigaction(SIGINT, &sa, NULL) < 0)
+         ap_log_error(APLOG_MARK, APLOG_WARNING, errno, ap_server_conf, APLOGNO(00266)
+@@ -604,7 +608,7 @@ AP_DECLARE(void) ap_unixd_mpm_set_signals(apr_pool_t *pconf, int one_process)
+     apr_signal(SIGXFSZ, SIG_IGN);
+ #endif /* SIGXFSZ */
+ 
+-    apr_signal(SIGTERM, sig_term);
++    apr_signal(SIGTERM, (ignore_sigterm && atoi(ignore_sigterm)) ? SIG_IGN : sig_term);
+ #ifdef AP_SIG_GRACEFUL_STOP
+     apr_signal(AP_SIG_GRACEFUL_STOP, sig_term);
+ #endif /* AP_SIG_GRACEFUL_STOP */

--- a/support/build/patches/nginx-ignoresigterm.patch
+++ b/support/build/patches/nginx-ignoresigterm.patch
@@ -1,0 +1,21 @@
+diff --git a/src/os/unix/ngx_process.c b/src/os/unix/ngx_process.c
+index 15680237..010a1877 100644
+--- a/src/os/unix/ngx_process.c
++++ b/src/os/unix/ngx_process.c
+@@ -286,10 +286,16 @@ ngx_init_signals(ngx_log_t *log)
+ {
+     ngx_signal_t      *sig;
+     struct sigaction   sa;
++    char* ignore_sigterm = getenv("HEROKU_PHP_GRACEFUL_SIGTERM");
+ 
+     for (sig = signals; sig->signo != 0; sig++) {
+         ngx_memzero(&sa, sizeof(struct sigaction));
+ 
++        if (strncmp(sig->name, "stop", 4) == 0 && ignore_sigterm && atoi(ignore_sigterm)) {
++            sig->name = "";
++            sig->handler = NULL;
++        }
++
+         if (sig->handler) {
+             sa.sa_sigaction = sig->handler;
+             sa.sa_flags = SA_SIGINFO;

--- a/support/build/patches/php-ignoresigterm.patch
+++ b/support/build/patches/php-ignoresigterm.patch
@@ -1,0 +1,53 @@
+diff --git a/sapi/fpm/fpm/fpm_signals.c b/sapi/fpm/fpm/fpm_signals.c
+index d3214b3d16..91b70e5713 100644
+--- a/sapi/fpm/fpm/fpm_signals.c
++++ b/sapi/fpm/fpm/fpm_signals.c
+@@ -184,7 +184,8 @@ static void sig_handler(int signo) /* {{{ */
+ 
+ int fpm_signals_init_main() /* {{{ */
+ {
+-	struct sigaction act;
++	struct sigaction act, act_ign;
++	char* ignore_sigterm = getenv("HEROKU_PHP_GRACEFUL_SIGTERM");
+ 
+ 	if (0 > socketpair(AF_UNIX, SOCK_STREAM, 0, sp)) {
+ 		zlog(ZLOG_SYSERROR, "failed to init signals: socketpair()");
+@@ -205,7 +206,10 @@ int fpm_signals_init_main() /* {{{ */
+ 	act.sa_handler = sig_handler;
+ 	sigfillset(&act.sa_mask);
+ 
+-	if (0 > sigaction(SIGTERM,  &act, 0) ||
++	memset(&act_ign, 0, sizeof(act_ign));
++	act_ign.sa_handler = SIG_IGN;
++
++	if (0 > sigaction(SIGTERM,  (ignore_sigterm && atoi(ignore_sigterm)) ? &act_ign : &act,  0) ||
+ 	    0 > sigaction(SIGINT,   &act, 0) ||
+ 	    0 > sigaction(SIGUSR1,  &act, 0) ||
+ 	    0 > sigaction(SIGUSR2,  &act, 0) ||
+@@ -226,20 +230,24 @@ int fpm_signals_init_main() /* {{{ */
+ 
+ int fpm_signals_init_child() /* {{{ */
+ {
+-	struct sigaction act, act_dfl;
++	struct sigaction act, act_dfl, act_ign;
++	char* ignore_sigterm = getenv("HEROKU_PHP_GRACEFUL_SIGTERM");
+ 
+ 	memset(&act, 0, sizeof(act));
+ 	memset(&act_dfl, 0, sizeof(act_dfl));
++	memset(&act_ign, 0, sizeof(act_ign));
+ 
+ 	act.sa_handler = &sig_soft_quit;
+ 	act.sa_flags |= SA_RESTART;
+ 
+ 	act_dfl.sa_handler = SIG_DFL;
+ 
++	act_ign.sa_handler = SIG_IGN;
++
+ 	close(sp[0]);
+ 	close(sp[1]);
+ 
+-	if (0 > sigaction(SIGTERM,  &act_dfl,  0) ||
++	if (0 > sigaction(SIGTERM,  (ignore_sigterm && atoi(ignore_sigterm)) ? &act_ign : &act_dfl,  0) ||
+ 	    0 > sigaction(SIGINT,   &act_dfl,  0) ||
+ 	    0 > sigaction(SIGUSR1,  &act_dfl,  0) ||
+ 	    0 > sigaction(SIGUSR2,  &act_dfl,  0) ||

--- a/support/build/php
+++ b/support/build/php
@@ -120,6 +120,8 @@ fi
 # see the AC_DEFUN([AC_FPM_TRACE] bits in sapi/fpm/config.m4
 sed -i 's/have_ptrace=yes/have_ptrace=no/' configure
 
+patch -p1 < $(dirname $BASH_SOURCE)/patches/php-ignoresigterm.patch
+
 configureopts=()
 if [[ $dep_version != 5.* ]]; then
 	if [[ $dep_version == 7.[0-3].* ]]; then


### PR DESCRIPTION
This PR only adds the conditionals in the builds for those three programs, but does not yet implement their usage in the buildpack.

Once that second part is done, a blanket SIGTERM to all processes like Heroku does will still gracefully shut down the web server and PHP, allowing requests to finish.

GUS-W-8215291