### PR TITLE
Fix optional bundled exts showing N/A in Devcenter

### DIFF
--- a/support/devcenter/generate.php
+++ b/support/devcenter/generate.php
@@ -157,7 +157,7 @@ foreach($packages as $package) {
 		$insertPackage->bindValue(':stack', $stack, SQLITE3_TEXT);
 		if($package['type'] == 'heroku-sys-php') {
 			$serie = implode('.', array_slice(explode('.', $package['version']), 0, 2)); // 7.3, 7.4, 8.0 etc
-			foreach($package["replace"] as $rname => $rversion) {
+			foreach(array_merge($package['replace']??[], $package['extra']['shared']??[]) as $rname => $rversion) {
 				if(strpos($rname, "heroku-sys/ext-") !== 0 || strpos($rname, ".native")) continue;
 				$insertExtension->reset();
 				$insertExtension->bindValue(':name', str_replace("heroku-sys/", "", $rname), SQLITE3_TEXT);


### PR DESCRIPTION
Because of how we now turn bundled extensions into their own dummy packages (#537), shared bundled extensions are no longer listed in a PHP package's `replace` section; they are still listed though in `extra.shared`, for this particular purpose, so we need to read them from there or the Dev Center table for the PHP support article will have a lot of sad little "-" signs, incorrectly indicating the extension isn't available.

GUS-W-11286871