### PR TITLE
Change curl timeout for low speed connection

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -28,7 +28,7 @@ trap 'err_trap' ERR
 
 # stdlib
 # download to a file first, as the function restarts the entire download on code 18 connection reset (not all servers support -C)
-curl_retry_on_18 --retry-connrefused --retry 3 --connect-timeout 5 --fail --silent --location -o $bp_dir/bin/util/stdlib.sh https://lang-common.s3.us-east-1.amazonaws.com/buildpack-stdlib/v8/stdlib.sh || {
+curl_retry_on_18 --retry-connrefused --retry 3 --connect-timeout 60 --fail --silent --location -o $bp_dir/bin/util/stdlib.sh https://lang-common.s3.us-east-1.amazonaws.com/buildpack-stdlib/v8/stdlib.sh || {
 	error <<-EOF
 		Failed to download standard library for bootstrapping!
 		
@@ -259,7 +259,7 @@ fi
 mkdir -p $build_dir/.heroku/php-min
 ln -s $build_dir/.heroku/php-min /app/.heroku/php-min
 
-curl_retry_on_18 --retry-connrefused --retry 3 --connect-timeout 5 --fail --silent --location -o $build_dir/.heroku/php-min.tar.gz "${s3_url}php-min-8.1.12.tar.gz" || {
+curl_retry_on_18 --retry-connrefused --retry 3 --connect-timeout 60 --fail --silent --location -o $build_dir/.heroku/php-min.tar.gz "${s3_url}php-min-8.1.12.tar.gz" || {
 	mcount "failures.bootstrap.download.php-min"
 	error <<-EOF
 		Failed to download minimal PHP for bootstrapping!
@@ -272,7 +272,7 @@ curl_retry_on_18 --retry-connrefused --retry 3 --connect-timeout 5 --fail --sile
 tar xzf $build_dir/.heroku/php-min.tar.gz -C $build_dir/.heroku/php-min
 rm $build_dir/.heroku/php-min.tar.gz
 
-curl_retry_on_18 --retry-connrefused --retry 3 --connect-timeout 5 --fail --silent --location -o $build_dir/.heroku/composer.tar.gz "${s3_url}composer-2.4.4.tar.gz" || {
+curl_retry_on_18 --retry-connrefused --retry 3 --connect-timeout 60 --fail --silent --location -o $build_dir/.heroku/composer.tar.gz "${s3_url}composer-2.4.4.tar.gz" || {
 	mcount "failures.bootstrap.download.composer"
 	error <<-EOF
 		Failed to download Composer for bootstrapping!


### PR DESCRIPTION
for the low-speed connection environment, the current 5s timeout value seems too low.
I often get `Failed to download standard library for bootstrapping!` error when deploying the app to my homelab server
can we increase it to ~ 60s to make it works more friendly?