### PR TITLE
Update the `publish.Ignore` list in `buildpack.toml`

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -3,6 +3,14 @@ name = "PHP"
 
 	[publish.Ignore]
 	files = [
+		".circleci/",
+		".github/",
 		".gitignore",
-		".github/"
+		".rspec_parallel",
+		"test/",
+		"Gemfile",
+		"Gemfile.lock",
+		"hatchet.json",
+		"hatchet.lock",
+		"requirements.txt",
 	]


### PR DESCRIPTION
To exclude test/development related files.

Spotted whilst looking at our new shimmed CNB builder (since it uses the buildpack registry archives as the input for the shimmed CNB).