### PR TITLE
Fix composer bin-dir $PATH settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # heroku-buildpack-php CHANGELOG
 
+## v185 (2020-11-22)
+
+### FIX
+
+- composer bin-dir is not available on $PATH to subsequent buildpacks [David Zuelke]
+
 ## v184 (2020-11-20)
 
 ### ADD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### FIX
 
 - composer bin-dir is not available on $PATH to subsequent buildpacks [David Zuelke]
+- composer bin-dir exported as relative location in $PATH at runtime [David Zuelke]
 
 ## v184 (2020-11-20)
 

--- a/support/build/composer
+++ b/support/build/composer
@@ -54,8 +54,15 @@ EOF
 cat >> ${OUT_PREFIX}/bin/export.composer.sh <<-'EOF'
 export PATH="/app/.heroku/php/bin:$PATH"
 # now composer is on the path
+# the export script is called with /app as the cwd, but the app source with composer.json is in another location
+# we need to cd to the dirname of realpath 'composer' first to find the actual location of the app during the build:
+# - we know 'composer' is on $PATH in /app/.heroku/php/bin
+# - we know /app/.heroku/php is a symlink to the build dir
+# - we $(dirname $(realpath 'composer')) to get $build_dir/.heroku/php/bin/
+# - then we cd up three times (from .heroku/php/bin, from .heroku/php, from .heroku) so we're in the build dir
+# - then we invoke 'composer config bin-dir' in there and realpath that so it's absolute
 # no scan dir so no newrelic starts up and outputs messages etc
-export PATH="$PATH:$(PHP_INI_SCAN_DIR= composer config --no-plugins bin-dir)"
+export PATH="$PATH:$(cd "$(dirname "$(realpath "$(which composer)")")"; cd ../../..; realpath "$(PHP_INI_SCAN_DIR= composer config --no-plugins bin-dir)")"
 EOF
 # this gets sourced on dyno boot
 # unlimited Composer process timeout only for runtime, not build time

--- a/support/build/composer
+++ b/support/build/composer
@@ -74,7 +74,7 @@ export COMPOSER_PROCESS_TIMEOUT=${COMPOSER_PROCESS_TIMEOUT:-0}
 export PATH="$HOME/.heroku/php/bin:$PATH"
 # now composer is on the path
 # no scan dir so no newrelic starts up and outputs messages etc
-export PATH="$PATH:$(PHP_INI_SCAN_DIR= composer config --no-plugins bin-dir)"
+export PATH="$PATH:$(realpath "$(PHP_INI_SCAN_DIR= composer config --no-plugins bin-dir)")"
 EOF
 
 # FIXME: we should also require heroku-sys/php so that gets installed before us; can't do that until cedar-14 with HHVM is history (it works fine right now because 'php' and 'composer' are in the same location on $PATH so our own $PATH logic above adds 'php' along with 'composer')

--- a/support/build/composer
+++ b/support/build/composer
@@ -62,7 +62,8 @@ export PATH="/app/.heroku/php/bin:$PATH"
 # - then we cd up three times (from .heroku/php/bin, from .heroku/php, from .heroku) so we're in the build dir
 # - then we invoke 'composer config bin-dir' in there and realpath that so it's absolute
 # no scan dir so no newrelic starts up and outputs messages etc
-export PATH="$PATH:$(cd "$(dirname "$(realpath "$(which composer)")")"; cd ../../..; realpath "$(PHP_INI_SCAN_DIR= composer config --no-plugins bin-dir)")"
+# FIXME: cedar-14 realpath doesn't have --canonicalize-missing, so we have to mkdir -p the bin-dir (it's not there yet when we source export early on in bin/compile)
+export PATH="$PATH:$(cd "$(dirname "$(realpath "$(which composer)")")"; cd ../../..; bin_dir="$(PHP_INI_SCAN_DIR= composer config --no-plugins bin-dir)"; mkdir -p "$bin_dir"; realpath "$bin_dir")"
 EOF
 # this gets sourced on dyno boot
 # unlimited Composer process timeout only for runtime, not build time

--- a/support/build/composer
+++ b/support/build/composer
@@ -69,6 +69,7 @@ export PATH="$HOME/.heroku/php/bin:$PATH"
 export PATH="$PATH:$(PHP_INI_SCAN_DIR= composer config --no-plugins bin-dir)"
 EOF
 
+# FIXME: we should also require heroku-sys/php so that gets installed before us; can't do that until cedar-14 with HHVM is history (it works fine right now because 'php' and 'composer' are in the same location on $PATH so our own $PATH logic above adds 'php' along with 'composer')
 MANIFEST_REQUIRE="${MANIFEST_REQUIRE:-"{}"}"
 MANIFEST_CONFLICT="${MANIFEST_CONFLICT:-"{}"}"
 MANIFEST_REPLACE="${MANIFEST_REPLACE:-"{}"}"

--- a/test/fixtures/bugs/export-composer-bin-dir/buildpack-run.sh
+++ b/test/fixtures/bugs/export-composer-bin-dir/buildpack-run.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+atoum --version

--- a/test/fixtures/bugs/export-composer-bin-dir/composer.json
+++ b/test/fixtures/bugs/export-composer-bin-dir/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "atoum/atoum": "^4.0"
+    }
+}

--- a/test/fixtures/bugs/export-composer-bin-dir/composer.lock
+++ b/test/fixtures/bugs/export-composer-bin-dir/composer.lock
@@ -1,0 +1,102 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "2f658a0db482698d3e689dce62da7408",
+    "packages": [
+        {
+            "name": "atoum/atoum",
+            "version": "4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/atoum/atoum.git",
+                "reference": "56e9c55cab42086c2eb6bd30fcf1e242f9c51f52"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/atoum/atoum/zipball/56e9c55cab42086c2eb6bd30fcf1e242f9c51f52",
+                "reference": "56e9c55cab42086c2eb6bd30fcf1e242f9c51f52",
+                "shasum": ""
+            },
+            "require": {
+                "ext-hash": "*",
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "ext-xml": "*",
+                "php": "^7.2 || ^8.0"
+            },
+            "replace": {
+                "mageekguy/atoum": "*"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2"
+            },
+            "suggest": {
+                "atoum/stubs": "Provides IDE support (like autocompletion) for atoum",
+                "ext-mbstring": "Provides support for UTF-8 strings",
+                "ext-xdebug": "Provides code coverage report (>= 2.3)"
+            },
+            "bin": [
+                "bin/atoum"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "classes/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Frédéric Hardy",
+                    "email": "frederic.hardy@atoum.org",
+                    "homepage": "http://blog.mageekbox.net"
+                },
+                {
+                    "name": "François Dussert",
+                    "email": "francois.dussert@atoum.org"
+                },
+                {
+                    "name": "Gérald Croes",
+                    "email": "gerald.croes@atoum.org"
+                },
+                {
+                    "name": "Julien Bianchi",
+                    "email": "julien.bianchi@atoum.org"
+                },
+                {
+                    "name": "Ludovic Fleury",
+                    "email": "ludovic.fleury@atoum.org"
+                }
+            ],
+            "description": "Simple modern and intuitive unit testing framework for PHP 5.3+",
+            "homepage": "http://www.atoum.org",
+            "keywords": [
+                "TDD",
+                "atoum",
+                "test",
+                "unit testing"
+            ],
+            "time": "2020-11-21T17:23:11+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": [],
+    "plugin-api-version": "1.1.0"
+}

--- a/test/spec/bugs_spec.rb
+++ b/test/spec/bugs_spec.rb
@@ -16,4 +16,16 @@ describe "A PHP application" do
 			end
 		end
 	end
+	context "that has another buildpack running after the PHP buildpack" do
+		it "puts binaries from composer's bin-dir on $PATH for subsequent buildpacks" do
+			buildpacks = [
+				:default,
+				"https://github.com/weibeld/heroku-buildpack-run"
+			]
+			app = new_app_with_stack_and_platrepo("test/fixtures/bugs/export-composer-bin-dir", buildpacks: buildpacks)
+			app.deploy do |app|
+				expect(app.output).to match("atoum version")
+			end
+		end
+	end
 end

--- a/test/spec/test_spec.rb
+++ b/test/spec/test_spec.rb
@@ -26,6 +26,17 @@ describe "A PHP application" do
     end
   end
 
+  it "have absolute buildpack paths" do
+    skip("force absolute paths buildpack requires an modern ruby version") if ENV["STACK"] == "cedar-14"
+    buildpacks = [
+      :default,
+      "https://github.com/sharpstone/force_absolute_paths_buildpack"
+    ]
+    new_app_with_stack_and_platrepo("php-getting-started", buildpacks: buildpacks).deploy do |app|
+      #deploy works
+    end
+  end
+
   it "uses cache with ci" do
     app = new_app_with_stack_and_platrepo('test/fixtures/ci/devdeps')
     app.run_ci do |test_run|

--- a/test/var/log/parallel_runtime_rspec.cedar-14.log
+++ b/test/var/log/parallel_runtime_rspec.cedar-14.log
@@ -1,3 +1,4 @@
+test/spec/bugs_spec.rb:27.62022092499999
 test/spec/ci_spec.rb:295.57726782000003
 test/spec/composer_spec.rb:30.616864848999995
 test/spec/hhvm_spec.rb:50.133655903999994

--- a/test/var/log/parallel_runtime_rspec.heroku-16.log
+++ b/test/var/log/parallel_runtime_rspec.heroku-16.log
@@ -1,3 +1,4 @@
+test/spec/bugs_spec.rb:28.50543559599999
 test/spec/ci_spec.rb:291.599527972
 test/spec/composer_spec.rb:30.616864848999995
 test/spec/newrelic_spec.rb:95.20561092300001

--- a/test/var/log/parallel_runtime_rspec.heroku-18.log
+++ b/test/var/log/parallel_runtime_rspec.heroku-18.log
@@ -1,4 +1,4 @@
-test/spec/bugs_spec.rb:21.748024453999996
+test/spec/bugs_spec.rb:45.368704143
 test/spec/ci_spec.rb:274.321140925
 test/spec/composer_spec.rb:30.616864848999995
 test/spec/newrelic_spec.rb:86.77255344099999

--- a/test/var/log/parallel_runtime_rspec.heroku-20.log
+++ b/test/var/log/parallel_runtime_rspec.heroku-20.log
@@ -1,3 +1,4 @@
+test/spec/bugs_spec.rb:30.021669688999992
 test/spec/ci_spec.rb:274.321140925
 test/spec/composer_spec.rb:30.616864848999995
 test/spec/newrelic_spec.rb:86.77255344099999


### PR DESCRIPTION
- at runtime, it's a relative path (minor)
- at build time, it's never been exported correctly (because it added `/app/vendor/bin`, not `/tmp/build…/vendor/bin`), but now the export also causes an error message (without affecting build success)