### PR TITLE
Allow graceful shutdown on SIGTERM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # heroku-buildpack-php CHANGELOG
 
+## v190 (2021-03-04)
+
+### CHG
+
+- If `HEROKU_PHP_GRACEFUL_SIGTERM=1`, gracefully shut down PHP-FPM, Apache/Nginx, and log redirection in environments where all processes (not just the leader) receive a SIGTERM for termination [David Zuelke]
+
 ## v189 (2021-02-05)
 
 ### ADD

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/heroku/hatchet.git
-  revision: 1e771cb2577a9c4ef3caa52d793e1c83fb8410af
+  revision: 53655a3b5a33c92560aef360d558c6f812a5b679
   branch: timeouts-etc
   specs:
     heroku_hatchet (7.4.0)
@@ -15,35 +15,37 @@ GEM
   specs:
     diff-lcs (1.4.4)
     erubis (2.7.0)
-    excon (0.78.0)
-    heroics (0.1.1)
+    excon (0.79.0)
+    heroics (0.1.2)
       erubis (~> 2.0)
       excon
       moneta
       multi_json (>= 1.9.2)
+      webrick
     moneta (1.0.0)
     multi_json (1.15.0)
     parallel (1.20.1)
-    parallel_tests (3.4.0)
+    parallel_tests (3.5.0)
       parallel
-    platform-api (3.2.0)
+    platform-api (3.3.0)
       heroics (~> 0.1.1)
       moneta (~> 1.0.0)
       rate_throttle_client (~> 0.1.0)
-    rake (13.0.1)
+    rake (13.0.3)
     rate_throttle_client (0.1.2)
     rrrretry (1.0.0)
-    rspec-core (3.10.0)
+    rspec-core (3.10.1)
       rspec-support (~> 3.10.0)
-    rspec-expectations (3.10.0)
+    rspec-expectations (3.10.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
     rspec-retry (0.6.2)
       rspec-core (> 3.3)
-    rspec-support (3.10.0)
+    rspec-support (3.10.2)
     sem_version (2.0.1)
-    thor (1.0.1)
+    thor (1.1.0)
     threaded (0.0.4)
+    webrick (1.7.0)
 
 PLATFORMS
   ruby

--- a/bin/heroku-php-apache2
+++ b/bin/heroku-php-apache2
@@ -389,6 +389,10 @@ mkfifo $wait_pipe
 exec 3<> $wait_pipe
 
 pids=()
+graceful_sigterm=
+if [[ "${HEROKU_PHP_GRACEFUL_SIGTERM:-0}" != "0" ]]; then
+	graceful_sigterm=1
+fi
 
 # trap SIGTERM (for when we get killed) and EXIT (upon failure of any command due to set -e, or because of the exit at the very end), we then
 # 1) restore the trap for the signal in question so it doesn't fire again due to the kill at the end of the trap, as well as for EXIT, because that would fire too
@@ -401,7 +405,7 @@ pids=()
 # 3) as the signal to subshells, we use SIGUSR1 if we're getting a SIGTERM or SIGINT (for graceful shutdown), and a SIGTERM otherwise
 # 3a) this is so subshells can tell whether we sent them the signal and they should in turn stop gracefully (SIGUSR1)...
 # 3b) ... or if something crashed, or e.g. Heroku's process manager sent SIGTERM to all processes in the group, in which case a graceful shutdown attempt is futile anyway
-# 3c) SIGINT oder SIGQUIT are not an option since backgrounded subshells cannot trap them (http://vaab.blog.kal.fr/2016/07/30/trapping-sigint-sigquit-in-asynchronous-tasks/)
+# 3c) SIGINT oder SIGQUIT are not an option since backgrounded subshells cannot trap them (http://vaab.blog.kal.fr/2016/07/30/trapping-sigint-sigquit-in-asynchronous-tasks/) in Bash 3 (it works in Bash 4+ in interactive shells at least)
 # 4) kill ourselves with the correct signal in case we're handling SIGTERM or, further down, SIGINT (http://www.cons.org/cracauer/sigint.html and http://mywiki.wooledge.org/SignalTrap#Special_Note_On_SIGINT1)
 cleanup() {
 	signal=${1:-TERM}
@@ -414,9 +418,11 @@ cleanup() {
 	rm -f ${wait_pipe} || true;
 	echo "Shutdown complete." >&2
 }
+# we always try to shut down gracefully on SIGTERM
+# this may not work depending on env vars and platform behavior, but the subshells will take care of those details
 trap 'trap - TERM EXIT; echo "SIGTERM received, attempting graceful shutdown..." >&2; cleanup USR1; kill -TERM $$' TERM
 # on "regular" EXIT (i.e. when we reached the end of the script because a process exited unexpectedly) just clean up and let the exit status bubble through (see last line)
-trap 'trap - EXIT; echo "Process exited unexpectedly: $exitproc, shutting down..." >&2; cleanup TERM' EXIT
+trap 'trap - EXIT; echo "Process exited unexpectedly: $exitproc, shutting down..." >&2; cleanup USR1' EXIT
 
 # if FD 1 is a TTY (that's the -t 1 check), trap SIGINT/Ctrl+C, then same procedure as for TERM above
 if [[ -t 1 ]]; then
@@ -466,13 +472,32 @@ fi
 		sedbufarg="-u" # unix/gnu sed: -u unbuffered (arbitrary) chunks of data
 	fi
 
-	tail -qF -n 0 "${logs[@]}" > "$logs_pipe" & logs_procs+=($!)
-	sed $sedbufarg -E -e 's/^\[[^]]+\] WARNING: \[pool [^]]+\] child [0-9]+ said into std(err|out): "(.*)("|...)$/\2\3/' -e 's/"$//' < "$logs_pipe" 1>&2 & logs_procs+=($!) # messages that are too long are cut off using "..." by FPM instead of closing double quotation marks; we want to preserve those three dots but not the closing double quotes
+	# we need 'tail' and 'sed' to ignore SIGTERM as well
+	# we do that by setting the handler for SIGTERM to SIG_IGN, then exec-ing the program, which preserves the signal handler (see https://pubs.opengroup.org/onlinepubs/9699919799/functions/execle.html):
+	# "Signals set to the default action (SIG_DFL) in the calling process image shall be set to the default action in the new process image. Except for SIGCHLD, signals set to be ignored (SIG_IGN) by the calling process image shall be set to be ignored by the new process image. Signals set to be caught by the calling process image shall be set to the default action in the new process image (see <signal.h>)."
+	# this of course doesn't work in more complex cases like Nginx or Apache or PHP, which install their own signal handlers on startup, but tail and sed don't do that
+	(
+		[[ $graceful_sigterm ]] && trap '' TERM
+		exec tail -qF -n 0 "${logs[@]}" > "$logs_pipe"
+	) & logs_procs+=($!)
+	(
+		[[ $graceful_sigterm ]] && trap '' TERM
+		# messages that are too long are cut off using "..." by FPM instead of closing double quotation marks; we want to preserve those three dots but not the closing double quotes
+		exec sed $sedbufarg -E -e 's/^\[[^]]+\] WARNING: \[pool [^]]+\] child [0-9]+ said into std(err|out): "(.*)("|...)$/\2\3/' -e 's/"$//' < "$logs_pipe" 1>&2
+	) & logs_procs+=($!)
 	# after the kill, we are redirecting stderr to /dev/null using exec to suppress "… Terminated …" messages from the shell, which it would print right before the next command is invoked
-	trap '[[ $verbose ]] && echo "Stopping log redirection..." >&2; kill -TERM "${logs_procs[@]}" 2> /dev/null || true; exec 2> /dev/null' TERM USR1
+	# we have to send SIGHUP to each process (could also use SIGUSR1 or any other process where the default behavior is termination, see https://man7.org/linux/man-pages/man7/signal.7.html); SIGQUIT or SIGINT doesn't work - this is because of the SIG_IGN workaround above, which is done using a backgrounded subshell and an exec - and backgrounded subshells cannot trap SIGTERM or SIGINT: http://vaab.blog.kal.fr/2016/07/30/trapping-sigint-sigquit-in-asynchronous-tasks/
+	trap '[[ $verbose ]] && echo "Stopping log redirection..." >&2; kill -HUP "${logs_procs[@]}" 2> /dev/null || true; exec 2> /dev/null' USR1
+	# ignore process group wide SIGTERM for this subshell if that env var is set
+	if [[ $graceful_sigterm ]]; then
+		trap '' TERM
+	else
+		trap '[[ $verbose ]] && echo "Stopping log redirection..." >&2; kill -TERM "${logs_procs[@]}" 2> /dev/null || true; exec 2> /dev/null' TERM
+	fi
 
 	wait 2> /dev/null || true # redirect stderr to prevent possible trap race condition warnings
-	trap - TERM USR1
+	trap - USR1
+	[[ $graceful_sigterm ]] || trap - TERM # only reset to default if we're not ignoring, or a SIGTERM from the outside that tries to kill all running processes might arrive just in this moment to unblock the next wait
 	wait 2> /dev/null || true # redirect stderr to prevent possible trap race condition warnings
 ) & pids+=($!)
 
@@ -494,11 +519,17 @@ fpm_pidfile=$(mktemp -t "heroku.php-fpm.pid-$PORT.XXXXXX" -u)
 
 	php-fpm --pid "$fpm_pidfile" --nodaemonize -y "$fpm_config" ${php_config:+-c "$php_config"} & pid=$!
 	# wait for the pidfile in the trap; otherwise, a previous subshell failing may result in us getting a SIGTERM and forwarding it to the child process before that child process is ready to process signals
-	trap 'echo "Stopping php-fpm..." >&2; wait_pid_and_pidfile $pid "$fpm_pidfile"; kill -TERM $pid 2> /dev/null || true' TERM
 	trap 'echo "Stopping php-fpm gracefully..." >&2; wait_pid_and_pidfile $pid "$fpm_pidfile"; kill -QUIT $pid 2> /dev/null || true' USR1
+	# we always want to try and stop gracefully, especially since on Heroku we might be getting a process group wide SIGTERM but running a patched PHP-FPM that ignores SIGTERM; so if that env var is set, we ignore SIGTERM in this subshell as well
+	if [[ $graceful_sigterm ]]; then
+		trap '' TERM
+	else
+		trap 'echo "Stopping php-fpm..." >&2; wait_pid_and_pidfile $pid "$fpm_pidfile"; kill -TERM $pid 2> /dev/null || true' TERM
+	fi
 
 	wait $pid 2> /dev/null || true # redirect stderr to prevent possible trap race condition warnings
-	trap - TERM USR1
+	trap - USR1
+	[[ $graceful_sigterm ]] || trap - TERM # only reset to default if we're not ignoring, or a SIGTERM from the outside that tries to kill all running processes might arrive just in this moment to unblock the next wait
 	wait $pid 2> /dev/null || true # redirect stderr to prevent possible trap race condition warnings
 ) & pids+=($!)
 
@@ -517,8 +548,13 @@ httpd_pidfile=$(httpd -t -D DUMP_RUN_CFG 2> /dev/null | sed -n -E 's/PidFile: "(
 
 	httpd -D NO_DETACH -c "Include $httpd_config" & pid=$!
 	# wait for the pidfile in the trap; otherwise, a previous subshell failing may result in us getting a SIGTERM and forwarding it to the child process before that child process is ready to process signals
-	trap 'echo "Stopping httpd..." >&2; wait_pid_and_pidfile $pid "$httpd_pidfile"; kill -TERM $pid 2> /dev/null || true' TERM
 	trap 'echo "Stopping httpd gracefully..." >&2; wait_pid_and_pidfile $pid "$httpd_pidfile"; kill -WINCH $pid 2> /dev/null || true' USR1
+	# we always want to try and stop gracefully, especially since on Heroku we might be getting a process group wide SIGTERM but running a patched HTTPD that ignores SIGTERM; so if that env var is set, we ignore SIGTERM in this subshell as well
+	if [[ $graceful_sigterm ]]; then
+		trap '' TERM
+	else
+		trap 'echo "Stopping httpd..." >&2; wait_pid_and_pidfile $pid "$httpd_pidfile"; kill -TERM $pid 2> /dev/null || true' TERM
+	fi
 
 	# first, we wait for the pid file to be written, so that we can emit a ready message
 	wait_pid_and_pidfile $pid "$httpd_pidfile"
@@ -526,7 +562,8 @@ httpd_pidfile=$(httpd -t -D DUMP_RUN_CFG 2> /dev/null | sed -n -E 's/PidFile: "(
 	[[ -z ${DYNO:-} || $verbose ]] && kill -0 $pid 2> /dev/null && echo "Application ready for connections on port $PORT." >&2
 
 	wait $pid 2> /dev/null || true # redirect stderr to prevent possible trap race condition warnings
-	trap - TERM USR1
+	trap - USR1
+	[[ $graceful_sigterm ]] || trap - TERM # only reset to default if we're not ignoring, or a SIGTERM from the outside that tries to kill all running processes might arrive just in this moment to unblock the next wait
 	wait $pid 2> /dev/null || true # redirect stderr to prevent possible trap race condition warnings
 ) & pids+=($!)
 

--- a/bin/heroku-php-nginx
+++ b/bin/heroku-php-nginx
@@ -433,7 +433,7 @@ fi
 # 2a) if a SIGTERM or SIGUSR1 is received, this will unblock the first 'wait' and execute the corresponding trap
 # 2b) a second 'wait' then ensures that the subshell remains alive until the process inside has shut down
 # 2c) both 'wait' calls use || true to prevent 'set -e' failures: 'wait' returns the exit status of the given program, and that won't be zero, because it's getting killed
-# 2d) 'wait' on that killed subprocess, sending wait's output to /dev/null - this prevents the logs getting cluttered with "vendor/bin/heroku-...: line 309:    96 Terminated" messages (we can't use 'disown' after launching programs for that purpose because that removes the jobs from the shell's jobs table and then we can no longer 'wait' on the program)
+# 2d) we restore traps before the second wait, because restoring them inside the trap handler occasionally caused bizarre signal handling failures
 # 3) each subshell has another trap on INT which does nothing (to prevent Ctrl+C interference)
 # 4) we execute the command in the background, recording its PID(s) for the subshell's TERM trap
 # 5) we also execute the subshell in the background, recording its PID for the main TERM/INT traps

--- a/bin/heroku-php-nginx
+++ b/bin/heroku-php-nginx
@@ -389,6 +389,10 @@ mkfifo $wait_pipe
 exec 3<> $wait_pipe
 
 pids=()
+graceful_sigterm=
+if [[ "${HEROKU_PHP_GRACEFUL_SIGTERM:-0}" != "0" ]]; then
+	graceful_sigterm=1
+fi
 
 # trap SIGTERM (for when we get killed) and EXIT (upon failure of any command due to set -e, or because of the exit at the very end), we then
 # 1) restore the trap for the signal in question so it doesn't fire again due to the kill at the end of the trap, as well as for EXIT, because that would fire too
@@ -401,7 +405,7 @@ pids=()
 # 3) as the signal to subshells, we use SIGUSR1 if we're getting a SIGTERM or SIGINT (for graceful shutdown), and a SIGTERM otherwise
 # 3a) this is so subshells can tell whether we sent them the signal and they should in turn stop gracefully (SIGUSR1)...
 # 3b) ... or if something crashed, or e.g. Heroku's process manager sent SIGTERM to all processes in the group, in which case a graceful shutdown attempt is futile anyway
-# 3c) SIGINT oder SIGQUIT are not an option since backgrounded subshells cannot trap them (http://vaab.blog.kal.fr/2016/07/30/trapping-sigint-sigquit-in-asynchronous-tasks/)
+# 3c) SIGINT oder SIGQUIT are not an option since backgrounded subshells cannot trap them (http://vaab.blog.kal.fr/2016/07/30/trapping-sigint-sigquit-in-asynchronous-tasks/) in Bash 3 (it works in Bash 4+ in interactive shells at least)
 # 4) kill ourselves with the correct signal in case we're handling SIGTERM or, further down, SIGINT (http://www.cons.org/cracauer/sigint.html and http://mywiki.wooledge.org/SignalTrap#Special_Note_On_SIGINT1)
 cleanup() {
 	signal=${1:-TERM}
@@ -414,9 +418,11 @@ cleanup() {
 	rm -f ${wait_pipe} || true;
 	echo "Shutdown complete." >&2
 }
+# we always try to shut down gracefully on SIGTERM
+# this may not work depending on env vars and platform behavior, but the subshells will take care of those details
 trap 'trap - TERM EXIT; echo "SIGTERM received, attempting graceful shutdown..." >&2; cleanup USR1; kill -TERM $$' TERM
 # on "regular" EXIT (i.e. when we reached the end of the script because a process exited unexpectedly) just clean up and let the exit status bubble through (see last line)
-trap 'trap - EXIT; echo "Process exited unexpectedly: $exitproc, shutting down..." >&2; cleanup TERM' EXIT
+trap 'trap - EXIT; echo "Process exited unexpectedly: $exitproc, shutting down..." >&2; cleanup USR1' EXIT
 
 # if FD 1 is a TTY (that's the -t 1 check), trap SIGINT/Ctrl+C, then same procedure as for TERM above
 if [[ -t 1 ]]; then
@@ -466,13 +472,32 @@ fi
 		sedbufarg="-u" # unix/gnu sed: -u unbuffered (arbitrary) chunks of data
 	fi
 
-	tail -qF -n 0 "${logs[@]}" > "$logs_pipe" & logs_procs+=($!)
-	sed $sedbufarg -E -e 's/^\[[^]]+\] WARNING: \[pool [^]]+\] child [0-9]+ said into std(err|out): "(.*)("|...)$/\2\3/' -e 's/"$//' < "$logs_pipe" 1>&2 & logs_procs+=($!) # messages that are too long are cut off using "..." by FPM instead of closing double quotation marks; we want to preserve those three dots but not the closing double quotes
+	# we need 'tail' and 'sed' to ignore SIGTERM as well
+	# we do that by setting the handler for SIGTERM to SIG_IGN, then exec-ing the program, which preserves the signal handler (see https://pubs.opengroup.org/onlinepubs/9699919799/functions/execle.html):
+	# "Signals set to the default action (SIG_DFL) in the calling process image shall be set to the default action in the new process image. Except for SIGCHLD, signals set to be ignored (SIG_IGN) by the calling process image shall be set to be ignored by the new process image. Signals set to be caught by the calling process image shall be set to the default action in the new process image (see <signal.h>)."
+	# this of course doesn't work in more complex cases like Nginx or Apache or PHP, which install their own signal handlers on startup, but tail and sed don't do that
+	(
+		[[ $graceful_sigterm ]] && trap '' TERM
+		exec tail -qF -n 0 "${logs[@]}" > "$logs_pipe"
+	) & logs_procs+=($!)
+	(
+		[[ $graceful_sigterm ]] && trap '' TERM
+		# messages that are too long are cut off using "..." by FPM instead of closing double quotation marks; we want to preserve those three dots but not the closing double quotes
+		exec sed $sedbufarg -E -e 's/^\[[^]]+\] WARNING: \[pool [^]]+\] child [0-9]+ said into std(err|out): "(.*)("|...)$/\2\3/' -e 's/"$//' < "$logs_pipe" 1>&2
+	) & logs_procs+=($!)
 	# after the kill, we are redirecting stderr to /dev/null using exec to suppress "… Terminated …" messages from the shell, which it would print right before the next command is invoked
-	trap '[[ $verbose ]] && echo "Stopping log redirection..." >&2; kill -TERM "${logs_procs[@]}" 2> /dev/null || true; exec 2> /dev/null' TERM USR1
+	# we have to send SIGHUP to each process (could also use SIGUSR1 or any other process where the default behavior is termination, see https://man7.org/linux/man-pages/man7/signal.7.html); SIGQUIT or SIGINT doesn't work - this is because of the SIG_IGN workaround above, which is done using a backgrounded subshell and an exec - and backgrounded subshells cannot trap SIGTERM or SIGINT: http://vaab.blog.kal.fr/2016/07/30/trapping-sigint-sigquit-in-asynchronous-tasks/
+	trap '[[ $verbose ]] && echo "Stopping log redirection..." >&2; kill -HUP "${logs_procs[@]}" 2> /dev/null || true; exec 2> /dev/null' USR1
+	# ignore process group wide SIGTERM for this subshell if that env var is set
+	if [[ $graceful_sigterm ]]; then
+		trap '' TERM
+	else
+		trap '[[ $verbose ]] && echo "Stopping log redirection..." >&2; kill -TERM "${logs_procs[@]}" 2> /dev/null || true; exec 2> /dev/null' TERM
+	fi
 
 	wait 2> /dev/null || true # redirect stderr to prevent possible trap race condition warnings
-	trap - TERM USR1
+	trap - USR1
+	[[ $graceful_sigterm ]] || trap - TERM # only reset to default if we're not ignoring, or a SIGTERM from the outside that tries to kill all running processes might arrive just in this moment to unblock the next wait
 	wait 2> /dev/null || true # redirect stderr to prevent possible trap race condition warnings
 ) & pids+=($!)
 
@@ -494,11 +519,17 @@ fpm_pidfile=$(mktemp -t "heroku.php-fpm.pid-$PORT.XXXXXX" -u)
 
 	php-fpm --pid "$fpm_pidfile" --nodaemonize -y "$fpm_config" ${php_config:+-c "$php_config"} & pid=$!
 	# wait for the pidfile in the trap; otherwise, a previous subshell failing may result in us getting a SIGTERM and forwarding it to the child process before that child process is ready to process signals
-	trap 'echo "Stopping php-fpm..." >&2; wait_pid_and_pidfile $pid "$fpm_pidfile"; kill -TERM $pid 2> /dev/null || true' TERM
 	trap 'echo "Stopping php-fpm gracefully..." >&2; wait_pid_and_pidfile $pid "$fpm_pidfile"; kill -QUIT $pid 2> /dev/null || true' USR1
+	# we always want to try and stop gracefully, especially since on Heroku we might be getting a process group wide SIGTERM but running a patched PHP-FPM that ignores SIGTERM; so if that env var is set, we ignore SIGTERM in this subshell as well
+	if [[ $graceful_sigterm ]]; then
+		trap '' TERM
+	else
+		trap 'echo "Stopping php-fpm..." >&2; wait_pid_and_pidfile $pid "$fpm_pidfile"; kill -TERM $pid 2> /dev/null || true' TERM
+	fi
 
 	wait $pid 2> /dev/null || true # redirect stderr to prevent possible trap race condition warnings
-	trap - TERM USR1
+	trap - USR1
+	[[ $graceful_sigterm ]] || trap - TERM # only reset to default if we're not ignoring, or a SIGTERM from the outside that tries to kill all running processes might arrive just in this moment to unblock the next wait
 	wait $pid 2> /dev/null || true # redirect stderr to prevent possible trap race condition warnings
 ) & pids+=($!)
 
@@ -517,8 +548,13 @@ nginx_pidfile=$(mktemp -t "heroku.nginx.pid-$PORT.XXXXXX" -u)
 
 	nginx -c "$nginx_main" -g "pid $nginx_pidfile; include $nginx_config;" & pid=$!
 	# wait for the pidfile in the trap; otherwise, a previous subshell failing may result in us getting a SIGTERM and forwarding it to the child process before that child process is ready to process signals
-	trap 'echo "Stopping nginx..." >&2; wait_pid_and_pidfile $pid "$nginx_pidfile"; kill -TERM $pid 2> /dev/null || true' TERM
 	trap 'echo "Stopping nginx gracefully..." >&2; wait_pid_and_pidfile $pid "$nginx_pidfile"; kill -QUIT $pid 2> /dev/null || true' USR1
+	# we always want to try and stop gracefully, especially since on Heroku we might be getting a process group wide SIGTERM but running a patched Nginx that ignores SIGTERM; so if that env var is set, we ignore SIGTERM in this subshell as well
+	if [[ $graceful_sigterm ]]; then
+		trap '' TERM
+	else
+		trap 'echo "Stopping nginx..." >&2; wait_pid_and_pidfile $pid "$nginx_pidfile"; kill -TERM $pid 2> /dev/null || true' TERM
+	fi
 
 	# first, we wait for the pid file to be written, so that we can emit a ready message
 	wait_pid_and_pidfile $pid "$nginx_pidfile"
@@ -526,7 +562,8 @@ nginx_pidfile=$(mktemp -t "heroku.nginx.pid-$PORT.XXXXXX" -u)
 	[[ -z ${DYNO:-} || $verbose ]] && kill -0 $pid 2> /dev/null && echo "Application ready for connections on port $PORT." >&2
 
 	wait $pid 2> /dev/null || true # redirect stderr to prevent possible trap race condition warnings
-	trap - TERM USR1
+	trap - USR1
+	[[ $graceful_sigterm ]] || trap - TERM # only reset to default if we're not ignoring, or a SIGTERM from the outside that tries to kill all running processes might arrive just in this moment to unblock the next wait
 	wait $pid 2> /dev/null || true # redirect stderr to prevent possible trap race condition warnings
 ) & pids+=($!)
 

--- a/test/fixtures/sigterm/index.php
+++ b/test/fixtures/sigterm/index.php
@@ -5,3 +5,5 @@ $wait = (int)($_GET['wait']??0);
 sleep($wait);
 
 echo "hello world after $wait second(s)\n";
+
+file_put_contents("php://stderr", "request complete");

--- a/test/spec/sigterm_spec.rb
+++ b/test/spec/sigterm_spec.rb
@@ -17,6 +17,22 @@ describe "A PHP application" do
 						cmd = "heroku-php-#{server} & pid=$! ; sleep 5; curl \"localhost:$PORT/index.php?wait=5\" & sleep 2; kill $pid; wait $pid"
 						output = app.run(cmd)
 						expect(output).to match(/^hello world after 5 second\(s\)$/)
+						expect(output).to match(/^request complete$/) # ensure a late log line is captured, meaning the logs tail process stays alive until the end
+					end
+				end
+				
+				it "gracefully shuts down when all processes receives a SIGTERM and HEROKU_PHP_GRACEFUL_SIGTERM is set" do
+					app.deploy do |app|
+						# first, launch in the background and get the pid
+						# then sleep five seconds to allow boot (semicolon before ! needs a space, Bash...)
+						# curl the sleep() script (and remember the curl pid)
+						# pgrep all our user's PIDs, then inverse-grep away $$ (that's our shell) and the curl PID
+						# hand all those PIDs to kill
+						# wait for $pid so that we can be certain to get all the output
+						cmd = "heroku-php-#{server} & pid=$! ; sleep 5; curl \"localhost:$PORT/index.php?wait=5\" & curlpid=$!; sleep 2; kill $(pgrep -U $UID | grep -vw -e $$ -e $curlpid) 2>/dev/null; wait $pid"
+						output = app.run(cmd, { :heroku => { "env" => "HEROKU_PHP_GRACEFUL_SIGTERM=1" }} )
+						expect(output).to match(/^hello world after 5 second\(s\)$/)
+						expect(output).to match(/^request complete$/) # ensure a late log line is captured, meaning the logs tail process stays alive until the end
 					end
 				end
 			end


### PR DESCRIPTION
Right now, Heroku sends a SIGTERM to every process when a dyno shuts down. This leads to Apache, Nginx and PHP-FPM also shutting down quickly, since that's what they do on that signal.

The result is requests terminated in-flight, and error messages for customers.

In preparation of this work, 0aac5b8 introduced support for PHP-FPM, Nginx and Apache to ignore SIGTERM if `HEROKU_PHP_GRACEFUL_SIGTERM` was set in the environment.

This PR updates both boot scripts to perform the right combination of signal sending or ignoring if that variable is set.

For the moment, this behavior is enabled only if setting `HEROKU_PHP_GRACEFUL_SIGTERM=1`.