### PR TITLE
retry_until for heroku runs inside tests

### DIFF
--- a/test/spec/bugs_spec.rb
+++ b/test/spec/bugs_spec.rb
@@ -10,9 +10,11 @@ describe "A PHP application" do
 			
 			app.deploy do |app|
 				expect(app.output).to match("- ext-imap")
-				output = app.run('php -r \'imap_open("{imap.gmail.com:993/imap/ssl}INBOX", "user", "pass") or die(imap_last_error());\'')
-				expect(output).to match("Can not authenticate to IMAP server")
-				expect(output).not_to match("Certificate failure")
+				retry_until retry: 3, sleep: 5 do
+					output = app.run('php -r \'imap_open("{imap.gmail.com:993/imap/ssl}INBOX", "user", "pass") or die(imap_last_error());\'')
+					expect(output).to match("Can not authenticate to IMAP server")
+					expect(output).not_to match("Certificate failure")
+				end
 			end
 		end
 	end

--- a/test/spec/composer_spec.rb
+++ b/test/spec/composer_spec.rb
@@ -30,8 +30,10 @@ describe "A PHP application" do
 			['v1', 'v2'].each do |cv|
 				new_app_with_stack_and_platrepo("test/fixtures/composer/basic_lock_#{cv}", run_multi: true).deploy do |app|
 					['heroku-php-apache2', 'heroku-php-nginx'].each do |script|
-						out = app.run("#{script} -F composer.lock", :heroku => {:env => "COMPOSER_AUTH=malformed"}) # prevent FPM from starting up using an invalid config, that way we don't have to wrap the server start in a `timeout` call
-						expect(out).to match(/Starting php-fpm/) # we got far enough (until FPM spits out an error)
+						retry_until retry: 3, sleep: 5 do
+							out = app.run("#{script} -F composer.lock", :heroku => {:env => "COMPOSER_AUTH=malformed"}) # prevent FPM from starting up using an invalid config, that way we don't have to wrap the server start in a `timeout` call
+							expect(out).to match(/Starting php-fpm/) # we got far enough (until FPM spits out an error)
+						end
 					end
 				end
 			end

--- a/test/spec/nginx_spec.rb
+++ b/test/spec/nginx_spec.rb
@@ -9,7 +9,9 @@ describe "A PHP application" do
 			nginx = app.output.match(/- nginx \((\d+\.\d*[02468]\.\d+)/)
 			expect(nginx).not_to be_nil, "expected nginx install line in build output"
 			expect(Gem::Dependency.new('nginx', '~> 1.14').match?('nginx', nginx[1])).to be == true, "expected nginx version compatible with selector '~> 1.14' but got #{nginx[1]}"
-			expect(app.run('nginx -V')).to match(/^built with OpenSSL/)
+			retry_until retry: 3, sleep: 5 do
+				expect(app.run('nginx -V')).to match(/^built with OpenSSL/)
+			end
 		end
 	end
 end

--- a/test/spec/php_7.4_base_spec.rb
+++ b/test/spec/php_7.4_base_spec.rb
@@ -20,9 +20,11 @@ describe "A basic PHP 7.4 application", :requires_php_on_stack => "7.4" do
 						# after `curl` completes, `wait-for.it.sh` will shut down
 						# ensure slowlog info and trace is there
 						cmd = "./waitforit.sh 20 'ready for connections' heroku-php-#{server} --verbose -F fpm.request_slowlog_timeout.conf | { read && curl \"localhost:$PORT/index.php?wait=5\"; }"
-						output = app.run(cmd)
-						expect(output).to include("executing too slow")
-						expect(output).to include("sleep() /app/index.php:5")
+						retry_until retry: 3, sleep: 5 do
+							output = app.run(cmd)
+							expect(output).to include("executing too slow")
+							expect(output).to include("sleep() /app/index.php:5")
+						end
 					end
 				end
 				
@@ -33,9 +35,11 @@ describe "A basic PHP 7.4 application", :requires_php_on_stack => "7.4" do
 						# after `curl` completes, `wait-for.it.sh` will shut down
 						# ensure slowlog and terminate output is there
 						cmd = "./waitforit.sh 50 'ready for connections' heroku-php-#{server} --verbose | { read && curl \"localhost:$PORT/index.php?wait=35\"; }"
-						output = app.run(cmd)
-						expect(output).to match(/executing too slow/)
-						expect(output).to match(/execution timed out/)
+						retry_until retry: 3, sleep: 5 do
+							output = app.run(cmd)
+							expect(output).to match(/executing too slow/)
+							expect(output).to match(/execution timed out/)
+						end
 					end
 				end
 			end

--- a/test/spec/php_8.0_base_spec.rb
+++ b/test/spec/php_8.0_base_spec.rb
@@ -20,9 +20,11 @@ describe "A basic PHP 8.0 application", :requires_php_on_stack => "8.0" do
 						# after `curl` completes, `wait-for.it.sh` will shut down
 						# ensure slowlog info and trace is there
 						cmd = "./waitforit.sh 20 'ready for connections' heroku-php-#{server} --verbose -F fpm.request_slowlog_timeout.conf | { read && curl \"localhost:$PORT/index.php?wait=5\"; }"
-						output = app.run(cmd)
-						expect(output).to include("executing too slow")
-						expect(output).to include("sleep() /app/index.php:5")
+						retry_until retry: 3, sleep: 5 do
+							output = app.run(cmd)
+							expect(output).to include("executing too slow")
+							expect(output).to include("sleep() /app/index.php:5")
+						end
 					end
 				end
 				
@@ -33,9 +35,11 @@ describe "A basic PHP 8.0 application", :requires_php_on_stack => "8.0" do
 						# after `curl` completes, `wait-for.it.sh` will shut down
 						# ensure slowlog and terminate output is there
 						cmd = "./waitforit.sh 50 'ready for connections' heroku-php-#{server} --verbose | { read && curl \"localhost:$PORT/index.php?wait=35\"; }"
-						output = app.run(cmd)
-						expect(output).to match(/executing too slow/)
-						expect(output).to match(/execution timed out/)
+						retry_until retry: 3, sleep: 5 do
+							output = app.run(cmd)
+							expect(output).to match(/executing too slow/)
+							expect(output).to match(/execution timed out/)
+						end
 					end
 				end
 			end

--- a/test/spec/php_8.1_base_spec.rb
+++ b/test/spec/php_8.1_base_spec.rb
@@ -20,9 +20,11 @@ describe "A basic PHP 8.1 application", :requires_php_on_stack => "8.1" do
 						# after `curl` completes, `wait-for.it.sh` will shut down
 						# ensure slowlog info and trace is there
 						cmd = "./waitforit.sh 20 'ready for connections' heroku-php-#{server} --verbose -F fpm.request_slowlog_timeout.conf | { read && curl \"localhost:$PORT/index.php?wait=5\"; }"
-						output = app.run(cmd)
-						expect(output).to include("executing too slow")
-						expect(output).to include("sleep() /app/index.php:5")
+						retry_until retry: 3, sleep: 5 do
+							output = app.run(cmd)
+							expect(output).to include("executing too slow")
+							expect(output).to include("sleep() /app/index.php:5")
+						end
 					end
 				end
 				
@@ -33,9 +35,11 @@ describe "A basic PHP 8.1 application", :requires_php_on_stack => "8.1" do
 						# after `curl` completes, `wait-for.it.sh` will shut down
 						# ensure slowlog and terminate output is there
 						cmd = "./waitforit.sh 50 'ready for connections' heroku-php-#{server} --verbose | { read && curl \"localhost:$PORT/index.php?wait=35\"; }"
-						output = app.run(cmd)
-						expect(output).to match(/executing too slow/)
-						expect(output).to match(/execution timed out/)
+						retry_until retry: 3, sleep: 5 do
+							output = app.run(cmd)
+							expect(output).to match(/executing too slow/)
+							expect(output).to match(/execution timed out/)
+						end
 					end
 				end
 			end

--- a/test/spec/php_default_spec.rb
+++ b/test/spec/php_default_spec.rb
@@ -9,7 +9,9 @@ describe "A PHP application" do
 			app.deploy do |app|
 				series = expected_default_php(ENV["STACK"])
 				expect(app.output).to match(/- php \(#{Regexp.escape(series)}\./)
-				expect(app.run('php -v')).to match(/#{Regexp.escape(series)}\./)
+				retry_until retry: 3, sleep: 5 do
+					expect(app.run('php -v')).to match(/#{Regexp.escape(series)}\./)
+				end
 			end
 		end
 		# FIXME re-use deploy
@@ -21,12 +23,14 @@ describe "A PHP application" do
 		
 		it "has Composer defaults set" do
 			app.deploy do |app|
-				composer_envs = app.run('env | grep COMPOSER_')
-				expect(composer_envs)
-					.to  match(/^COMPOSER_MEMORY_LIMIT=536870912$/)
-					.and match(/^COMPOSER_MIRROR_PATH_REPOS=1$/)
-					.and match(/^COMPOSER_NO_INTERACTION=1$/)
-					.and match(/^COMPOSER_PROCESS_TIMEOUT=0$/)
+				retry_until retry: 3, sleep: 5 do
+					composer_envs = app.run('env | grep COMPOSER_')
+					expect(composer_envs)
+						.to  match(/^COMPOSER_MEMORY_LIMIT=536870912$/)
+						.and match(/^COMPOSER_MIRROR_PATH_REPOS=1$/)
+						.and match(/^COMPOSER_NO_INTERACTION=1$/)
+						.and match(/^COMPOSER_PROCESS_TIMEOUT=0$/)
+				end
 			end
 		end
 	end

--- a/test/spec/php_shared_base.rb
+++ b/test/spec/php_shared_base.rb
@@ -16,20 +16,26 @@ shared_examples "A basic PHP application" do |series|
 		
 		it "picks a version from the desired series" do
 			expect(@app.output).to match(/- php \(#{Regexp.escape(series)}\./)
-			expect(@app.run('php -v')).to match(/#{Regexp.escape(series)}\./)
+			retry_until retry: 3, sleep: 5 do
+				expect(@app.run('php -v')).to match(/#{Regexp.escape(series)}\./)
+			end
 		end
 		
 		it "has Heroku php.ini defaults" do
-			ini_output = @app.run('php -i')
-			expect(ini_output).to match(/date.timezone => UTC/)
-			                 .and match(/error_reporting => 30719/)
-			                 .and match(/expose_php => Off/)
-			                 .and match(/user_ini.cache_ttl => 86400/)
-			                 .and match(/variables_order => EGPCS/)
+			retry_until retry: 3, sleep: 5 do
+				ini_output = @app.run('php -i')
+				expect(ini_output).to match(/date.timezone => UTC/)
+				                 .and match(/error_reporting => 30719/)
+				                 .and match(/expose_php => Off/)
+				                 .and match(/user_ini.cache_ttl => 86400/)
+				                 .and match(/variables_order => EGPCS/)
+			end
 		end
 		
 		it "uses all available RAM as PHP CLI memory_limit", :if => series.between?("7.2","8.1") do
-			expect(@app.run("php -i | grep memory_limit")).to match "memory_limit => 536870912 => 536870912"
+			retry_until retry: 3, sleep: 5 do
+				expect(@app.run("php -i | grep memory_limit")).to match "memory_limit => 536870912 => 536870912"
+			end
 		end
 		
 		it "is running a PHP build that links against libc-client, libonig, libsqlite3 and libzip from the stack", :if => series.between?("7.2","8.1") do

--- a/test/spec/php_shared_boot.rb
+++ b/test/spec/php_shared_boot.rb
@@ -106,13 +106,17 @@ shared_examples "A PHP application for testing boot options" do |series, server|
 			context "launching using `#{cmd}'" do
 				if combination.value?(false) or cmd.match("broken")
 					it "does not boot" do
-						# check if "timeout" exited with a status other than 124, which means the process exited (due to the expected error) before "timeout" stepped in after the given duration (five seconds) and terminated it
-						expect_exit(expect: :not_to, code: 124) { @app.run("timeout 15 #{cmd}", :return_obj => true) }
+						retry_until retry: 3, sleep: 5 do
+								# check if "timeout" exited with a status other than 124, which means the process exited (due to the expected error) before "timeout" stepped in after the given duration (five seconds) and terminated it
+							expect_exit(expect: :not_to, code: 124) { @app.run("timeout 15 #{cmd}", :return_obj => true) }
+						end
 					end
 				else
 					it "boots" do
-						# check if "waitforit" exited with status 0, which means the process successfully output the expected message
-						expect_exit(expect: :to, code: 0) { @app.run("./waitforit.sh 15 'ready for connections' #{cmd}", :return_obj => true) }
+						retry_until retry: 3, sleep: 5 do
+							# check if "waitforit" exited with status 0, which means the process successfully output the expected message
+							expect_exit(expect: :to, code: 0) { @app.run("./waitforit.sh 15 'ready for connections' #{cmd}", :return_obj => true) }
+						end
 					end
 				end
 			end
@@ -120,13 +124,17 @@ shared_examples "A PHP application for testing boot options" do |series, server|
 		
 		context "launching using too many arguments" do
 			it "fails to boot" do
-				expect_exit(expect: :to, code: 2) { @app.run("timeout 10 heroku-php-#{server} docroot/ anotherarg", :return_obj => true) }
+				retry_until retry: 3, sleep: 5 do
+					expect_exit(expect: :to, code: 2) { @app.run("timeout 10 heroku-php-#{server} docroot/ anotherarg", :return_obj => true) }
+				end
 			end
 		end
 		
 		context "launching using unknown options" do
 			it "fails to boot" do
-				expect_exit(expect: :to, code: 2) { @app.run("timeout 10 heroku-php-#{server} --what -u erp", :return_obj => true) }
+				retry_until retry: 3, sleep: 5 do
+					expect_exit(expect: :to, code: 2) { @app.run("timeout 10 heroku-php-#{server} --what -u erp", :return_obj => true) }
+				end
 			end
 		end
 	end

--- a/test/spec/php_shared_concurrency.rb
+++ b/test/spec/php_shared_concurrency.rb
@@ -17,70 +17,92 @@ shared_examples "A PHP application for testing WEB_CONCURRENCY behavior" do |ser
 		
 		context "setting concurrency via .user.ini memory_limit" do
 			it "calculates concurrency correctly" do
-				expect(expect_exit(code: 0) { @app.run("./waitforit.sh 15 'ready for connections' heroku-php-#{server} --verbose docroot/", :return_obj => true) }.output)
-					 .to match("PHP memory_limit is 32M Bytes")
-					.and match("Starting php-fpm with 16 workers...")
+				retry_until retry: 3, sleep: 5 do
+					expect(expect_exit(code: 0) { @app.run("./waitforit.sh 15 'ready for connections' heroku-php-#{server} --verbose docroot/", :return_obj => true) }.output)
+						 .to match("PHP memory_limit is 32M Bytes")
+						.and match("Starting php-fpm with 16 workers...")
+				end
 			end
 			it "always launches at least one worker" do
-				expect(expect_exit(code: 0) { @app.run("./waitforit.sh 15 'ready for connections' heroku-php-#{server} --verbose docroot/onegig/", :return_obj => true) }.output)
-					 .to match("PHP memory_limit is 1024M Bytes")
-					.and match("Starting php-fpm with 1 workers...")
+				retry_until retry: 3, sleep: 5 do
+					expect(expect_exit(code: 0) { @app.run("./waitforit.sh 15 'ready for connections' heroku-php-#{server} --verbose docroot/onegig/", :return_obj => true) }.output)
+						 .to match("PHP memory_limit is 1024M Bytes")
+						.and match("Starting php-fpm with 1 workers...")
+				end
 			end
 			it "is only done for a .user.ini directly in the document root" do
-				expect(expect_exit(code: 0) { @app.run("./waitforit.sh 15 'ready for connections' heroku-php-#{server} --verbose", :return_obj => true) }.output)
-					 .to match("PHP memory_limit is 128M Bytes")
-					.and match("Starting php-fpm with 4 workers...")
+				retry_until retry: 3, sleep: 5 do
+					expect(expect_exit(code: 0) { @app.run("./waitforit.sh 15 'ready for connections' heroku-php-#{server} --verbose", :return_obj => true) }.output)
+						 .to match("PHP memory_limit is 128M Bytes")
+						.and match("Starting php-fpm with 4 workers...")
+				end
 			end
 		end
 		
 		context "setting concurrency via FPM config memory_limit" do
 			it "calculates concurrency correctly" do
-				expect(expect_exit(code: 0) { @app.run("./waitforit.sh 15 'ready for connections' heroku-php-#{server} --verbose -F conf/fpm.include.conf", :return_obj => true) }.output)
-					 .to match("PHP memory_limit is 32M Bytes")
-					.and match("Starting php-fpm with 16 workers...")
+				retry_until retry: 3, sleep: 5 do
+					expect(expect_exit(code: 0) { @app.run("./waitforit.sh 15 'ready for connections' heroku-php-#{server} --verbose -F conf/fpm.include.conf", :return_obj => true) }.output)
+						 .to match("PHP memory_limit is 32M Bytes")
+						.and match("Starting php-fpm with 16 workers...")
+				end
 			end
 			it "always launches at least one worker" do
-				expect(expect_exit(code: 0) { @app.run("./waitforit.sh 15 'ready for connections' heroku-php-#{server} --verbose -F conf/fpm.onegig.conf", :return_obj => true) }.output)
-					 .to match("PHP memory_limit is 1024M Bytes")
-					.and match("Starting php-fpm with 1 workers...")
+				retry_until retry: 3, sleep: 5 do
+					expect(expect_exit(code: 0) { @app.run("./waitforit.sh 15 'ready for connections' heroku-php-#{server} --verbose -F conf/fpm.onegig.conf", :return_obj => true) }.output)
+						 .to match("PHP memory_limit is 1024M Bytes")
+						.and match("Starting php-fpm with 1 workers...")
+				end
 			end
 			it "takes precedence over a .user.ini memory_limit" do
-				expect(expect_exit(code: 0) { @app.run("./waitforit.sh 15 'ready for connections' heroku-php-#{server} --verbose -F conf/fpm.include.conf docroot/onegig/", :return_obj => true) }.output)
-					 .to match("PHP memory_limit is 32M Bytes")
-					.and match("Starting php-fpm with 16 workers...")
+				retry_until retry: 3, sleep: 5 do
+					expect(expect_exit(code: 0) { @app.run("./waitforit.sh 15 'ready for connections' heroku-php-#{server} --verbose -F conf/fpm.include.conf docroot/onegig/", :return_obj => true) }.output)
+						 .to match("PHP memory_limit is 32M Bytes")
+						.and match("Starting php-fpm with 16 workers...")
+				end
 			end
 		end
 		
 		context "setting WEB_CONCURRENCY explicitly" do
 			it "uses the explicit value" do
-				expect(expect_exit(code: 0) { @app.run("./waitforit.sh 15 'ready for connections' heroku-php-#{server} --verbose", :return_obj => true, :heroku => {:env => "WEB_CONCURRENCY=22"}) }.output)
-					 .to match("\\$WEB_CONCURRENCY env var is set, skipping automatic calculation")
-					.and match("Starting php-fpm with 22 workers...")
+				retry_until retry: 3, sleep: 5 do
+					expect(expect_exit(code: 0) { @app.run("./waitforit.sh 15 'ready for connections' heroku-php-#{server} --verbose", :return_obj => true, :heroku => {:env => "WEB_CONCURRENCY=22"}) }.output)
+						 .to match("\\$WEB_CONCURRENCY env var is set, skipping automatic calculation")
+						.and match("Starting php-fpm with 22 workers...")
+				end
 			end
 			it "overrides a .user.ini memory_limit" do
-				expect(expect_exit(code: 0) { @app.run("./waitforit.sh 15 'ready for connections' heroku-php-#{server} --verbose docroot/onegig/", :return_obj => true, :heroku => {:env => "WEB_CONCURRENCY=22"}) }.output)
-					 .to match("\\$WEB_CONCURRENCY env var is set, skipping automatic calculation")
-					.and match("Starting php-fpm with 22 workers...")
+				retry_until retry: 3, sleep: 5 do
+					expect(expect_exit(code: 0) { @app.run("./waitforit.sh 15 'ready for connections' heroku-php-#{server} --verbose docroot/onegig/", :return_obj => true, :heroku => {:env => "WEB_CONCURRENCY=22"}) }.output)
+						 .to match("\\$WEB_CONCURRENCY env var is set, skipping automatic calculation")
+						.and match("Starting php-fpm with 22 workers...")
+				end
 			end
 			it "overrides an FPM config memory_limit" do
-				expect(expect_exit(code: 0) { @app.run("./waitforit.sh 15 'ready for connections' heroku-php-#{server} --verbose -F conf/fpm.onegig.conf", :return_obj => true, :heroku => {:env => "WEB_CONCURRENCY=22"}) }.output)
-					 .to match("\\$WEB_CONCURRENCY env var is set, skipping automatic calculation")
-					.and match("Starting php-fpm with 22 workers...")
+				retry_until retry: 3, sleep: 5 do
+					expect(expect_exit(code: 0) { @app.run("./waitforit.sh 15 'ready for connections' heroku-php-#{server} --verbose -F conf/fpm.onegig.conf", :return_obj => true, :heroku => {:env => "WEB_CONCURRENCY=22"}) }.output)
+						 .to match("\\$WEB_CONCURRENCY env var is set, skipping automatic calculation")
+						.and match("Starting php-fpm with 22 workers...")
+				end
 			end
 		end
 		
 		context "running on a Performance-L dyno" do
 			it "restricts the app to 6 GB of RAM", :if => series < "7.4" do
-				expect(expect_exit(code: 0) { @app.run("./waitforit.sh 15 'ready for connections' heroku-php-#{server} --verbose", :return_obj => true, :heroku => {:size => "Performance-L"}) }.output)
-					 .to match("Detected 15032385536 Bytes of RAM")
-					.and match("Limiting to 6G Bytes of RAM usage")
-					.and match("Starting php-fpm with 48 workers...")
+				retry_until retry: 3, sleep: 5 do
+					expect(expect_exit(code: 0) { @app.run("./waitforit.sh 15 'ready for connections' heroku-php-#{server} --verbose", :return_obj => true, :heroku => {:size => "Performance-L"}) }.output)
+						 .to match("Detected 15032385536 Bytes of RAM")
+						.and match("Limiting to 6G Bytes of RAM usage")
+						.and match("Starting php-fpm with 48 workers...")
+				end
 			end
 			
 			it "uses all available RAM for PHP-FPM workers", :unless => series < "7.4" do
-				expect(expect_exit(code: 0) { @app.run("./waitforit.sh 15 'ready for connections' heroku-php-#{server} --verbose", :return_obj => true, :heroku => {:size => "Performance-L"}) }.output)
-					 .to match("Detected 15032385536 Bytes of RAM")
-					.and match("Starting php-fpm with 112 workers...")
+				retry_until retry: 3, sleep: 5 do
+					expect(expect_exit(code: 0) { @app.run("./waitforit.sh 15 'ready for connections' heroku-php-#{server} --verbose", :return_obj => true, :heroku => {:size => "Performance-L"}) }.output)
+						 .to match("Detected 15032385536 Bytes of RAM")
+						.and match("Starting php-fpm with 112 workers...")
+				end
 			end
 		end
 	end

--- a/test/spec/sigterm_spec.rb
+++ b/test/spec/sigterm_spec.rb
@@ -19,9 +19,11 @@ describe "A PHP application" do
 					# curl the sleep() script, kill it after two seconds
 					# wait for $pid so that we can be certain to get all the output
 					cmd = "heroku-php-#{server} & pid=$! ; sleep 5; curl \"localhost:$PORT/index.php?wait=5\" & sleep 2; kill $pid; wait $pid"
-					output = @app.run(cmd)
-					expect(output).to match(/^hello world after 5 second\(s\)$/)
-					expect(output).to match(/^request complete$/) # ensure a late log line is captured, meaning the logs tail process stays alive until the end
+					retry_until retry: 3, sleep: 5 do
+						output = @app.run(cmd)
+						expect(output).to match(/^hello world after 5 second\(s\)$/)
+						expect(output).to match(/^request complete$/) # ensure a late log line is captured, meaning the logs tail process stays alive until the end
+					end
 				end
 				
 				it "gracefully shuts down when all processes receives a SIGTERM because HEROKU_PHP_GRACEFUL_SIGTERM is on by default" do
@@ -32,9 +34,11 @@ describe "A PHP application" do
 					# hand all those PIDs to kill
 					# wait for $pid so that we can be certain to get all the output
 					cmd = "heroku-php-#{server} & pid=$! ; sleep 5; curl \"localhost:$PORT/index.php?wait=5\" & curlpid=$!; sleep 2; kill $(pgrep -U $UID | grep -vw -e $$ -e $curlpid) 2>/dev/null; wait $pid"
-					output = @app.run(cmd)
-					expect(output).to match(/^hello world after 5 second\(s\)$/)
-					expect(output).to match(/^request complete$/) # ensure a late log line is captured, meaning the logs tail process stays alive until the end
+					retry_until retry: 3, sleep: 5 do
+						output = @app.run(cmd)
+						expect(output).to match(/^hello world after 5 second\(s\)$/)
+						expect(output).to match(/^request complete$/) # ensure a late log line is captured, meaning the logs tail process stays alive until the end
+					end
 				end
 			end
 		end

--- a/test/spec/spec_helper.rb
+++ b/test/spec/spec_helper.rb
@@ -86,3 +86,25 @@ def run!(cmd)
 	raise "Command #{cmd} failed: #{out}" unless $?.success?
 	out
 end
+
+def retry_until(options = {})
+	options = {
+		retry: 1,
+		sleep: 1,
+		rescue: RSpec::Expectations::ExpectationNotMetError
+	}.merge(options)
+
+	options[:rescue] = Array(options[:rescue])
+
+	tries = 0
+	begin
+		tries += 1
+		yield
+	rescue *options[:rescue] => e
+		can_retry = tries < options[:retry]
+		raise e unless can_retry
+
+		sleep options[:sleep]
+		retry
+	end
+end


### PR DESCRIPTION
Sometimes, a "heroku run" directly after a deploy will execute against an empty slug, as the build has not propagated all the way through API yet; this will then result in failures like "bash: php: command not found"

rspec_retry retries the entire test, so is not a solution here; we have to re-try only the "heroku run" portion

GUS-W-10293507