### PR TITLE
use local eol.php in generate.php

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
           command: |
             php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
             php -r "if (hash_file('sha384', 'composer-setup.php') === file_get_contents('https://composer.github.io/installer.sig')) { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
-            sudo php composer-setup.php --install-dir=/usr/local/bin --filename=composer
+            sudo php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=2.2.10
             rm composer-setup.php
       - checkout
       - run:

--- a/bin/util/eol.php
+++ b/bin/util/eol.php
@@ -13,6 +13,8 @@ $eol = array(
 	"8.1" => array("2023-11-25", "2024-11-25"),
 );
 
+if(basename(__FILE__) != basename($_SERVER["PHP_SELF"])) return $eol; // we're being included, just return the data
+
 if(!isset($eol[PHP_MAJOR_VERSION.".".PHP_MINOR_VERSION])) exit(0);
 
 list($secdate, $eoldate) = $eol[PHP_MAJOR_VERSION.".".PHP_MINOR_VERSION];


### PR DESCRIPTION
php.net has started returning CAPTCHAs occasionally, so our fetching of EOL versions and supported versions is no longer reliable.

but we already have the info in bin/util/eol.php, so now we are loading that instead