### PR TITLE
Fix "heroku-sys/php" name in platform repo example

### DIFF
--- a/support/build/README.md
+++ b/support/build/README.md
@@ -780,7 +780,7 @@ Assuming that the extension has no stack-specific requirements (meaning it can r
     				"version": "1.2.3",
     				"type": "heroku-sys-php-extension",
     				"require": {
-    					"php": "7.3.*",
+    					"heroku-sys/php": "7.3.*",
     					"heroku/installer-plugin": "^1.2.0",
     				},
     				"dist": {


### PR DESCRIPTION
Platform packages must require others with their "`heroku-sys`" prefix; thanks for bringing this up in https://github.com/heroku/heroku-buildpack-php/issues/417#issuecomment-780084876, @boboldehampsink