### PR TITLE
Reduce Dependabot frequency to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,4 +7,4 @@ updates:
   - package-ecosystem: "composer"
     directory: "/support/devcenter"
     schedule:
-      interval: "weekly"
+      interval: "monthly"


### PR DESCRIPTION
To reduce the churn + email notification noise slightly. GitHub will still open PRs for any security issues outside of the monthly cadence.