### PR TITLE
v209

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,6 @@ jobs:
             not:
               or:
                 - equal: [ main, << pipeline.git.branch >> ]
-                - equal: [ composer2installer, << pipeline.git.branch >> ]
                 - << pipeline.git.tag >>
           steps:
             - run: 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # heroku-buildpack-php CHANGELOG
 
+## v209 (2021-02-10)
+
+(no changes; release bump for rolling out v208 repository update)
+
 ## v208 (2021-02-10)
 
 ### CHG

--- a/test/spec/platform_spec.rb
+++ b/test/spec/platform_spec.rb
@@ -225,7 +225,7 @@ describe "The PHP Platform Installer" do
 	
 	describe "during a build" do
 		context "of a project that uses polyfills providing both bundled-with-PHP and third-party extensions" do
-			skip "treats polyfills for bundled-with-PHP and third-party extensions the same" do
+			it "treats polyfills for bundled-with-PHP and third-party extensions the same" do
 				new_app_with_stack_and_platrepo('test/fixtures/platform/installer/polyfills').deploy do |app|
 					expect(app.output).to include("- php (7.4")
 					expect(app.output).not_to include("- ext-xmlrpc")


### PR DESCRIPTION
undo the test skipping and repository pinning for v208 for actual rollout of the repository update upon merge of this commit