### PR TITLE
Update Hatchet to latest timeouts-etc branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,12 +2,10 @@ name: CI
 
 on:
   push:
-    # Avoid duplicate builds on PRs.
     branches:
-      - main
+      - "**"
     tags:
       - v*
-  pull_request:
 
 permissions:
   contents: read

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/heroku/hatchet.git
-  revision: 53655a3b5a33c92560aef360d558c6f812a5b679
+  revision: 661bcd6696b8d00f3c18f21d810ac02df5ab50a8
   branch: timeouts-etc
   specs:
     heroku_hatchet (7.4.0)
@@ -16,7 +16,7 @@ GEM
     ansi (1.5.0)
     diff-lcs (1.5.0)
     erubis (2.7.0)
-    excon (0.93.1)
+    excon (0.97.2)
     heroics (0.1.2)
       erubis (~> 2.0)
       excon


### PR DESCRIPTION
This buildpack uses that branch (https://github.com/heroku/hatchet/compare/main...timeouts-etc) for its timeout handling capability. Its changes have now been ported to include recent Hatchet changes such as the fix for scaling to "basic" instead of "free" after multi-dyno runs, restoring the ability to run CI without bogus failures.

GUS-W-12421825