### PR TITLE
Test stability improvements

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem 'heroku_hatchet'
+gem 'heroku_hatchet', git: 'https://github.com/heroku/hatchet.git', branch: 'timeouts-etc'
 gem 'rspec-retry'
 gem 'rspec-expectations'
 gem 'sem_version'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,49 +1,55 @@
+GIT
+  remote: https://github.com/heroku/hatchet.git
+  revision: 1e771cb2577a9c4ef3caa52d793e1c83fb8410af
+  branch: timeouts-etc
+  specs:
+    heroku_hatchet (7.4.0)
+      excon (~> 0)
+      platform-api (~> 3)
+      rrrretry (~> 1)
+      thor (~> 1)
+      threaded (~> 0)
+
 GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.4.4)
     erubis (2.7.0)
-    excon (0.76.0)
+    excon (0.78.0)
     heroics (0.1.1)
       erubis (~> 2.0)
       excon
       moneta
       multi_json (>= 1.9.2)
-    heroku_hatchet (7.3.0)
-      excon (~> 0)
-      platform-api (~> 3)
-      rrrretry (~> 1)
-      thor (~> 0)
-      threaded (~> 0)
     moneta (1.0.0)
     multi_json (1.15.0)
-    parallel (1.19.2)
-    parallel_tests (3.3.0)
+    parallel (1.20.1)
+    parallel_tests (3.4.0)
       parallel
-    platform-api (3.0.0)
+    platform-api (3.2.0)
       heroics (~> 0.1.1)
       moneta (~> 1.0.0)
       rate_throttle_client (~> 0.1.0)
     rake (13.0.1)
     rate_throttle_client (0.1.2)
     rrrretry (1.0.0)
-    rspec-core (3.9.2)
-      rspec-support (~> 3.9.3)
-    rspec-expectations (3.9.2)
+    rspec-core (3.10.0)
+      rspec-support (~> 3.10.0)
+    rspec-expectations (3.10.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.9.0)
+      rspec-support (~> 3.10.0)
     rspec-retry (0.6.2)
       rspec-core (> 3.3)
-    rspec-support (3.9.3)
+    rspec-support (3.10.0)
     sem_version (2.0.1)
-    thor (0.20.3)
+    thor (1.0.1)
     threaded (0.0.4)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  heroku_hatchet
+  heroku_hatchet!
   parallel_tests
   rake
   rspec-expectations

--- a/test/spec/newrelic_spec.rb
+++ b/test/spec/newrelic_spec.rb
@@ -29,7 +29,7 @@ describe "A PHP application using New Relic" do
 					# a NEW_RELIC_LICENSE_KEY triggers the automatic installation of ext-newrelic at the end of the build
 					@app = new_app_with_stack_and_platrepo('test/fixtures/bootopts',
 						config: { "NEW_RELIC_LOG_LEVEL" => "info", "NEW_RELIC_LICENSE_KEY" => "thiswilltriggernewrelic" },
-						before_deploy: -> { system("composer require --quiet --ignore-platform-reqs 'php:*'") or raise "Failed to require PHP version" },
+						before_deploy: -> { system("composer require --quiet --ignore-platform-reqs 'php:7.*'") or raise "Failed to require PHP version" },
 						run_multi: true
 					)
 				end

--- a/test/spec/php_shared_boot.rb
+++ b/test/spec/php_shared_boot.rb
@@ -108,12 +108,12 @@ shared_examples "A PHP application for testing boot options" do |series, server|
 				if combination.value?(false) or cmd.match("broken")
 					it "does not boot" do
 						# check if "timeout" exited with a status other than 124, which means the process exited (due to the expected error) before "timeout" stepped in after the given duration (five seconds) and terminated it
-						expect_exit(expect: :not_to, code: 124) { @app.run("timeout 15 #{cmd}") }
+						expect_exit(expect: :not_to, code: 124) { @app.run("timeout 15 #{cmd}", :return_obj => true) }
 					end
 				else
 					it "boots" do
 						# check if "waitforit" exited with status 0, which means the process successfully output the expected message
-						expect_exit(expect: :to, code: 0) { @app.run("./waitforit.sh 15 'ready for connections' #{cmd}") }
+						expect_exit(expect: :to, code: 0) { @app.run("./waitforit.sh 15 'ready for connections' #{cmd}", :return_obj => true) }
 					end
 				end
 			end
@@ -121,13 +121,13 @@ shared_examples "A PHP application for testing boot options" do |series, server|
 		
 		context "launching using too many arguments" do
 			it "fails to boot" do
-				expect_exit(expect: :to, code: 2) { @app.run("timeout 10 heroku-php-#{server} docroot/ anotherarg") }
+				expect_exit(expect: :to, code: 2) { @app.run("timeout 10 heroku-php-#{server} docroot/ anotherarg", :return_obj => true) }
 			end
 		end
 		
 		context "launching using unknown options" do
 			it "fails to boot" do
-				expect_exit(expect: :to, code: 2) { @app.run("timeout 10 heroku-php-#{server} --what -u erp") }
+				expect_exit(expect: :to, code: 2) { @app.run("timeout 10 heroku-php-#{server} --what -u erp", :return_obj => true) }
 			end
 		end
 	end

--- a/test/spec/php_shared_concurrency.rb
+++ b/test/spec/php_shared_concurrency.rb
@@ -18,17 +18,17 @@ shared_examples "A PHP application for testing WEB_CONCURRENCY behavior" do |ser
 		
 		context "setting concurrency via .user.ini memory_limit" do
 			it "calculates concurrency correctly" do
-				expect(expect_exit(code: 0) { @app.run("./waitforit.sh 15 'ready for connections' heroku-php-#{server} --verbose docroot/") })
+				expect(expect_exit(code: 0) { @app.run("./waitforit.sh 15 'ready for connections' heroku-php-#{server} --verbose docroot/", :return_obj => true) }.output)
 					 .to match("PHP memory_limit is 32M Bytes")
 					.and match("Starting php-fpm with 16 workers...")
 			end
 			it "always launches at least one worker" do
-				expect(expect_exit(code: 0) { @app.run("./waitforit.sh 15 'ready for connections' heroku-php-#{server} --verbose docroot/onegig/") })
+				expect(expect_exit(code: 0) { @app.run("./waitforit.sh 15 'ready for connections' heroku-php-#{server} --verbose docroot/onegig/", :return_obj => true) }.output)
 					 .to match("PHP memory_limit is 1024M Bytes")
 					.and match("Starting php-fpm with 1 workers...")
 			end
 			it "is only done for a .user.ini directly in the document root" do
-				expect(expect_exit(code: 0) { @app.run("./waitforit.sh 15 'ready for connections' heroku-php-#{server} --verbose") })
+				expect(expect_exit(code: 0) { @app.run("./waitforit.sh 15 'ready for connections' heroku-php-#{server} --verbose", :return_obj => true) }.output)
 					 .to match("PHP memory_limit is 128M Bytes")
 					.and match("Starting php-fpm with 4 workers...")
 			end
@@ -36,17 +36,17 @@ shared_examples "A PHP application for testing WEB_CONCURRENCY behavior" do |ser
 		
 		context "setting concurrency via FPM config memory_limit" do
 			it "calculates concurrency correctly" do
-				expect(expect_exit(code: 0) { @app.run("./waitforit.sh 15 'ready for connections' heroku-php-#{server} --verbose -F conf/fpm.include.conf") })
+				expect(expect_exit(code: 0) { @app.run("./waitforit.sh 15 'ready for connections' heroku-php-#{server} --verbose -F conf/fpm.include.conf", :return_obj => true) }.output)
 					 .to match("PHP memory_limit is 32M Bytes")
 					.and match("Starting php-fpm with 16 workers...")
 			end
 			it "always launches at least one worker" do
-				expect(expect_exit(code: 0) { @app.run("./waitforit.sh 15 'ready for connections' heroku-php-#{server} --verbose -F conf/fpm.onegig.conf") })
+				expect(expect_exit(code: 0) { @app.run("./waitforit.sh 15 'ready for connections' heroku-php-#{server} --verbose -F conf/fpm.onegig.conf", :return_obj => true) }.output)
 					 .to match("PHP memory_limit is 1024M Bytes")
 					.and match("Starting php-fpm with 1 workers...")
 			end
 			it "takes precedence over a .user.ini memory_limit" do
-				expect(expect_exit(code: 0) { @app.run("./waitforit.sh 15 'ready for connections' heroku-php-#{server} --verbose -F conf/fpm.include.conf docroot/onegig/") })
+				expect(expect_exit(code: 0) { @app.run("./waitforit.sh 15 'ready for connections' heroku-php-#{server} --verbose -F conf/fpm.include.conf docroot/onegig/", :return_obj => true) }.output)
 					 .to match("PHP memory_limit is 32M Bytes")
 					.and match("Starting php-fpm with 16 workers...")
 			end
@@ -54,17 +54,17 @@ shared_examples "A PHP application for testing WEB_CONCURRENCY behavior" do |ser
 		
 		context "setting WEB_CONCURRENCY explicitly" do
 			it "uses the explicit value" do
-				expect(expect_exit(code: 0) { @app.run("./waitforit.sh 15 'ready for connections' heroku-php-#{server} --verbose", :heroku => {:env => "WEB_CONCURRENCY=22"}) })
+				expect(expect_exit(code: 0) { @app.run("./waitforit.sh 15 'ready for connections' heroku-php-#{server} --verbose", :return_obj => true, :heroku => {:env => "WEB_CONCURRENCY=22"}) }.output)
 					 .to match("\\$WEB_CONCURRENCY env var is set, skipping automatic calculation")
 					.and match("Starting php-fpm with 22 workers...")
 			end
 			it "overrides a .user.ini memory_limit" do
-				expect(expect_exit(code: 0) { @app.run("./waitforit.sh 15 'ready for connections' heroku-php-#{server} --verbose docroot/onegig/", :heroku => {:env => "WEB_CONCURRENCY=22"}) })
+				expect(expect_exit(code: 0) { @app.run("./waitforit.sh 15 'ready for connections' heroku-php-#{server} --verbose docroot/onegig/", :return_obj => true, :heroku => {:env => "WEB_CONCURRENCY=22"}) }.output)
 					 .to match("\\$WEB_CONCURRENCY env var is set, skipping automatic calculation")
 					.and match("Starting php-fpm with 22 workers...")
 			end
 			it "overrides an FPM config memory_limit" do
-				expect(expect_exit(code: 0) { @app.run("./waitforit.sh 15 'ready for connections' heroku-php-#{server} --verbose -F conf/fpm.onegig.conf", :heroku => {:env => "WEB_CONCURRENCY=22"}) })
+				expect(expect_exit(code: 0) { @app.run("./waitforit.sh 15 'ready for connections' heroku-php-#{server} --verbose -F conf/fpm.onegig.conf", :return_obj => true, :heroku => {:env => "WEB_CONCURRENCY=22"}) }.output)
 					 .to match("\\$WEB_CONCURRENCY env var is set, skipping automatic calculation")
 					.and match("Starting php-fpm with 22 workers...")
 			end
@@ -72,14 +72,14 @@ shared_examples "A PHP application for testing WEB_CONCURRENCY behavior" do |ser
 		
 		context "running on a Performance-L dyno" do
 			it "restricts the app to 6 GB of RAM", :if => series < "7.4" do
-				expect(expect_exit(code: 0) { @app.run("./waitforit.sh 15 'ready for connections' heroku-php-#{server} --verbose", :heroku => {:size => "Performance-L"}) })
+				expect(expect_exit(code: 0) { @app.run("./waitforit.sh 15 'ready for connections' heroku-php-#{server} --verbose", :return_obj => true, :heroku => {:size => "Performance-L"}) }.output)
 					 .to match("Detected 15032385536 Bytes of RAM")
 					.and match("Limiting to 6G Bytes of RAM usage")
 					.and match("Starting php-fpm with 48 workers...")
 			end
 			
 			it "uses all available RAM for PHP-FPM workers", :unless => series < "7.4" do
-				expect(expect_exit(code: 0) { @app.run("./waitforit.sh 15 'ready for connections' heroku-php-#{server} --verbose", :heroku => {:size => "Performance-L"}) })
+				expect(expect_exit(code: 0) { @app.run("./waitforit.sh 15 'ready for connections' heroku-php-#{server} --verbose", :return_obj => true, :heroku => {:size => "Performance-L"}) }.output)
 					 .to match("Detected 15032385536 Bytes of RAM")
 					.and match("Starting php-fpm with 112 workers...")
 			end

--- a/test/spec/spec_helper.rb
+++ b/test/spec/spec_helper.rb
@@ -10,8 +10,6 @@ require 'json'
 require 'sem_version'
 require 'shellwords'
 require 'excon'
-require 'open3'
-require 'timeout'
 
 ENV['RACK_ENV'] = 'test'
 
@@ -29,7 +27,7 @@ RSpec.configure do |config|
 	config.verbose_retry       = true # show retry status in spec process
 	config.default_retry_count = 2 if ENV['IS_RUNNING_ON_CI'] # retry all tests that fail again...
 	# config.exceptions_to_retry = [Excon::Errors::Timeout] #... if they're caused by these exception types
-  # config.fail_fast = 1 if ENV['IS_RUNNING_ON_CI']
+	config.fail_fast = 1 if ENV['IS_RUNNING_ON_CI']
 
 	config.expect_with :rspec do |c|
 		c.syntax = :expect
@@ -44,12 +42,12 @@ end
 
 def expect_exit(expect: :to, operator: :eq, code: 0)
 	raise ArgumentError, "Expected a block but none given" unless block_given?
-	output = yield
-	expect($?.exitstatus).method(expect).call(
+	run_obj = yield
+	expect(run_obj.status.exitstatus).method(expect).call(
 		method(operator).call(code),
-		"Expected exit code #{$?.exitstatus} #{expect} be #{operator} to #{code}; output:\n#{output}"
+		"Expected exit code #{run_obj.status.exitstatus} #{expect} be #{operator} to #{code}; output:\n#{run_obj.output}"
 	)
-	output # so that can be tested too
+	run_obj # so that can be tested too
 end
 
 def expected_default_php(stack)
@@ -91,192 +89,4 @@ def run!(cmd)
 	out = `#{cmd}`
 	raise "Command #{cmd} failed: #{out}" unless $?.success?
 	out
-end
-
-module Hatchet
-	class App
-    def run(cmd_type, command = DefaultCommand, options = {}, &block)
-      case command
-      when Hash
-        options.merge!(command)
-        command = cmd_type.to_s
-      when nil
-        STDERR.puts "Calling App#run with an explicit nil value in the second argument is deprecated."
-        STDERR.puts "You can pass in a hash directly as the second argument now.\n#{caller.join("\n")}"
-        command = cmd_type.to_s
-      when DefaultCommand
-        command = cmd_type.to_s
-      else
-        command = command.to_s
-      end
-
-      allow_run_multi! if @run_multi
-
-      run_obj = Hatchet::HerokuRun.new(
-        command,
-        app: self,
-        retry_on_empty: options.fetch(:retry_on_empty, !ENV["HATCHET_DISABLE_EMPTY_RUN_RETRY"]),
-        retry_delay: @run_multi ? 0 : (ENV["HATCHET_RUN_RETRY_DELAY"] || 5).to_i,
-        heroku: options[:heroku],
-        raw: options[:raw],
-        timeout: options.fetch(:timeout, (ENV["HATCHET_DEFAULT_RUN_TIMEOUT"] || 60).to_i)
-      ).call
-
-      return options[:return_obj] ? run_obj : run_obj.output
-    end
-    def run_multi(command, options = {}, &block)
-      raise "Block required" if block.nil?
-      allow_run_multi!
-
-      run_thread = Thread.new do
-        run_obj = Hatchet::HerokuRun.new(
-          command,
-          app: self,
-          retry_on_empty: options.fetch(:retry_on_empty, !ENV["HATCHET_DISABLE_EMPTY_RUN_RETRY"]),
-          retry_delay: @run_multi ? 0 : (ENV["HATCHET_RUN_RETRY_DELAY"] || 5).to_i,
-          heroku: options[:heroku],
-          raw: options[:raw],
-          timeout: options.fetch(:timeout, (ENV["HATCHET_DEFAULT_RUN_TIMEOUT"] || 60).to_i)
-        ).call
-
-        yield run_obj.output, run_obj.status
-      end
-      run_thread.abort_on_exception = true
-
-      @run_multi_array << run_thread
-
-      true
-    end
-	end
-  class HerokuRun
-    class HerokuRunEmptyOutputError < RuntimeError; end
-    class HerokuRunTimeoutError < RuntimeError; end
-
-    attr_reader :command
-
-    def initialize(
-      command,
-      app: ,
-      heroku: {},
-      retry_on_empty: !ENV["HATCHET_DISABLE_EMPTY_RUN_RETRY"],
-      retry_delay: 0,
-      raw: false,
-      stderr: $stderr,
-      timeout: 0)
-
-      @raw = raw
-      @app = app
-      @timeout = timeout
-      @command = build_heroku_command(command, heroku || {})
-      @retry_on_empty = retry_on_empty
-      @retry_delay = retry_delay
-      @stderr = stderr
-      @output = ""
-      @status = nil
-      @empty_fail_count = 0
-      @timeout_fail_count = 0
-    end
-
-    def output
-      raise "You must run `call` on this object first" unless @status
-      @output
-    end
-
-    def status
-      raise "You must run `call` on this object first" unless @status
-      @status
-    end
-
-    def call
-      begin
-        execute!
-      rescue HerokuRunEmptyOutputError => e
-        if @retry_on_empty and (@empty_fail_count += 1) <=3
-          message = String.new("Empty output from run #{@dyno_id} with command #{@command}, retrying in #{@retry_delay} seconds.")
-          message << "\nTo disable pass in `retry_on_empty: false` or set HATCHET_DISABLE_EMPTY_RUN_RETRY=1 globally"
-          message << "\nfailed_count: #{@empty_fail_count}"
-          message << "\nreleases: #{@app.releases}"
-          message << "\n#{caller.join("\n")}"
-          @stderr.puts message
-          sleep(@retry_delay) # without run_multi, this will prevent frequent "can only run one free dyno" errors
-          retry
-        end
-      rescue HerokuRunTimeoutError => e
-        if (@timeout_fail_count += 1) <= 3
-          message = String.new("Run #{@dyno_id} with command #{@command} timed out after #{@timeout}, stopping dyno and re-trying.")
-          message << "\nOutput until moment of termination was: #{@output}"
-          message << "\nTo disable pass in `timeout: 0` or set HATCHET_DEFAULT_RUN_TIMEOUT=0 globally"
-          message << "\nfailed_count: #{@timeout_fail_count}"
-          message << "\nreleases: #{@app.releases}"
-          message << "\n#{caller.join("\n")}"
-          @stderr.puts message
-          @app.platform_api.dyno.stop(@app.name, @dyno_id) if @dyno_id
-          sleep(@retry_delay == 0 ? 0 : 1) # a second should be enough for all cases after our explicit stop
-          retry
-        end
-      end
-
-      self
-    end
-
-    private def execute!
-      ShellThrottle.new(platform_api: @app.platform_api).call do |throttle|
-        run_shell!
-        throw(:throttle) if output.match?(/reached the API rate limit/)
-      end
-    end
-
-    def run_shell!
-      @output = ""
-      @dyno_id = nil
-      Open3.popen3(@command) do |stdin, stdout, stderr, wait_thread|
-      begin
-        Timeout.timeout(@timeout) do
-          Thread.new do
-            until stdout.eof? do
-              @output += stdout.gets
-            end
-          rescue IOError # eof? and gets race condition
-          end
-          Thread.new do
-            until stderr.eof? do
-              @stderr.puts line = stderr.gets
-              if !@dyno_id and run = line.match(/, (run\.\d+)/)
-                @dyno_id = run.captures.first
-              end
-            end
-          rescue IOError # eof? and gets race condition
-          end
-          @status = wait_thread.value # wait for termination
-        end
-        rescue Timeout::Error
-          Process.kill("TERM", wait_thread.pid)
-          @status = wait_thread.value # wait for termination
-        end
-        # FIXME: usage of $? in tests is very likely not threadsafe, and does not allow a test to distinguish between a TERM by us or inside the dyno
-        # this should be part of a proper interface to the run result instead but that's a breaking change
-        # change app.run to return whole run object which has to_s and to_str for output?
-        status = @status.signaled? ? @status.termsig+128 : @status.exitstatus # a signaled program will not have an exit status, but the shell represents that case as 128+$signal, so e.g. 128+15=143 for SIGTERM
-        `exit #{status}` # re-set $? for tests that rely on us previously having used backticks
-        raise HerokuRunTimeoutError if @status.signaled? # program got terminated by our SIGTERM, raise
-        raise HerokuRunEmptyOutputError if @output.empty?
-      end
-    end
-
-    private def build_heroku_command(command, options = {})
-      command = command.shellescape unless @raw
-
-      default_options = { "app" => @app.name, "exit-code" => nil }
-      heroku_options_array = (default_options.merge(options)).map do |k,v|
-        # This was a bad interface decision
-        next if v == Hatchet::App::SkipDefaultOption # for forcefully removing e.g. --exit-code, a user can pass this
-
-        arg = "--#{k.to_s.shellescape}"
-        arg << "=#{v.to_s.shellescape}" unless v.nil? # nil means we include the option without an argument
-        arg
-      end
-
-      "heroku run #{heroku_options_array.compact.join(' ')} -- #{command}"
-    end
-  end
 end

--- a/test/spec/spec_helper.rb
+++ b/test/spec/spec_helper.rb
@@ -10,6 +10,8 @@ require 'json'
 require 'sem_version'
 require 'shellwords'
 require 'excon'
+require 'open3'
+require 'timeout'
 
 ENV['RACK_ENV'] = 'test'
 
@@ -27,7 +29,7 @@ RSpec.configure do |config|
 	config.verbose_retry       = true # show retry status in spec process
 	config.default_retry_count = 2 if ENV['IS_RUNNING_ON_CI'] # retry all tests that fail again...
 	# config.exceptions_to_retry = [Excon::Errors::Timeout] #... if they're caused by these exception types
-	config.fail_fast = 1 if ENV['IS_RUNNING_ON_CI']
+  # config.fail_fast = 1 if ENV['IS_RUNNING_ON_CI']
 
 	config.expect_with :rspec do |c|
 		c.syntax = :expect
@@ -89,4 +91,192 @@ def run!(cmd)
 	out = `#{cmd}`
 	raise "Command #{cmd} failed: #{out}" unless $?.success?
 	out
+end
+
+module Hatchet
+	class App
+    def run(cmd_type, command = DefaultCommand, options = {}, &block)
+      case command
+      when Hash
+        options.merge!(command)
+        command = cmd_type.to_s
+      when nil
+        STDERR.puts "Calling App#run with an explicit nil value in the second argument is deprecated."
+        STDERR.puts "You can pass in a hash directly as the second argument now.\n#{caller.join("\n")}"
+        command = cmd_type.to_s
+      when DefaultCommand
+        command = cmd_type.to_s
+      else
+        command = command.to_s
+      end
+
+      allow_run_multi! if @run_multi
+
+      run_obj = Hatchet::HerokuRun.new(
+        command,
+        app: self,
+        retry_on_empty: options.fetch(:retry_on_empty, !ENV["HATCHET_DISABLE_EMPTY_RUN_RETRY"]),
+        retry_delay: @run_multi ? 0 : (ENV["HATCHET_RUN_RETRY_DELAY"] || 5).to_i,
+        heroku: options[:heroku],
+        raw: options[:raw],
+        timeout: options.fetch(:timeout, (ENV["HATCHET_DEFAULT_RUN_TIMEOUT"] || 60).to_i)
+      ).call
+
+      return options[:return_obj] ? run_obj : run_obj.output
+    end
+    def run_multi(command, options = {}, &block)
+      raise "Block required" if block.nil?
+      allow_run_multi!
+
+      run_thread = Thread.new do
+        run_obj = Hatchet::HerokuRun.new(
+          command,
+          app: self,
+          retry_on_empty: options.fetch(:retry_on_empty, !ENV["HATCHET_DISABLE_EMPTY_RUN_RETRY"]),
+          retry_delay: @run_multi ? 0 : (ENV["HATCHET_RUN_RETRY_DELAY"] || 5).to_i,
+          heroku: options[:heroku],
+          raw: options[:raw],
+          timeout: options.fetch(:timeout, (ENV["HATCHET_DEFAULT_RUN_TIMEOUT"] || 60).to_i)
+        ).call
+
+        yield run_obj.output, run_obj.status
+      end
+      run_thread.abort_on_exception = true
+
+      @run_multi_array << run_thread
+
+      true
+    end
+	end
+  class HerokuRun
+    class HerokuRunEmptyOutputError < RuntimeError; end
+    class HerokuRunTimeoutError < RuntimeError; end
+
+    attr_reader :command
+
+    def initialize(
+      command,
+      app: ,
+      heroku: {},
+      retry_on_empty: !ENV["HATCHET_DISABLE_EMPTY_RUN_RETRY"],
+      retry_delay: 0,
+      raw: false,
+      stderr: $stderr,
+      timeout: 0)
+
+      @raw = raw
+      @app = app
+      @timeout = timeout
+      @command = build_heroku_command(command, heroku || {})
+      @retry_on_empty = retry_on_empty
+      @retry_delay = retry_delay
+      @stderr = stderr
+      @output = ""
+      @status = nil
+      @empty_fail_count = 0
+      @timeout_fail_count = 0
+    end
+
+    def output
+      raise "You must run `call` on this object first" unless @status
+      @output
+    end
+
+    def status
+      raise "You must run `call` on this object first" unless @status
+      @status
+    end
+
+    def call
+      begin
+        execute!
+      rescue HerokuRunEmptyOutputError => e
+        if @retry_on_empty and (@empty_fail_count += 1) <=3
+          message = String.new("Empty output from run #{@dyno_id} with command #{@command}, retrying in #{@retry_delay} seconds.")
+          message << "\nTo disable pass in `retry_on_empty: false` or set HATCHET_DISABLE_EMPTY_RUN_RETRY=1 globally"
+          message << "\nfailed_count: #{@empty_fail_count}"
+          message << "\nreleases: #{@app.releases}"
+          message << "\n#{caller.join("\n")}"
+          @stderr.puts message
+          sleep(@retry_delay) # without run_multi, this will prevent frequent "can only run one free dyno" errors
+          retry
+        end
+      rescue HerokuRunTimeoutError => e
+        if (@timeout_fail_count += 1) <= 3
+          message = String.new("Run #{@dyno_id} with command #{@command} timed out after #{@timeout}, stopping dyno and re-trying.")
+          message << "\nOutput until moment of termination was: #{@output}"
+          message << "\nTo disable pass in `timeout: 0` or set HATCHET_DEFAULT_RUN_TIMEOUT=0 globally"
+          message << "\nfailed_count: #{@timeout_fail_count}"
+          message << "\nreleases: #{@app.releases}"
+          message << "\n#{caller.join("\n")}"
+          @stderr.puts message
+          @app.platform_api.dyno.stop(@app.name, @dyno_id) if @dyno_id
+          sleep(@retry_delay == 0 ? 0 : 1) # a second should be enough for all cases after our explicit stop
+          retry
+        end
+      end
+
+      self
+    end
+
+    private def execute!
+      ShellThrottle.new(platform_api: @app.platform_api).call do |throttle|
+        run_shell!
+        throw(:throttle) if output.match?(/reached the API rate limit/)
+      end
+    end
+
+    def run_shell!
+      @output = ""
+      @dyno_id = nil
+      Open3.popen3(@command) do |stdin, stdout, stderr, wait_thread|
+      begin
+        Timeout.timeout(@timeout) do
+          Thread.new do
+            until stdout.eof? do
+              @output += stdout.gets
+            end
+          rescue IOError # eof? and gets race condition
+          end
+          Thread.new do
+            until stderr.eof? do
+              @stderr.puts line = stderr.gets
+              if !@dyno_id and run = line.match(/, (run\.\d+)/)
+                @dyno_id = run.captures.first
+              end
+            end
+          rescue IOError # eof? and gets race condition
+          end
+          @status = wait_thread.value # wait for termination
+        end
+        rescue Timeout::Error
+          Process.kill("TERM", wait_thread.pid)
+          @status = wait_thread.value # wait for termination
+        end
+        # FIXME: usage of $? in tests is very likely not threadsafe, and does not allow a test to distinguish between a TERM by us or inside the dyno
+        # this should be part of a proper interface to the run result instead but that's a breaking change
+        # change app.run to return whole run object which has to_s and to_str for output?
+        status = @status.signaled? ? @status.termsig+128 : @status.exitstatus # a signaled program will not have an exit status, but the shell represents that case as 128+$signal, so e.g. 128+15=143 for SIGTERM
+        `exit #{status}` # re-set $? for tests that rely on us previously having used backticks
+        raise HerokuRunTimeoutError if @status.signaled? # program got terminated by our SIGTERM, raise
+        raise HerokuRunEmptyOutputError if @output.empty?
+      end
+    end
+
+    private def build_heroku_command(command, options = {})
+      command = command.shellescape unless @raw
+
+      default_options = { "app" => @app.name, "exit-code" => nil }
+      heroku_options_array = (default_options.merge(options)).map do |k,v|
+        # This was a bad interface decision
+        next if v == Hatchet::App::SkipDefaultOption # for forcefully removing e.g. --exit-code, a user can pass this
+
+        arg = "--#{k.to_s.shellescape}"
+        arg << "=#{v.to_s.shellescape}" unless v.nil? # nil means we include the option without an argument
+        arg
+      end
+
+      "heroku run #{heroku_options_array.compact.join(' ')} -- #{command}"
+    end
+  end
 end


### PR DESCRIPTION
Use Hatchet branch with timeout support so those `heroku run`s that time out get re-tried.

Don't use `$?` anymore for exit status checks as Hatchet no longer uses backticks internally to shell out to `heroku run`.

As `ext-newrelic` isn't available yet for PHP 8, special casing for that one test.