### PR TITLE
Add ` --connect-timeout 5` to curl usages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # heroku-buildpack-php CHANGELOG
 
+## main
+
+- Adjust curl connection timeout handling [Ed Morley]
+
 ## v220 (2022-06-15)
 
 ### CHG

--- a/bin/compile
+++ b/bin/compile
@@ -28,7 +28,7 @@ trap 'err_trap' ERR
 
 # stdlib
 # download to a file first, as the function restarts the entire download on code 18 connection reset (not all servers support -C)
-curl_retry_on_18 --retry-connrefused --retry 3 --fail --silent --location -o $bp_dir/bin/util/stdlib.sh https://lang-common.s3.us-east-1.amazonaws.com/buildpack-stdlib/v8/stdlib.sh || {
+curl_retry_on_18 --retry-connrefused --retry 3 --connect-timeout 5 --fail --silent --location -o $bp_dir/bin/util/stdlib.sh https://lang-common.s3.us-east-1.amazonaws.com/buildpack-stdlib/v8/stdlib.sh || {
 	error <<-EOF
 		Failed to download standard library for bootstrapping!
 		
@@ -219,7 +219,7 @@ fi
 mkdir -p $build_dir/.heroku/php-min
 ln -s $build_dir/.heroku/php-min /app/.heroku/php-min
 
-curl_retry_on_18 --retry-connrefused --retry 3 --fail --silent --location -o $build_dir/.heroku/php-min.tar.gz "${s3_url}php-min-8.1.7.tar.gz" || {
+curl_retry_on_18 --retry-connrefused --retry 3 --connect-timeout 5 --fail --silent --location -o $build_dir/.heroku/php-min.tar.gz "${s3_url}php-min-8.1.7.tar.gz" || {
 	mcount "failures.bootstrap.download.php-min"
 	error <<-EOF
 		Failed to download minimal PHP for bootstrapping!
@@ -232,7 +232,7 @@ curl_retry_on_18 --retry-connrefused --retry 3 --fail --silent --location -o $bu
 tar xzf $build_dir/.heroku/php-min.tar.gz -C $build_dir/.heroku/php-min
 rm $build_dir/.heroku/php-min.tar.gz
 
-curl_retry_on_18 --retry-connrefused --retry 3 --fail --silent --location -o $build_dir/.heroku/composer.tar.gz "${s3_url}composer-2.3.7.tar.gz" || {
+curl_retry_on_18 --retry-connrefused --retry 3 --connect-timeout 5 --fail --silent --location -o $build_dir/.heroku/composer.tar.gz "${s3_url}composer-2.3.7.tar.gz" || {
 	mcount "failures.bootstrap.download.composer"
 	error <<-EOF
 		Failed to download Composer for bootstrapping!


### PR DESCRIPTION
Since otherwise the OS default socket timeout is used, which:
- can be several minutes
- can mean bugs like https://github.com/curl/curl/issues/4461   on older curl versions

GUS-W-11283397.