### PR TITLE
Fix #528: symfony/polyfill v1.24 fail installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # heroku-buildpack-php CHANGELOG
 
+## v205 (2021-01-07)
+
+### FIX
+
+- `symfony/polyfill-…` packages' `ext-…` `provide` declarations (added in v1.24) cause install failure (#528) [David Zuelke]
+
 ## v204 (2021-01-03)
 
 ### CHG

--- a/bin/util/platform.php
+++ b/bin/util/platform.php
@@ -45,6 +45,10 @@ function mkmetas($package, array &$metapaks, &$have_runtime_req = false) {
 		$prep = $prep + array_filter($ppro, function($k) { return strpos($k, "ext-") === 0; }, ARRAY_FILTER_USE_KEY);
 		$ppro = array_diff_key($ppro, $prep);
 	}
+	// hotfix for https://github.com/heroku/heroku-buildpack-php/issues/528 until Composer2 installer lands: remove ext-* provides from symfony/polyfill-* packages
+	if(strpos($package["name"], "symfony/polyfill-") === 0) {
+		$ppro = array_filter($ppro, function($k) { return strpos($k, "ext-") !== 0; }, ARRAY_FILTER_USE_KEY);
+	}
 	$have_runtime_req |= hasreq($preq);
 	$metapaks[] = [
 		"type" => "metapackage",

--- a/test/fixtures/platform/generator/symfony-polyfill/composer.json
+++ b/test/fixtures/platform/generator/symfony-polyfill/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "symfony/polyfill-ctype": "^1.24"
+    }
+}

--- a/test/fixtures/platform/generator/symfony-polyfill/composer.lock
+++ b/test/fixtures/platform/generator/symfony-polyfill/composer.lock
@@ -1,0 +1,101 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "8441602ff534cd48d5e7e8d7dc82afee",
+    "packages": [
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.24.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "30885182c981ab175d4d034db0f6f469898070ab"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/30885182c981ab175d4d034db0f6f469898070ab",
+                "reference": "30885182c981ab175d4d034db0f6f469898070ab",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "provide": {
+                "ext-ctype": "*"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.23-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.24.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-10-20T20:35:02+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": [],
+    "plugin-api-version": "2.1.0"
+}

--- a/test/fixtures/platform/generator/symfony-polyfill/expected_platform_composer.json
+++ b/test/fixtures/platform/generator/symfony-polyfill/expected_platform_composer.json
@@ -1,0 +1,52 @@
+{
+    "config": {
+        "cache-files-ttl": 0,
+        "discard-changes": true
+    },
+    "minimum-stability": "stable",
+    "prefer-stable": false,
+    "provide": {
+        "heroku-sys\/heroku": "20.2022.01.07"
+    },
+    "replace": {},
+    "require": {
+        "symfony\/polyfill-ctype": "v1.24.0",
+        "heroku-sys\/composer": "*",
+        "heroku-sys\/composer-plugin-api": "^2",
+        "heroku-sys\/apache": "^2.4.10",
+        "heroku-sys\/nginx": "^1.8.0"
+    },
+    "require-dev": {},
+    "repositories": [
+        {
+            "packagist": false
+        },
+        {
+            "type": "path",
+            "url": "..\/..\/..\/..\/..\/support\/installer",
+            "options": {
+                "symlink": false
+            }
+        },
+        {
+            "type": "composer",
+            "url": "https:\/\/lang-php.s3.amazonaws.com\/dist-heroku-20-stable\/packages.json"
+        },
+        {
+            "type": "package",
+            "package": [
+                {
+                    "type": "metapackage",
+                    "name": "symfony\/polyfill-ctype",
+                    "version": "v1.24.0",
+                    "require": {
+                        "heroku-sys\/php": ">=7.1"
+                    },
+                    "replace": {},
+                    "provide": {},
+                    "conflict": {}
+                }
+            ]
+        }
+    ]
+}

--- a/test/spec/platform_spec.rb
+++ b/test/spec/platform_spec.rb
@@ -62,7 +62,7 @@ describe "The PHP Platform Installer" do
 						end
 					end
 					
-					break unless ["base", "blackfire-cli", "complex", "defaultphp", "mongo-php-adapter"].include?(testcase)
+					break unless ["base", "blackfire-cli", "complex", "defaultphp", "mongo-php-adapter", "symfony-polyfill"].include?(testcase)
 					
 					# and finally check if it's installable in a dry run
 					cmd = "COMPOSER=expected_platform_composer.json composer install --dry-run"


### PR DESCRIPTION
Each symfony/polyfill-foobar declares a 'provide' for their respective PHP ext-foobar package since v1.24, and that causes a conflict with our PHP packages, which declare these extensions as 'replace'd; that's a no-no in Composer 1.

GUS-W-10395025