### PR TITLE
Dev Center PHP Support matrix generator

### DIFF
--- a/support/devcenter/.gitignore
+++ b/support/devcenter/.gitignore
@@ -1,0 +1,2 @@
+!composer.lock
+vendor

--- a/support/devcenter/README.md
+++ b/support/devcenter/README.md
@@ -1,0 +1,35 @@
+# Dev Center PHP Support Article Generator
+
+This `generate.php` tool will, given platform repository URLs as arguments, generate:
+
+- the list of PHP runtimes, per stack
+- the list of built-in extensions, per PHP runtime series
+- the list of third-party extensions, per PHP runtime series
+
+for inclusion in https://devcenter.heroku.com/articles/php-support
+
+The extensions list is, where needed, annotated with footnotes that indicate if an extension isn't available on one or more stacks (this can happen e.g. when a required library doesn't exist on a stack).
+
+The third-party extensions list will list major version series (e.g. 2.x and 3.x) separately unless they can be collapsed into a single row (e.g. because for PHP 7, they're all versions 1.x and for PHP 8, versions 2.x). Separate entries will be generated in a single cell if the versions should, for any reason, differ between stacks. Only the latest version of an x.0.0 series is listed.
+
+## Invocation
+
+First, `composer install` the dependencies.
+
+By default, all three sections will be generated:
+
+```ShellSession
+$ ./generate.php https://lang-php.s3.amazonaws.com/dist-heroku-18-stable/packages.json https://lang-php.s3.amazonaws.com/dist-heroku-20-stable/packages.json
+```
+
+You may also generate any of the three sections individually using the `--runtimes`, `--built-in-extensions` or `--third-party-extensions` options:
+
+```ShellSession
+$ ./generate.php --third-party-extensions https://lang-php.s3.amazonaws.com/dist-heroku-18-stable/packages.json https://lang-php.s3.amazonaws.com/dist-heroku-20-stable/packages.json
+```
+
+You'd usually pipe the output into e.g. `pbcopy` and then update the Dev Center article.
+
+## Updating stacks and versions
+
+To add a new stack or PHP runtime series, add them to the respective lists at the top of `generate.php`. Stacks or series that are no longer in use will not be output, but it's still a good idea to periodically remove EOL stacks or series from the list.

--- a/support/devcenter/built-in-extensions.twig
+++ b/support/devcenter/built-in-extensions.twig
@@ -1,0 +1,2 @@
+{% set type = "built-in" %}
+{{ include("extensions.twig") }}

--- a/support/devcenter/composer.json
+++ b/support/devcenter/composer.json
@@ -1,0 +1,7 @@
+{
+	"require": {
+		"composer/semver": "^1.4",
+		"guzzlehttp/guzzle": "^6.0",
+		"twig/twig": "^2.0"
+	}
+}

--- a/support/devcenter/composer.lock
+++ b/support/devcenter/composer.lock
@@ -1,0 +1,882 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "0edea7109da5272f1f08b45762072407",
+    "packages": [
+        {
+            "name": "composer/semver",
+            "version": "1.7.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/semver.git",
+                "reference": "647490bbcaf7fc4891c58f47b825eb99d19c377a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/semver/zipball/647490bbcaf7fc4891c58f47b825eb99d19c377a",
+                "reference": "647490bbcaf7fc4891c58f47b825eb99d19c377a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.5 || ^5.0.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Semver\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nils Adermann",
+                    "email": "naderman@naderman.de",
+                    "homepage": "http://www.naderman.de"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                },
+                {
+                    "name": "Rob Bast",
+                    "email": "rob.bast@gmail.com",
+                    "homepage": "http://robbast.nl"
+                }
+            ],
+            "description": "Semver library that offers utilities, version constraint parsing and validation.",
+            "keywords": [
+                "semantic",
+                "semver",
+                "validation",
+                "versioning"
+            ],
+            "support": {
+                "irc": "irc://irc.freenode.org/composer",
+                "issues": "https://github.com/composer/semver/issues",
+                "source": "https://github.com/composer/semver/tree/1.7.2"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-12-03T15:47:16+00:00"
+        },
+        {
+            "name": "guzzlehttp/guzzle",
+            "version": "6.5.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/guzzle.git",
+                "reference": "9d4290de1cfd701f38099ef7e183b64b4b7b0c5e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/9d4290de1cfd701f38099ef7e183b64b4b7b0c5e",
+                "reference": "9d4290de1cfd701f38099ef7e183b64b4b7b0c5e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "guzzlehttp/promises": "^1.0",
+                "guzzlehttp/psr7": "^1.6.1",
+                "php": ">=5.5",
+                "symfony/polyfill-intl-idn": "^1.17.0"
+            },
+            "require-dev": {
+                "ext-curl": "*",
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.4 || ^7.0",
+                "psr/log": "^1.1"
+            },
+            "suggest": {
+                "psr/log": "Required for using the Log middleware"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "6.5-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Guzzle is a PHP HTTP client library",
+            "homepage": "http://guzzlephp.org/",
+            "keywords": [
+                "client",
+                "curl",
+                "framework",
+                "http",
+                "http client",
+                "rest",
+                "web service"
+            ],
+            "support": {
+                "issues": "https://github.com/guzzle/guzzle/issues",
+                "source": "https://github.com/guzzle/guzzle/tree/6.5"
+            },
+            "time": "2020-06-16T21:01:06+00:00"
+        },
+        {
+            "name": "guzzlehttp/promises",
+            "version": "1.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/promises.git",
+                "reference": "8e7d04f1f6450fef59366c399cfad4b9383aa30d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/8e7d04f1f6450fef59366c399cfad4b9383aa30d",
+                "reference": "8e7d04f1f6450fef59366c399cfad4b9383aa30d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "symfony/phpunit-bridge": "^4.4 || ^5.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Promise\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Guzzle promises library",
+            "keywords": [
+                "promise"
+            ],
+            "support": {
+                "issues": "https://github.com/guzzle/promises/issues",
+                "source": "https://github.com/guzzle/promises/tree/1.4.1"
+            },
+            "time": "2021-03-07T09:25:29+00:00"
+        },
+        {
+            "name": "guzzlehttp/psr7",
+            "version": "1.8.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/psr7.git",
+                "reference": "dc960a912984efb74d0a90222870c72c87f10c91"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/dc960a912984efb74d0a90222870c72c87f10c91",
+                "reference": "dc960a912984efb74d0a90222870c72c87f10c91",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0",
+                "psr/http-message": "~1.0",
+                "ralouphie/getallheaders": "^2.0.5 || ^3.0.0"
+            },
+            "provide": {
+                "psr/http-message-implementation": "1.0"
+            },
+            "require-dev": {
+                "ext-zlib": "*",
+                "phpunit/phpunit": "~4.8.36 || ^5.7.27 || ^6.5.14 || ^7.5.20 || ^8.5.8 || ^9.3.10"
+            },
+            "suggest": {
+                "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Psr7\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "homepage": "https://github.com/Tobion"
+                }
+            ],
+            "description": "PSR-7 message implementation that also provides common utility methods",
+            "keywords": [
+                "http",
+                "message",
+                "psr-7",
+                "request",
+                "response",
+                "stream",
+                "uri",
+                "url"
+            ],
+            "support": {
+                "issues": "https://github.com/guzzle/psr7/issues",
+                "source": "https://github.com/guzzle/psr7/tree/1.8.2"
+            },
+            "time": "2021-04-26T09:17:50+00:00"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-message/tree/master"
+            },
+            "time": "2016-08-06T14:39:51+00:00"
+        },
+        {
+            "name": "ralouphie/getallheaders",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ralouphie/getallheaders.git",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ralouphie/getallheaders/zipball/120b605dfeb996808c31b6477290a714d356e822",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^2.1",
+                "phpunit/phpunit": "^5 || ^6.5"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/getallheaders.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ralph Khattar",
+                    "email": "ralph.khattar@gmail.com"
+                }
+            ],
+            "description": "A polyfill for getallheaders.",
+            "support": {
+                "issues": "https://github.com/ralouphie/getallheaders/issues",
+                "source": "https://github.com/ralouphie/getallheaders/tree/develop"
+            },
+            "time": "2019-03-08T08:55:37+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.23.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "46cd95797e9df938fdd2b03693b5fca5e64b01ce"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/46cd95797e9df938fdd2b03693b5fca5e64b01ce",
+                "reference": "46cd95797e9df938fdd2b03693b5fca5e64b01ce",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.23-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.23.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-02-19T12:13:01+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-idn",
+            "version": "v1.23.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-idn.git",
+                "reference": "65bd267525e82759e7d8c4e8ceea44f398838e65"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/65bd267525e82759e7d8c4e8ceea44f398838e65",
+                "reference": "65bd267525e82759e7d8c4e8ceea44f398838e65",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1",
+                "symfony/polyfill-intl-normalizer": "^1.10",
+                "symfony/polyfill-php72": "^1.10"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.23-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Idn\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Laurent Bassin",
+                    "email": "laurent@bassin.info"
+                },
+                {
+                    "name": "Trevor Rowbotham",
+                    "email": "trevor.rowbotham@pm.me"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's idn_to_ascii and idn_to_utf8 functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "idn",
+                "intl",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.23.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-05-27T09:27:20+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-normalizer",
+            "version": "v1.23.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
+                "reference": "8590a5f561694770bdcd3f9b5c69dde6945028e8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/8590a5f561694770bdcd3f9b5c69dde6945028e8",
+                "reference": "8590a5f561694770bdcd3f9b5c69dde6945028e8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.23-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's Normalizer class and related functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "intl",
+                "normalizer",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.23.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-02-19T12:13:01+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.23.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "2df51500adbaebdc4c38dea4c89a2e131c45c8a1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/2df51500adbaebdc4c38dea4c89a2e131c45c8a1",
+                "reference": "2df51500adbaebdc4c38dea4c89a2e131c45c8a1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.23-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.23.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-05-27T09:27:20+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php72",
+            "version": "v1.23.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php72.git",
+                "reference": "9a142215a36a3888e30d0a9eeea9766764e96976"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/9a142215a36a3888e30d0a9eeea9766764e96976",
+                "reference": "9a142215a36a3888e30d0a9eeea9766764e96976",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.23-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php72\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 7.2+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php72/tree/v1.23.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-05-27T09:17:38+00:00"
+        },
+        {
+            "name": "twig/twig",
+            "version": "v2.14.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/twigphp/Twig.git",
+                "reference": "27e5cf2b05e3744accf39d4c68a3235d9966d260"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/27e5cf2b05e3744accf39d4c68a3235d9966d260",
+                "reference": "27e5cf2b05e3744accf39d4c68a3235d9966d260",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/polyfill-ctype": "^1.8",
+                "symfony/polyfill-mbstring": "^1.3"
+            },
+            "require-dev": {
+                "psr/container": "^1.0",
+                "symfony/phpunit-bridge": "^4.4.9|^5.0.9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.14-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Twig_": "lib/"
+                },
+                "psr-4": {
+                    "Twig\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com",
+                    "homepage": "http://fabien.potencier.org",
+                    "role": "Lead Developer"
+                },
+                {
+                    "name": "Twig Team",
+                    "role": "Contributors"
+                },
+                {
+                    "name": "Armin Ronacher",
+                    "email": "armin.ronacher@active-4.com",
+                    "role": "Project Founder"
+                }
+            ],
+            "description": "Twig, the flexible, fast, and secure template language for PHP",
+            "homepage": "https://twig.symfony.com",
+            "keywords": [
+                "templating"
+            ],
+            "support": {
+                "issues": "https://github.com/twigphp/Twig/issues",
+                "source": "https://github.com/twigphp/Twig/tree/v2.14.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/twig/twig",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-05-16T12:12:47+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": [],
+    "plugin-api-version": "2.0.0"
+}

--- a/support/devcenter/extensions.twig
+++ b/support/devcenter/extensions.twig
@@ -1,0 +1,56 @@
+<!-- BEGIN {{ type|upper }}_EXTENSIONS -->
+<!-- THIS SECTION, BEGINNING WITH THE MARKER COMMENT ABOVE, IS AUTOMATICALLY GENERATED; DO NOT EDIT CONTENT BELOW BY HAND OR REMOVE MARKER ABOVE -->
+{% set numCaveats = 0 %}
+<table>
+	<thead>
+		<tr>
+			<th>Extension</th>
+{% for serie in series %}
+			<th{% if attribute(eol, serie) is defined %} style="{% if attribute(eol, serie) == "eol" %}background-color: rgba(194, 66, 0, 0.1); color: #C24200{% else %}background-color: #fff3c5; color: #927200{% endif %}"{% endif %}>PHP {{ serie }}</th>
+{% endfor %}
+		</tr>
+	</thead>
+	<tbody>
+{% for extension in extensions %}
+		<tr>
+			<td style="white-space: nowrap"><code>{% if extension.url %}<a href="{{ extension.url }}">{% endif %}{{ extension.name }}{% if extension.url %}</a>{% endif %}</code>{% if extension.major_version is defined %} ({{ extension.major_version }}x){% endif %}</td>
+	{% for serie, data in extension.data %}
+			<td {% if attribute(eol, serie) is defined %}style="{% if attribute(eol, serie) == "eol" %}background-color: rgba(194, 66, 0, 0.1); color: #C24200{% else %}background-color: #fff3c5; color: #927200{% endif %}"{% endif %}>
+		{% for version, caveats in data %}
+				{{ version|raw }}
+			{% for number, stack in caveats %}{% set numCaveats = numCaveats + 1 %}
+				<sup><a title="not available on the heroku-{{ stack }} stack" href="#footnote-{{ type }}-ext-not-{{ stack }}">&#x200b;[&#x200b;{{ number }}&#x200b;]</a></sup>
+			{% endfor %}
+				<br/>
+		{% else %}
+				-
+		{% endfor %}
+			</td>
+	{% endfor %}
+		</tr>
+{% endfor %}
+	</tbody>
+{% if numCaveats or type == "built-in" %}
+	<tfoot>
+{% if type == "built-in" %}
+		<tr>
+			<td colspan="{{ series|length + 1 }}">
+				<small>&#x2714;: enabled by default</small><br/>
+				<small>&#x2731;: optional, can be <a href="#using-optional-extensions">enabled via <code>composer.json</code></a></small><br/>
+			</td>
+		</tr>
+{% endif %}
+{% if numCaveats %}
+		<tr>
+			<td colspan="{{ series|length + 1 }}">
+{% for index, stack in stacks %}
+				<small id="footnote-{{ type }}-ext-not-{{ stack }}">[{{ index }}]: This extension is not available on the <a href="/articles/heroku-{{ stack }}-stack"><code>heroku-{{ stack }}</code> stack</a>.</small><br />
+{% endfor %}
+			</td>
+		</tr>
+{% endif %}
+	</tfoot>
+{% endif %}
+</table>
+<!-- THIS SECTION, ENDING WITH THE MARKER BELOW, IS AUTOMATICALLY GENERATED; DO NOT EDIT CONTENT ABOVE BY HAND OR REMOVE MARKER BELOW -->
+<!-- END {{ type|upper }}_EXTENSIONS -->

--- a/support/devcenter/generate.php
+++ b/support/devcenter/generate.php
@@ -5,13 +5,13 @@ use Composer\Semver\Comparator;
 
 require('vendor/autoload.php');
 
-// TODO: could we dynamically generate these by scanning all repos and somehow evaluating the constraints?
+// these need updating from time to time to add new stacks and remove EOL ones
 $stacks = [
 	1 => '16', // the offset we start with here is relevant for the numbering of footnotes
 	'18',
 	'20',
 ];
-// TODO: could we dynamically generate these by scanning all repos and somehow evaluating the constraints?
+// these need updating from time to time to add new series and remove EOL ones
 $series = [
 	'5.6',
 	'7.0',
@@ -196,6 +196,12 @@ while($row = $results->fetchArray(SQLITE3_ASSOC)) {
 		}
 	}
 }
+
+// now show just the real series that are even available as runtimes; no need to show empty columns
+$series = array_unique(array_merge(...$seriesByStack));
+// and from these also get the stacks that are actually populated
+$stacks = array_keys(array_filter($seriesByStack)); // filter with no args removes empty items
+$stacks = array_combine(range(1, count($stacks)), array_values($stacks)); // reindex from key 1, for our footnotes
 
 $extensionsQuery = ["SELECT extensions.name, extensions.url"];
 foreach($series as $serie) {

--- a/support/devcenter/generate.php
+++ b/support/devcenter/generate.php
@@ -7,14 +7,11 @@ require('vendor/autoload.php');
 
 // these need updating from time to time to add new stacks and remove EOL ones
 $stacks = [
-	1 => '16', // the offset we start with here is relevant for the numbering of footnotes
-	'18',
+	1 => '18', // the offset we start with here is relevant for the numbering of footnotes
 	'20',
 ];
 // these need updating from time to time to add new series and remove EOL ones
 $series = [
-	'5.6',
-	'7.0',
 	'7.1',
 	'7.2',
 	'7.3',

--- a/support/devcenter/generate.php
+++ b/support/devcenter/generate.php
@@ -1,0 +1,303 @@
+#!/usr/bin/env php
+<?php
+
+use Composer\Semver\Comparator;
+
+require('vendor/autoload.php');
+
+// TODO: could we dynamically generate these by scanning all repos and somehow evaluating the constraints?
+$stacks = [
+	1 => '16', // the offset we start with here is relevant for the numbering of footnotes
+	'18',
+	'20',
+];
+// TODO: could we dynamically generate these by scanning all repos and somehow evaluating the constraints?
+$series = [
+	'5.6',
+	'7.0',
+	'7.1',
+	'7.2',
+	'7.3',
+	'7.4',
+	'8.0',
+];
+
+$findstacks = function(array $package) use($stacks) {
+	if($package['require']) {
+		if(isset($package['require']['heroku-sys/heroku'])) {
+			return Composer\Semver\Semver::satisfiedBy($stacks, $package['require']['heroku-sys/heroku']);
+		}
+	}
+	return [];
+};
+
+$findseries = function(array $package) use($series) {
+	if($package['require']) {
+		if(isset($package['require']['heroku-sys/php'])) {
+			return Composer\Semver\Semver::satisfiedBy($series, $package['require']['heroku-sys/php']);
+		}
+	}
+	return [];
+};
+
+$stackname = function($version) {
+	return "heroku-${version}";
+};
+
+$filterStackVersions = function(array $row, string $serie, array $stacks, array $seriesByStack, callable $getValue) {
+	$versions = [];
+	foreach($stacks as $index => $stack) {
+		$value = $getValue($row, $serie, $stack);
+		if($value !== null) {
+			$versions[$value][$index] = $stack;
+		}
+	}
+	foreach($versions as &$version) {
+		$version = array_diff($stacks, $version);
+		$version = array_filter($version, function($stack) use($serie, $seriesByStack) { return isset($seriesByStack[$stack]) && in_array($serie, $seriesByStack[$stack]); });
+	}
+	return $versions;
+};
+
+$getBuiltinExtensionUrl = function($name) {
+	$name = str_replace("heroku-sys/ext-", "", $name);
+	switch(strtolower($name)) {
+		case "bz2":
+			$name = "bzip2";
+			break;
+		case "mysql":
+			return "http://php.net/manual/en/book.mysql.php";
+		case "zend-opcache":
+			$name = "opcache";
+			break;
+	}
+	return "http://php.net/$name";
+};
+
+$handlerStack = GuzzleHttp\HandlerStack::create(new GuzzleHttp\Handler\CurlHandler());
+$handlerStack->push(GuzzleHttp\Middleware::retry(function($times, $req, $res, $e) {
+	if($times >= 5) return false; // php.net sometimes randomly doesn't cooperate
+	if($e instanceof GuzzleHttp\Exception\ConnectException) return true;
+	if($res && $res->getStatusCode() >= 500) return true;
+	return false;
+}));
+$client = new GuzzleHttp\Client(['handler' => $handlerStack, "timeout" => "2.0"]);
+
+$repositories = [];
+array_shift($argv);
+$responses = GuzzleHttp\Pool::batch($client, (function() use($argv, $client) {
+	foreach($argv as $arg) {
+		yield function() use($client, $arg) {
+			if(file_exists($arg)) { // for local files
+				return new GuzzleHttp\Psr7\Response(200, [], file_get_contents($arg));
+			} else {
+				return $client->getAsync($arg);
+			}
+		};
+	}
+})(), [
+	'concurrency' => 5,
+	'rejected' => function($reason) {
+		throw $reason;
+	},
+	'fulfilled' => function($response, $index) use(&$repositories, $argv) {
+		if(!($repositories[] = json_decode($response->getBody(), true))) {
+			throw new Exception('Could not decode JSON for ' . $argv[$index]);
+		}
+	},
+]);
+
+$responses = GuzzleHttp\Promise\unwrap([
+	'eol' => $client->getAsync("http://php.net/eol.php"),
+	'sv' => $client->getAsync("http://php.net/supported-versions.php"),
+]);
+
+if(!preg_match_all("#<td>\s*([1-9]+\.[0-9]+)\s*</td>#m", $responses['eol']->getBody(), $matches)) {
+	throw new Exception('Could not parse eol.php');
+}
+$eol = array_combine($matches[1], array_fill(0, count($matches[1]), "eol")); // list of all release series that are EOL
+
+if(!preg_match_all('#<tr class="security">\s*<td>\s*<a href="/downloads.php[^"]+">(\d+\.\d+)#m', $responses['sv']->getBody(), $matches)) {
+	throw new Exception('Could not parse supported-versions.php');
+}
+$eol = array_merge($eol, array_combine($matches[1], array_fill(0, count($matches[1]), "security"))); // add list of all release series that are security only
+
+$packages = [];
+foreach($repositories as $repository) {
+	$packages = array_merge($packages, $repository['packages'][0]);
+}
+
+$db = new SQLite3(':memory:');
+$db->createCollation('VERSION_CMP', 'version_compare'); // for sorting/MAXing versions; we have to use it explicitly inside MAX(CASE…) statements in addition to setting it on the version column
+$db->exec("CREATE TABLE runtimes (name TEXT COLLATE NOCASE, version TEXT COLLATE VERSION_CMP, series TEXT, stack TEXT)");
+$db->exec("CREATE TABLE extensions (name TEXT COLLATE NOCASE, url TEXT, version TEXT COLLATE VERSION_CMP, runtime TEXT, series TEXT, stack TEXT, bundled INTEGER DEFAULT 0, enabled INTEGER DEFAULT 1)");
+$insertRuntime = $db->prepare("INSERT INTO runtimes (name, version, series, stack) VALUES(:name, :version, :series, :stack)");
+$insertExtension = $db->prepare("INSERT INTO extensions (name, url, version, runtime, series, stack, bundled, enabled) VALUES(:name, :url, :version, :runtime, :series, :stack, :bundled, :enabled)");
+
+foreach($packages as $package) {
+	if($package['type'] == 'heroku-sys-php') {
+		foreach($findstacks($package) as $stack) {
+			$serie = implode('.', array_slice(explode('.', $package['version']), 0, 2));
+			$insertRuntime->reset();
+			$insertRuntime->bindValue(':name', 'php', SQLITE3_TEXT);
+			$insertRuntime->bindValue(':version', $package['version'], SQLITE3_TEXT);
+			$insertRuntime->bindValue(':series', $serie, SQLITE3_TEXT);
+			$insertRuntime->bindValue(':stack', $stack, SQLITE3_TEXT);
+			$insertRuntime->execute();
+			foreach($package["replace"] as $rname => $rversion) {
+				if(strpos($rname, "heroku-sys/ext-") !== 0) continue;
+				$insertExtension->reset();
+				$insertExtension->bindValue(':name', str_replace("heroku-sys/", "", $rname), SQLITE3_TEXT);
+				$insertExtension->bindValue(':url', $getBuiltinExtensionUrl($rname), SQLITE3_TEXT);
+				$insertExtension->bindValue(':version', $package['version'], SQLITE3_TEXT);
+				$insertExtension->bindValue(':runtime', 'php', SQLITE3_TEXT);
+				$insertExtension->bindValue(':series', $serie, SQLITE3_TEXT);
+				$insertExtension->bindValue(':stack', $stack, SQLITE3_TEXT);
+				$insertExtension->bindValue(':bundled', 1, SQLITE3_INTEGER);
+				$insertExtension->bindValue(':enabled', !($package["extra"]["shared"][$rname]??false), SQLITE3_INTEGER);
+				$insertExtension->execute();
+			}
+		}
+	} elseif($package['type'] == 'heroku-sys-php-extension') {
+		foreach($findstacks($package) as $stack) {
+			foreach($findseries($package) as $serie) {
+				$insertExtension->reset();
+				$insertExtension->bindValue(':name', str_replace("heroku-sys/", "", $package['name']), SQLITE3_TEXT);
+				$insertExtension->bindValue(':url', $package['homepage'] ?? null, SQLITE3_TEXT);
+				$insertExtension->bindValue(':version', $package['version'], SQLITE3_TEXT);
+				$insertExtension->bindValue(':runtime', 'php', SQLITE3_TEXT);
+				$insertExtension->bindValue(':series', $serie, SQLITE3_TEXT);
+				$insertExtension->bindValue(':stack', $stack, SQLITE3_TEXT);
+				$insertExtension->bindValue(':bundled', 0, SQLITE3_INTEGER);
+				$insertExtension->bindValue(':enabled', 0, SQLITE3_INTEGER);
+				$insertExtension->execute();
+			}
+		}
+	}
+}
+
+$latestByStack = []; // remember these for the next step, where we fetch all default extensions for them
+$seriesByStack = [];
+$runtimesQuery = ["SELECT name, series"];
+foreach($stacks as $key => $stack) {
+	$runtimesQuery[] = ", MAX(CASE WHEN stack = '${stack}' THEN version END COLLATE VERSION_CMP) AS '${stack}'";
+}
+$runtimesQuery[] = "FROM runtimes GROUP BY name, series ORDER BY series ASC";
+$results = $db->query(implode(" ", $runtimesQuery));
+$runtimes = [];
+while($row = $results->fetchArray(SQLITE3_ASSOC)) {
+	$runtimes[] = $row;
+	foreach($stacks as $stack) {
+		if($row["${stack}"]) {
+			$latestByStack[$stack][$row["series"]] = $row["${stack}"];
+			$seriesByStack[$stack][] = $row["series"];
+		}
+	}
+}
+
+$extensionsQuery = ["SELECT extensions.name, extensions.url"];
+foreach($series as $serie) {
+	foreach($stacks as $stack) {
+		$extensionsQuery[] = ", MAX(CASE WHEN extensions.series = '${serie}' AND extensions.stack='${stack}' THEN extensions.enabled END) AS 'enabled_${serie}_${stack}'";
+	}
+}
+$extensionsQuery[] = "FROM extensions";
+$extensionsQuery[] = "WHERE extensions.bundled = 1 AND(0";
+foreach($latestByStack as $stack => $versions) {
+	foreach($versions as $serie => $version) {
+		// we intentionally don't use prepared statements here
+		// some bug with positional parameter binding...
+		$extensionsQuery[] = "OR (extensions.stack = '${stack}' AND extensions.version = '${version}')";
+	}
+}
+$extensionsQuery[] = ") GROUP BY extensions.name ORDER BY extensions.name ASC";
+$result = $db->query(implode(" ", $extensionsQuery));
+$bExtensions = [];
+while($row = $result->fetchArray(SQLITE3_ASSOC)) {
+	$row['data'] = [];
+	foreach($series as $serie) {
+		$row['data'][$serie] = $filterStackVersions($row, $serie, $stacks, $seriesByStack, function($row, $serie, $stack) { return isset($row["enabled_${serie}_${stack}"]) ? strtr($row["enabled_${serie}_${stack}"], ["0" => "&#x2731;", "1" => "&#x2714;"]) : null; });
+	}
+	$bExtensions[] = $row;
+}
+
+$extensionsQuery = ["SELECT extensions.name, extensions.url, substr(extensions.version, 1, instr(extensions.version, '.')) AS major_version"];
+foreach($series as $serie) {
+	foreach($stacks as $stack) {
+		$extensionsQuery[] = ", MAX(CASE WHEN extensions.series = '${serie}' AND extensions.stack = '${stack}' THEN extensions.version END COLLATE VERSION_CMP) AS 'version_${serie}_${stack}'";
+	}
+}
+$extensionsQuery[] = "FROM extensions WHERE extensions.bundled = 0 GROUP BY extensions.name, major_version ORDER BY extensions.name ASC, major_version ASC";
+$result = $db->query(implode(" ", $extensionsQuery));
+$eExtensions = [];
+while($row = $result->fetchArray(SQLITE3_ASSOC)) {
+	$row['data'] = [];
+	foreach($series as $serie) {
+		$row['data'][$serie] = $filterStackVersions($row, $serie, $stacks, $seriesByStack, function($row, $serie, $stack) { return $row["version_${serie}_${stack}"] ?? null; });
+	}
+	$eExtensions[] = $row;
+}
+// find those extensions that have multiple major versions
+$extCounts = array_count_values(array_column($eExtensions, 'name')); // preserves keys
+// remove major_version key from each non-matched row
+foreach($eExtensions as &$row) if($extCounts[$row['name']] < 2) unset($row['major_version']);
+// but then see if any of these have no overlap by series, e.g. v1 only for PHP 5.5 and 5.6, and v2 for 7.0+; we can collapse them into one row then after all
+foreach($extCounts as $name => $count) {
+	if($count < 2) continue;
+	// this preserves keys from $eExtensions, so we can splice later
+	$collapse = array_filter($eExtensions, function($row) use($name) { return $row["name"] == $name; });
+	foreach($collapse as &$row) { $row = array_filter($row); }
+	// now figure out the overlap by intersecting an entry's keys with the next entry's keys
+	// if only "name", "data" and "major_version" remain, then none of the other keys intersected, meaning no overlap
+	// this doesn't work: count(array_intersect_key(...$collapse)) == 3
+	// because for more than two arguments, it returns keys present in the first array that are in ALL other arrays, not ANY
+	// meaning if the first and second have overlap, but the first and third do not, it returns the wrong stuff
+	$overlap = false;
+	while($current = current($collapse)) {
+		$next = next($collapse);
+		if(!$next) break;
+		if(count(array_intersect_key($current, $next)) != 3) {
+			// contains more than just "name", "data", and "major_version" keys
+			// that means at least one of the runtime series "columm" contains more than one major version
+			// we thus cannot collapse anything, even if some versions do not have any overlap, to avoid confusion
+			// (e.g. ext-phalcon 2.x is only on 5.5 and 5.6, 3.x is on 7.0+, 4.x is on 7.3+, so we want three rows, even though 2.x and 3.x have no overlap)
+			$overlap = true;
+			break;
+		}
+	}
+	if(!$overlap) {
+		// no overlap between any major versions per runtime series
+		// we can collapse the multiple major versions into one row
+		$position = array_key_first($collapse);
+		$length = count($collapse);
+		$collapse = array_merge(...$collapse); // result is one row, and we unpack it
+		// recalculate data array
+		foreach($series as $serie) {
+			$collapse['data'][$serie] = $filterStackVersions($collapse, $serie, $stacks, $seriesByStack, function($row, $serie, $stack) { return $row["version_${serie}_${stack}"] ?? null; });
+		}
+		unset($collapse['major_version']);
+		// overwrite collapsible rows with our new single one
+		array_splice($eExtensions, $position, $length, [$collapse]);
+	}
+}
+
+$twig = new Twig\Environment(new \Twig\Loader\FilesystemLoader(__DIR__));
+echo $twig->render("runtimes.twig", [
+	'stacks' => $stacks,
+	'eol' => $eol,
+	'runtimes' => $runtimes,
+]);
+echo $twig->render("extensions.twig", [
+	'type' => 'built-in',
+	'series' => $series,
+	'stacks' => $stacks,
+	'eol' => $eol,
+	'extensions' => $bExtensions,
+]);
+echo $twig->render("extensions.twig", [
+	'type' => 'third-party',
+	'series' => $series,
+	'stacks' => $stacks,
+	'eol' => $eol,
+	'extensions' => $eExtensions,
+]);

--- a/support/devcenter/runtimes.twig
+++ b/support/devcenter/runtimes.twig
@@ -1,0 +1,24 @@
+<!-- BEGIN RUNTIMES -->
+<!-- THIS SECTION, BEGINNING WITH THE MARKER COMMENT ABOVE, IS AUTOMATICALLY GENERATED; DO NOT EDIT CONTENT BELOW BY HAND OR REMOVE MARKER ABOVE -->
+<table>
+	<thead>
+		<tr>
+			<th>Runtime&nbsp;/&nbsp;series</th>
+{% for stack in stacks %}
+			<th><a href="/articles/heroku-{{ stack }}-stack"><code>heroku-{{ stack }}</code></a></th>
+{% endfor %}
+		</tr>
+	</thead>
+	<tbody>
+{% for runtime in runtimes %}
+		<tr {% if attribute(eol, runtime.series) is defined %}style="{% if attribute(eol, runtime.series) == "eol" %}background-color: rgba(194, 66, 0, 0.1); color: #C24200{% else %}background-color: #fff3c5; color: #927200{% endif %}"{% endif %}>
+			<td style="white-space:nowrap">PHP {{ runtime.series }}</td>
+	{% for stack in stacks %}
+			<td>{% if attribute(runtime, stack) %}{{ attribute(runtime, stack) }}{% else %}-{% endif %}</td>
+	{% endfor %}
+		</tr>
+{% endfor %}
+	</tbody>
+</table>
+<!-- THIS SECTION, ENDING WITH THE MARKER BELOW, IS AUTOMATICALLY GENERATED; DO NOT EDIT CONTENT ABOVE BY HAND OR REMOVE MARKER BELOW -->
+<!-- END RUNTIMES -->

--- a/support/devcenter/third-party-extensions.twig
+++ b/support/devcenter/third-party-extensions.twig
@@ -1,0 +1,2 @@
+{% set type = "third-party" %}
+{{ include("extensions.twig") }}


### PR DESCRIPTION
This `generate.php` tool will, given platform repository URLs as arguments, generate:

- the list of PHP runtimes, per stack
- the list of built-in extensions, per PHP runtime series
- the list of third-party extensions, per PHP runtime series

for inclusion in https://devcenter.heroku.com/articles/php-support
