### PR TITLE
PHP 8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # heroku-buildpack-php CHANGELOG
 
+## v229 (2023-01-25)
+
+### ADD
+
+- PHP/8.2.1 [David Zuelke]
+
 ## v228 (2023-01-25)
 
 ### ADD

--- a/bin/util/eol.php
+++ b/bin/util/eol.php
@@ -11,6 +11,7 @@ $eol = array(
 	"7.4" => array("2021-11-28", "2022-11-28"),
 	"8.0" => array("2022-11-26", "2023-11-26"),
 	"8.1" => array("2023-11-25", "2024-11-25"),
+	"8.2" => array("2024-12-08", "2025-12-08"),
 );
 
 if(basename(__FILE__) != basename($_SERVER["PHP_SELF"])) return $eol; // we're being included, just return the data

--- a/support/build/extensions/no-debug-non-zts-20160303/blackfire
+++ b/support/build/extensions/no-debug-non-zts-20160303/blackfire
@@ -32,6 +32,9 @@ case ${ZEND_MODULE_API_VERSION} in
 	20210902)
 		series=8.1
 		;;
+	20220829)
+		series=8.2
+		;;
 	*)
 		echo "Unsupported PHP/Zend Module API version: ${ZEND_MODULE_API_VERSION}"
 		exit 1

--- a/support/build/extensions/no-debug-non-zts-20160303/newrelic
+++ b/support/build/extensions/no-debug-non-zts-20160303/newrelic
@@ -38,6 +38,9 @@ case ${ZEND_MODULE_API_VERSION} in
 	20210902)
 		series=8.1
 		;;
+	20220829)
+		series=8.2
+		;;
 esac
 dep_manifest=${dep_package}_php-$series.composer.json
 

--- a/support/build/extensions/no-debug-non-zts-20220829/amqp-1.11.0
+++ b/support/build/extensions/no-debug-non-zts-20220829/amqp-1.11.0
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Build Path: /app/.heroku/php
+# Build Deps: php-8.2.*
+
+source $(dirname $0)/../no-debug-non-zts-20160303/amqp

--- a/support/build/extensions/no-debug-non-zts-20220829/apcu-5.1.21
+++ b/support/build/extensions/no-debug-non-zts-20220829/apcu-5.1.21
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Build Path: /app/.heroku/php
+# Build Deps: php-8.2.*
+
+source $(dirname $0)/../no-debug-non-zts-20160303/apcu

--- a/support/build/extensions/no-debug-non-zts-20220829/blackfire-1.86.3
+++ b/support/build/extensions/no-debug-non-zts-20220829/blackfire-1.86.3
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Build Path: /app/.heroku/php
+
+source $(dirname $0)/../no-debug-non-zts-20160303/blackfire

--- a/support/build/extensions/no-debug-non-zts-20220829/ev-1.1.5
+++ b/support/build/extensions/no-debug-non-zts-20220829/ev-1.1.5
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Build Path: /app/.heroku/php
+# Build Deps: php-8.2.*
+
+source $(dirname $0)/../no-debug-non-zts-20160303/ev

--- a/support/build/extensions/no-debug-non-zts-20220829/event-3.0.8
+++ b/support/build/extensions/no-debug-non-zts-20220829/event-3.0.8
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Build Path: /app/.heroku/php
+# Build Deps: php-8.2.*
+
+source $(dirname $0)/../no-debug-non-zts-20160303/event

--- a/support/build/extensions/no-debug-non-zts-20220829/imagick-3.7.0
+++ b/support/build/extensions/no-debug-non-zts-20220829/imagick-3.7.0
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Build Path: /app/.heroku/php
+# Build Deps: php-8.2.*
+
+source $(dirname $0)/../no-debug-non-zts-20160303/imagick

--- a/support/build/extensions/no-debug-non-zts-20220829/memcached-3.2.0
+++ b/support/build/extensions/no-debug-non-zts-20220829/memcached-3.2.0
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Build Path: /app/.heroku/php
+# Build Deps: php-8.2.*
+
+source $(dirname $0)/../no-debug-non-zts-20160303/memcached

--- a/support/build/extensions/no-debug-non-zts-20220829/mongodb-1.15.0
+++ b/support/build/extensions/no-debug-non-zts-20220829/mongodb-1.15.0
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Build Path: /app/.heroku/php
+# Build Deps: php-8.2.*
+
+source $(dirname $0)/../no-debug-non-zts-20160303/mongodb

--- a/support/build/extensions/no-debug-non-zts-20220829/oauth-2.0.7
+++ b/support/build/extensions/no-debug-non-zts-20220829/oauth-2.0.7
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Build Path: /app/.heroku/php
+# Build Deps: php-8.2.*
+
+source $(dirname $0)/../no-debug-non-zts-20160303/oauth

--- a/support/build/extensions/no-debug-non-zts-20220829/pcov-1.0.11
+++ b/support/build/extensions/no-debug-non-zts-20220829/pcov-1.0.11
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Build Path: /app/.heroku/php
+# Build Deps: php-8.2.*
+
+source $(dirname $0)/../no-debug-non-zts-20170718/pcov

--- a/support/build/extensions/no-debug-non-zts-20220829/pq-2.2.0
+++ b/support/build/extensions/no-debug-non-zts-20220829/pq-2.2.0
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Build Path: /app/.heroku/php
+# Build Deps: php-8.2.*, extensions/no-debug-non-zts-20220829/raphf-2.*
+
+source $(dirname $0)/../no-debug-non-zts-20160303/pq

--- a/support/build/extensions/no-debug-non-zts-20220829/psr-1.2.0
+++ b/support/build/extensions/no-debug-non-zts-20220829/psr-1.2.0
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Build Path: /app/.heroku/php
+# Build Deps: php-8.2.*
+
+source $(dirname $0)/../no-debug-non-zts-20170718/psr

--- a/support/build/extensions/no-debug-non-zts-20220829/raphf-2.0.1
+++ b/support/build/extensions/no-debug-non-zts-20220829/raphf-2.0.1
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Build Path: /app/.heroku/php
+# Build Deps: php-8.2.*
+
+source $(dirname $0)/../no-debug-non-zts-20160303/raphf

--- a/support/build/extensions/no-debug-non-zts-20220829/rdkafka-6.0.3
+++ b/support/build/extensions/no-debug-non-zts-20220829/rdkafka-6.0.3
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Build Path: /app/.heroku/php
+# Build Deps: php-8.2.*, libraries/librdkafka-1.*
+
+source $(dirname $0)/../no-debug-non-zts-20160303/rdkafka

--- a/support/build/extensions/no-debug-non-zts-20220829/redis-5.3.7
+++ b/support/build/extensions/no-debug-non-zts-20220829/redis-5.3.7
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Build Path: /app/.heroku/php
+# Build Deps: php-8.2.*
+
+source $(dirname $0)/../no-debug-non-zts-20160303/redis

--- a/support/build/extensions/no-debug-non-zts-20220829/uuid-1.2.0
+++ b/support/build/extensions/no-debug-non-zts-20220829/uuid-1.2.0
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Build Path: /app/.heroku/php
+# Build Deps: php-8.2.*
+
+source $(dirname $0)/../no-debug-non-zts-20160303/uuid

--- a/support/build/php
+++ b/support/build/php
@@ -28,6 +28,8 @@ if [[ $dep_version == *alpha* ]] || [[ $dep_version == *beta* ]] || [[ $dep_vers
 		dep_url=https://downloads.php.net/~carusogabriel/${dep_archive_name}
 	elif [[ $dep_version == 8.1.* ]]; then
 		dep_url=https://downloads.php.net/~ramsey/${dep_archive_name}
+	elif [[ $dep_version == 8.2.* ]]; then
+		dep_url=https://downloads.php.net/~pierrick/${dep_archive_name}
 	fi
 else
 	dep_url=https://www.php.net/distributions/${dep_archive_name}

--- a/support/build/php-8.2.1
+++ b/support/build/php-8.2.1
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Build Path: /app/.heroku/php
+
+source $(dirname $0)/php

--- a/support/devcenter/generate.php
+++ b/support/devcenter/generate.php
@@ -19,6 +19,7 @@ $series = [
 	'7.4',
 	'8.0',
 	'8.1',
+	'8.2',
 ];
 
 $findstacks = function(array $package) use($stacks) {

--- a/test/spec/newrelic_spec.rb
+++ b/test/spec/newrelic_spec.rb
@@ -29,7 +29,7 @@ describe "A PHP application using New Relic" do
 					# a NEW_RELIC_LICENSE_KEY triggers the automatic installation of ext-newrelic at the end of the build
 					@app = new_app_with_stack_and_platrepo('test/fixtures/bootopts',
 						config: { "NEW_RELIC_LOG_LEVEL" => "info", "NEW_RELIC_LICENSE_KEY" => "thiswilltriggernewrelic" },
-						before_deploy: -> { system("composer require --quiet --ignore-platform-reqs 'php:*'") or raise "Failed to require PHP version" },
+						before_deploy: -> { system("composer require --quiet --ignore-platform-reqs 'php:8.1.*'") or raise "Failed to require PHP version" },
 						run_multi: true
 					)
 				end

--- a/test/spec/php_8.2-apache2_boot_spec.rb
+++ b/test/spec/php_8.2-apache2_boot_spec.rb
@@ -1,0 +1,5 @@
+require_relative "php_shared_boot"
+
+describe "A PHP 8.2/Apache application for testing boot options", :requires_php_on_stack => "8.2" do
+	include_examples "A PHP application for testing boot options", "8.2", "apache2"
+end

--- a/test/spec/php_8.2-apache2_concurrency_spec.rb
+++ b/test/spec/php_8.2-apache2_concurrency_spec.rb
@@ -1,0 +1,5 @@
+require_relative "php_shared_concurrency"
+
+describe "A PHP 8.2/Apache application for testing WEB_CONCURRENCY behavior", :requires_php_on_stack => "8.2" do
+	include_examples "A PHP application for testing WEB_CONCURRENCY behavior", "8.2", "apache2"
+end

--- a/test/spec/php_8.2-nginx_boot_spec.rb
+++ b/test/spec/php_8.2-nginx_boot_spec.rb
@@ -1,0 +1,5 @@
+require_relative "php_shared_boot"
+
+describe "A PHP 8.2/Nginx application for testing boot options", :requires_php_on_stack => "8.2" do
+	include_examples "A PHP application for testing boot options", "8.2", "nginx"
+end

--- a/test/spec/php_8.2-nginx_concurrency_spec.rb
+++ b/test/spec/php_8.2-nginx_concurrency_spec.rb
@@ -1,0 +1,5 @@
+require_relative "php_shared_concurrency"
+
+describe "A PHP 8.2/Nginx application for testing WEB_CONCURRENCY behavior", :requires_php_on_stack => "8.2" do
+	include_examples "A PHP application for testing WEB_CONCURRENCY behavior", "8.2", "nginx"
+end

--- a/test/spec/php_8.2_base_spec.rb
+++ b/test/spec/php_8.2_base_spec.rb
@@ -1,0 +1,48 @@
+require_relative "php_shared_base"
+
+describe "A basic PHP 8.2 application", :requires_php_on_stack => "8.2" do
+	include_examples "A basic PHP application", "8.2"
+	
+	context "with an index.php that allows for different execution times" do
+		['apache2', 'nginx'].each do |server|
+			context "running the #{server} web server" do
+				let(:app) {
+					new_app_with_stack_and_platrepo('test/fixtures/sigterm',
+						before_deploy: -> { system("composer require --quiet --ignore-platform-reqs php '8.2.*'") or raise "Failed to require PHP version" }
+					)
+				}
+				
+				# FIXME: move to php_shared.rb once all PHPs are rebuilt with that tracing capability
+				it "logs slowness after configured time and sees a trace" do
+					app.deploy do |app|
+						# launch web server wrapped in a 20 second timeout
+						# once web server is ready, `read` unblocks and we curl the sleep() script which will take a few seconds to run
+						# after `curl` completes, `wait-for.it.sh` will shut down
+						# ensure slowlog info and trace is there
+						cmd = "./waitforit.sh 20 'ready for connections' heroku-php-#{server} --verbose -F fpm.request_slowlog_timeout.conf | { read && curl \"localhost:$PORT/index.php?wait=5\"; }"
+						retry_until retry: 3, sleep: 5 do
+							output = app.run(cmd)
+							expect(output).to include("executing too slow")
+							expect(output).to include("sleep() /app/index.php:5")
+						end
+					end
+				end
+				
+				it "logs slowness after about 3 seconds and terminates the process after about 30 seconds" do
+					app.deploy do |app|
+						# launch web server wrapped in a 50 second timeout
+						# once web server is ready, `read` unblocks and we curl the sleep() script with a very long timeout
+						# after `curl` completes, `wait-for.it.sh` will shut down
+						# ensure slowlog and terminate output is there
+						cmd = "./waitforit.sh 50 'ready for connections' heroku-php-#{server} --verbose | { read && curl \"localhost:$PORT/index.php?wait=35\"; }"
+						retry_until retry: 3, sleep: 5 do
+							output = app.run(cmd)
+							expect(output).to match(/executing too slow/)
+							expect(output).to match(/execution timed out/)
+						end
+					end
+				end
+			end
+		end
+	end
+end

--- a/test/spec/php_shared_base.rb
+++ b/test/spec/php_shared_base.rb
@@ -32,13 +32,13 @@ shared_examples "A basic PHP application" do |series|
 			end
 		end
 		
-		it "uses all available RAM as PHP CLI memory_limit", :if => series.between?("7.2","8.1") do
+		it "uses all available RAM as PHP CLI memory_limit", :if => series.between?("7.2","8.2") do
 			retry_until retry: 3, sleep: 5 do
 				expect(@app.run("php -i | grep memory_limit")).to match "memory_limit => 536870912 => 536870912"
 			end
 		end
 		
-		it "is running a PHP build that links against libc-client, libonig, libsqlite3 and libzip from the stack", :if => series.between?("7.2","8.1") do
+		it "is running a PHP build that links against libc-client, libonig, libsqlite3 and libzip from the stack", :if => series.between?("7.2","8.2") do
 			ldd_output = @app.run("ldd .heroku/php/bin/php .heroku/php/lib/php/extensions/no-debug-non-zts-*/{imap,mbstring,pdo_sqlite,sqlite3}.so | grep -E ' => (/usr)?/lib/' | grep -e 'libc-client.so' -e 'libonig.so' -e 'libsqlite3.so' -e 'libzip.so' | wc -l")
 			# 1x libc-client.so for extensions/…/imap.so
 			# 1x libonig for extensions/…/mbstring.so

--- a/test/spec/spec_helper.rb
+++ b/test/spec/spec_helper.rb
@@ -56,7 +56,7 @@ def expected_default_php(stack)
 		when "heroku-18"
 			"7.4"
 		else
-			"8.1"
+			"8.2"
 	end
 end
 
@@ -65,9 +65,9 @@ def php_on_stack?(series)
 		when "heroku-18"
 			available = ["7.1", "7.2", "7.3", "7.4", "8.0", "8.1"]
 		when "heroku-20"
-			available = ["7.3", "7.4", "8.0", "8.1"]
+			available = ["7.3", "7.4", "8.0", "8.1", "8.2"]
 		else
-			available = ["8.1"]
+			available = ["8.1", "8.2"]
 	end
 	available.include?(series)
 end

--- a/test/var/log/parallel_runtime_rspec.heroku-20.log
+++ b/test/var/log/parallel_runtime_rspec.heroku-20.log
@@ -24,6 +24,11 @@ test/spec/php_8.1-apache2_concurrency_spec.rb:134.627796263
 test/spec/php_8.1_base_spec.rb:210.99503811600005
 test/spec/php_8.1-nginx_boot_spec.rb:137.466478774
 test/spec/php_8.1-nginx_concurrency_spec.rb:130.15884861399996
+test/spec/php_8.2-apache2_boot_spec.rb:160.79852702099998
+test/spec/php_8.2-apache2_concurrency_spec.rb:134.627796263
+test/spec/php_8.2_base_spec.rb:210.99503811600005
+test/spec/php_8.2-nginx_boot_spec.rb:137.466478774
+test/spec/php_8.2-nginx_concurrency_spec.rb:130.15884861399996
 test/spec/php_default_spec.rb:65.515156888
 test/spec/platform_spec.rb:50.8424652760033496
 test/spec/sigterm_spec.rb:56.08510167799997

--- a/test/var/log/parallel_runtime_rspec.heroku-22.log
+++ b/test/var/log/parallel_runtime_rspec.heroku-22.log
@@ -9,6 +9,11 @@ test/spec/php_8.1-apache2_concurrency_spec.rb:134.627796263
 test/spec/php_8.1_base_spec.rb:210.99503811600005
 test/spec/php_8.1-nginx_boot_spec.rb:137.466478774
 test/spec/php_8.1-nginx_concurrency_spec.rb:130.15884861399996
+test/spec/php_8.2-apache2_boot_spec.rb:160.79852702099998
+test/spec/php_8.2-apache2_concurrency_spec.rb:134.627796263
+test/spec/php_8.2_base_spec.rb:210.99503811600005
+test/spec/php_8.2-nginx_boot_spec.rb:137.466478774
+test/spec/php_8.2-nginx_concurrency_spec.rb:130.15884861399996
 test/spec/php_default_spec.rb:65.515156888
 test/spec/platform_spec.rb:50.8424652760033496
 test/spec/sigterm_spec.rb:56.08510167799997


### PR DESCRIPTION
Not for heroku-18.

Extensions currently not available:

- ext-newrelic
- ext-phalcon

Closes https://github.com/heroku/heroku-buildpack-php/issues/610

GUS-W-12421803