### PR TITLE
Whitespace/tests/output fixes

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -28,7 +28,7 @@ trap 'err_trap' ERR
 
 # stdlib
 # download to a file first, as the function restarts the entire download on code 18 connection reset (not all servers support -C)
-curl_retry_on_18 --fail --silent --location -o $bp_dir/bin/util/stdlib.sh https://lang-common.s3.amazonaws.com/buildpack-stdlib/v8/stdlib.sh || {
+curl_retry_on_18 --retry-connrefused --retry 3 --fail --silent --location -o $bp_dir/bin/util/stdlib.sh https://lang-common.s3.amazonaws.com/buildpack-stdlib/v8/stdlib.sh || {
 	error <<-EOF
 		Failed to download standard library for bootstrapping!
 		
@@ -219,7 +219,7 @@ fi
 mkdir -p $build_dir/.heroku/php-min
 ln -s $build_dir/.heroku/php-min /app/.heroku/php-min
 
-curl_retry_on_18 --fail --silent --location -o $build_dir/.heroku/php-min.tar.gz "${s3_url}php-min-8.1.6.tar.gz" || {
+curl_retry_on_18 --retry-connrefused --retry 3 --fail --silent --location -o $build_dir/.heroku/php-min.tar.gz "${s3_url}php-min-8.1.6.tar.gz" || {
 	mcount "failures.bootstrap.download.php-min"
 	error <<-EOF
 		Failed to download minimal PHP for bootstrapping!
@@ -232,7 +232,7 @@ curl_retry_on_18 --fail --silent --location -o $build_dir/.heroku/php-min.tar.gz
 tar xzf $build_dir/.heroku/php-min.tar.gz -C $build_dir/.heroku/php-min
 rm $build_dir/.heroku/php-min.tar.gz
 
-curl_retry_on_18 --fail --silent --location -o $build_dir/.heroku/composer.tar.gz "${s3_url}composer-2.3.5.tar.gz" || {
+curl_retry_on_18 --retry-connrefused --retry 3 --fail --silent --location -o $build_dir/.heroku/composer.tar.gz "${s3_url}composer-2.3.5.tar.gz" || {
 	mcount "failures.bootstrap.download.composer"
 	error <<-EOF
 		Failed to download Composer for bootstrapping!

--- a/bin/compile
+++ b/bin/compile
@@ -399,6 +399,7 @@ else
 			-e 's/heroku-sys\///g' \
 			-e 's/^Loading composer repositories with package information/Loading repositories with available runtimes and extensions/' \
 			-e 's/^Installing dependencies.*//' \
+			-e '/^No composer\.lock file present/d' \
 			-e '/^Potential causes:/,$d' \
 			-e "\#satisfiable by ${COMPOSER}/${COMPOSER_LOCK}#d" \
 			-e "s#(${COMPOSER}/${COMPOSER_LOCK}) dev-[0-9a-f]+#\1#" \

--- a/bin/util/autotune.php
+++ b/bin/util/autotune.php
@@ -77,8 +77,8 @@ $max_ram_string = $argv[$argc-1];
 $max_ram = stringtobytes($max_ram_string); // last arg is the maximum RAM we're allowed
 
 if($ram > $max_ram) {
-  $ram = $max_ram;
-  file_put_contents("php://stderr", "Limiting to ${max_ram_string} Bytes of RAM usage\n");
+	$ram = $max_ram;
+	file_put_contents("php://stderr", "Limiting to ${max_ram_string} Bytes of RAM usage\n");
 }
 
 // assume 64 MB base overhead for web server and FPM, and 1 MB overhead for each worker

--- a/bin/util/common.sh
+++ b/bin/util/common.sh
@@ -124,6 +124,7 @@ curl_retry_on_18() {
 	while (( ec == 18 && attempts++ < 3 )); do
 		curl "$@" # -C - would return code 33 if unsupported by server
 		ec=$?
+		sleep "$attempts" # naive backoff
 	done
 	return $ec
 }

--- a/support/build/_util/include/manifest.py
+++ b/support/build/_util/include/manifest.py
@@ -59,4 +59,3 @@ if manifest["type"] == "heroku-sys-php":
 	manifest.get("extra", {})["shared"] = extensions
 
 json.dump(manifest, sys.stdout, sort_keys=True)
-  

--- a/test/spec/spec_helper.rb
+++ b/test/spec/spec_helper.rb
@@ -63,7 +63,7 @@ def php_on_stack?(series)
 	case ENV["STACK"]
 		when "heroku-18"
 			available = ["7.1", "7.2", "7.3", "7.4", "8.0", "8.1"]
-    when "heroku-20"
+		when "heroku-20"
 			available = ["7.3", "7.4", "8.0", "8.1"]
 		else
 			available = ["8.1"]

--- a/test/spec/spec_helper.rb
+++ b/test/spec/spec_helper.rb
@@ -35,9 +35,10 @@ RSpec.configure do |config|
 end
 
 def successful_body(app, options = {})
-	retry_limit = options[:retry_limit] || 100
+	retry_limit = options[:retry_limit] || 5
+	retry_interval = options[:retry_interval] || 2
 	path = options[:path] ? "/#{options[:path]}" : ''
-	Excon.get("http://#{app.name}.herokuapp.com#{path}", :idempotent => true, :expects => 200, :retry_limit => retry_limit).body
+	Excon.get("http://#{app.name}.herokuapp.com#{path}", :idempotent => true, :expects => 200, :retry_limit => retry_limit, :retry_interval => retry_interval).body
 end
 
 def expect_exit(expect: :to, operator: :eq, code: 0)


### PR DESCRIPTION
A few small ones:

- spaces/tabs fixes
- retry Hatchet web requests with a wait (caused occasional test failures before, see commit message)
- suppress confusing "No composer.lock file present..." messages on platform install failure
- improve cURL retries in `bin/compile` to address transient pack-images build failures (https://app.circleci.com/pipelines/github/heroku/pack-images/1862/workflows/65547ba4-40ed-49cf-af96-c30da0a96643/jobs/38790, https://app.circleci.com/pipelines/github/heroku/builder/1873/workflows/bc6dac87-2a91-41e8-bf62-b3d7d5c4700e/jobs/39230)

GUS-W-11272821
GUS-W-11272794
GUS-W-11272774