### PR TITLE
Use GHA for platform package builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,9 @@ name: CI
 on:
   push:
     branches:
-      - "**"
-    tags:
-      - v*
+      - "main"
+  pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/platform-build.yml
+++ b/.github/workflows/platform-build.yml
@@ -78,7 +78,7 @@ jobs:
   deploys:
     needs: [formulae-list, docker-build]
     if: ${{ needs.formulae-list.outputs.formulae != '[]' && needs.formulae-list.outputs.formulae != '' }}
-    runs-on: ubuntu-22.04
+    runs-on: pub-hk-ubuntu-22.04-medium
     strategy:
       max-parallel: ${{ fromJSON(inputs.concurrency) }}
       matrix:

--- a/.github/workflows/platform-build.yml
+++ b/.github/workflows/platform-build.yml
@@ -1,4 +1,4 @@
-name: Build platform packages and deploy to -develop/
+name: Platform packages build and deploy to -develop/
 
 on:
   workflow_dispatch:

--- a/.github/workflows/platform-build.yml
+++ b/.github/workflows/platform-build.yml
@@ -1,0 +1,128 @@
+name: Build platform packages and deploy to -develop/
+
+on:
+  workflow_dispatch:
+    inputs:
+      formulae:
+        description: 'Shell word list of formulae to build; any Bash wildcards are allowed, e.g. "php-8.1.8 extensions/no-debug-non-zts-{2022,2021}*/newrelic-10*"'
+        type: string
+        required: true
+      stack:
+        description: 'Stack to build for'
+        type: choice
+        options:
+        - heroku-18
+        - heroku-20
+        - heroku-22
+        required: true
+      dry-run:
+        description: 'Build packages without deploying to S3 (e.g. for testing a formula)'
+        type: boolean
+        default: false
+        required: false
+      overwrite:
+        description: 'Overwrite existing packages'
+        type: boolean
+        default: false
+        required: false
+      publish:
+        description: 'Publish updated Composer platform repository after all builds are complete'
+        type: boolean
+        default: true
+        required: false
+      concurrency:
+        description: 'GitHub Actions runner concurrency'
+        type: number
+        default: 3
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  formulae-list:
+    runs-on: ubuntu-22.04
+    outputs:
+      formulae: ${{ steps.expand-formulae.outputs.matrix }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install jq tool
+        run: |
+          sudo apt-get update
+          sudo apt-get install jq
+      - id: expand-formulae
+        name: Expand list of given formulae
+        run: |
+          cd support/build
+          echo -n "matrix=" >> "$GITHUB_OUTPUT"
+          set -o pipefail
+          ls ${{inputs.formulae}} | jq -jcRn '[inputs|select(length>0)]' >> "$GITHUB_OUTPUT"
+  docker-build:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Build Docker image
+        run: docker build --tag heroku-php-build-${{inputs.stack}}:${{github.sha}} --file support/build/_docker/${{inputs.stack}}.Dockerfile .
+      - name: Save built Docker image
+        run: |
+          mkdir -p /tmp/docker-cache
+          docker save -o /tmp/docker-cache/heroku-php-build-${{inputs.stack}}.${{github.sha}}.tar heroku-php-build-${{inputs.stack}}:${{github.sha}}
+      - name: Cache saved Docker image as Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: docker-cache-heroku-php-build-${{inputs.stack}}.${{github.sha}}
+          path: /tmp/docker-cache
+          retention-days: 1
+  deploys:
+    needs: [formulae-list, docker-build]
+    if: ${{ needs.formulae-list.outputs.formulae != '[]' && needs.formulae-list.outputs.formulae != '' }}
+    runs-on: ubuntu-22.04
+    strategy:
+      max-parallel: ${{ fromJSON(inputs.concurrency) }}
+      matrix:
+        formula: ${{ fromJSON(needs.formulae-list.outputs.formulae) }}
+    env:
+      AWS_ACCESS_KEY_ID:  ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Fetch cached Docker image
+        uses: actions/download-artifact@v3
+        with:
+          name: docker-cache-heroku-php-build-${{inputs.stack}}.${{github.sha}}
+          path: /tmp/docker-cache
+      - name: Load cached Docker image
+        run: docker load -i /tmp/docker-cache/heroku-php-build-${{inputs.stack}}.${{github.sha}}.tar
+      - name: Build formula without deploying
+        if: ${{ inputs.dry-run == true }}
+        run: docker run --rm --env-file=support/build/_docker/env.default heroku-php-build-${{inputs.stack}}:${{github.sha}} bob build ${{matrix.formula}}
+      - name: Build and deploy formula
+        if: ${{ inputs.dry-run == false && inputs.overwrite == false }}
+        run: docker run --rm --env-file=support/build/_docker/env.default heroku-php-build-${{inputs.stack}}:${{github.sha}} deploy.sh ${{matrix.formula}}
+      - name: Build and deploy(+overwrite) formula
+        if: ${{ inputs.dry-run == false && inputs.overwrite == true }}
+        run: docker run --rm --env-file=support/build/_docker/env.default heroku-php-build-${{inputs.stack}}:${{github.sha}} deploy.sh --overwrite ${{matrix.formula}}
+  mkrepo:
+    needs: [deploys]
+    if: ${{ inputs.dry-run == false && inputs.publish == true }}
+    runs-on: ubuntu-22.04
+    env:
+      AWS_ACCESS_KEY_ID:  ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Fetch cached Docker image
+        uses: actions/download-artifact@v3
+        with:
+          name: docker-cache-heroku-php-build-${{inputs.stack}}.${{github.sha}}
+          path: /tmp/docker-cache
+      - name: Load cached Docker image
+        run: docker load -i /tmp/docker-cache/heroku-php-build-${{inputs.stack}}.${{github.sha}}.tar
+      - name: Re-generate platform package repository
+        run: docker run --rm --env-file=support/build/_docker/env.default heroku-php-build-${{inputs.stack}}:${{github.sha}} mkrepo.sh --upload
+      - name: Dry-run sync.sh to show package changes available for syncing to production bucket
+        run: yes n 2>/dev/null | docker run --rm -i --env-file=support/build/_docker/env.default heroku-php-build-${{inputs.stack}}:${{github.sha}} sync.sh lang-php dist-${{inputs.stack}}-stable/

--- a/.github/workflows/platform-build.yml
+++ b/.github/workflows/platform-build.yml
@@ -63,18 +63,18 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Cache Docker build
+        id: cache-docker
+        uses: actions/cache@v3
+        with:
+          key: docker-cache-heroku-php-build-${{inputs.stack}}.${{github.sha}}
+          path: /tmp/docker-cache.tar.gz
       - name: Build Docker image
+        if: steps.cache-docker.outputs.cache-hit != 'true'
         run: docker build --tag heroku-php-build-${{inputs.stack}}:${{github.sha}} --file support/build/_docker/${{inputs.stack}}.Dockerfile .
       - name: Save built Docker image
-        run: |
-          mkdir -p /tmp/docker-cache
-          docker save -o /tmp/docker-cache/heroku-php-build-${{inputs.stack}}.${{github.sha}}.tar heroku-php-build-${{inputs.stack}}:${{github.sha}}
-      - name: Cache saved Docker image as Artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: docker-cache-heroku-php-build-${{inputs.stack}}.${{github.sha}}
-          path: /tmp/docker-cache
-          retention-days: 1
+        if: steps.cache-docker.outputs.cache-hit != 'true'
+        run: docker save heroku-php-build-${{inputs.stack}}:${{github.sha}} | gzip -1 > /tmp/docker-cache.tar.gz
   deploys:
     needs: [formulae-list, docker-build]
     if: ${{ needs.formulae-list.outputs.formulae != '[]' && needs.formulae-list.outputs.formulae != '' }}
@@ -89,13 +89,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Fetch cached Docker image
-        uses: actions/download-artifact@v3
+      - name: Restore cached Docker build
+        uses: actions/cache/restore@v3
         with:
-          name: docker-cache-heroku-php-build-${{inputs.stack}}.${{github.sha}}
-          path: /tmp/docker-cache
+          key: docker-cache-heroku-php-build-${{inputs.stack}}.${{github.sha}}
+          path: /tmp/docker-cache.tar.gz
       - name: Load cached Docker image
-        run: docker load -i /tmp/docker-cache/heroku-php-build-${{inputs.stack}}.${{github.sha}}.tar
+        run: docker load -i /tmp/docker-cache.tar.gz
       - name: Build formula without deploying
         if: ${{ inputs.dry-run == true }}
         run: docker run --rm --env-file=support/build/_docker/env.default heroku-php-build-${{inputs.stack}}:${{github.sha}} bob build ${{matrix.formula}}
@@ -115,13 +115,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Fetch cached Docker image
-        uses: actions/download-artifact@v3
+      - name: Restore cached Docker build
+        uses: actions/cache/restore@v3
         with:
-          name: docker-cache-heroku-php-build-${{inputs.stack}}.${{github.sha}}
-          path: /tmp/docker-cache
+          key: docker-cache-heroku-php-build-${{inputs.stack}}.${{github.sha}}
+          path: /tmp/docker-cache.tar.gz
       - name: Load cached Docker image
-        run: docker load -i /tmp/docker-cache/heroku-php-build-${{inputs.stack}}.${{github.sha}}.tar
+        run: docker load -i /tmp/docker-cache.tar.gz
       - name: Re-generate platform package repository
         run: docker run --rm --env-file=support/build/_docker/env.default heroku-php-build-${{inputs.stack}}:${{github.sha}} mkrepo.sh --upload
       - name: Dry-run sync.sh to show package changes available for syncing to production bucket

--- a/.github/workflows/platform-remove.yml
+++ b/.github/workflows/platform-remove.yml
@@ -1,0 +1,43 @@
+name: Remove platform packages from -develop/
+
+on:
+  workflow_dispatch:
+    inputs:
+      manifests:
+        description: 'Shell word list of packages manifest names to remove; Bash brace expansion and S3 wildcard expansion is supported, e.g. "php-8.1.{8..16} ext-{redis-4,newrelic-9}.*_php-7.*"'
+        type: string
+        required: true
+      stack:
+        description: 'Stack to remove from'
+        type: choice
+        options:
+        - heroku-18
+        - heroku-20
+        - heroku-22
+        required: true
+      dry-run:
+        description: 'Only list package removals, without executing'
+        type: boolean
+        default: false
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  remove:
+    runs-on: ubuntu-22.04
+    env:
+      AWS_ACCESS_KEY_ID:  ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Build Docker image
+        run: docker build --tag heroku-php-build-${{inputs.stack}}:${{github.sha}} --file support/build/_docker/${{inputs.stack}}.Dockerfile .
+      - name: List packages for removal using given input list
+        if: ${{ inputs.dry-run == true }}
+        run: yes n 2>/dev/null | docker run --rm -i --env-file=support/build/_docker/env.default heroku-php-build-${{inputs.stack}}:${{github.sha}} remove.sh ${{inputs.manifests}}
+      - name: Remove packages from repository
+        if: ${{ inputs.dry-run == false }}
+        run: yes 2>/dev/null | docker run --rm -i --env-file=support/build/_docker/env.default heroku-php-build-${{inputs.stack}}:${{github.sha}} remove.sh ${{inputs.manifests}}

--- a/.github/workflows/platform-remove.yml
+++ b/.github/workflows/platform-remove.yml
@@ -33,8 +33,26 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Restore cached Docker image
+        id: restore-docker
+        uses: actions/cache/restore@v3
+        with:
+          key: docker-cache-heroku-php-build-${{inputs.stack}}.${{github.sha}}
+          path: /tmp/docker-cache.tar.gz
+      - name: Load cached Docker image
+        if: steps.restore-docker.outputs.cache-hit == 'true'
+        run: docker load -i /tmp/docker-cache.tar.gz
       - name: Build Docker image
+        if: steps.restore-docker.outputs.cache-hit != 'true'
         run: docker build --tag heroku-php-build-${{inputs.stack}}:${{github.sha}} --file support/build/_docker/${{inputs.stack}}.Dockerfile .
+      - name: Save built Docker image
+        if: steps.restore-docker.outputs.cache-hit != 'true'
+        run: docker save heroku-php-build-${{inputs.stack}}:${{github.sha}} | gzip -1 > /tmp/docker-cache.tar.gz
+      - name: Cache built Docker image
+        uses: actions/cache/save@v3
+        with:
+          key: ${{ steps.restore-docker.outputs.cache-primary-key }}
+          path: /tmp/docker-cache.tar.gz
       - name: List packages for removal using given input list
         if: ${{ inputs.dry-run == true }}
         run: yes n 2>/dev/null | docker run --rm -i --env-file=support/build/_docker/env.default heroku-php-build-${{inputs.stack}}:${{github.sha}} remove.sh ${{inputs.manifests}}

--- a/.github/workflows/platform-remove.yml
+++ b/.github/workflows/platform-remove.yml
@@ -1,4 +1,4 @@
-name: Remove platform packages from -develop/
+name: Platform packages removal from -develop/
 
 on:
   workflow_dispatch:

--- a/.github/workflows/platform-sync.yml
+++ b/.github/workflows/platform-sync.yml
@@ -1,0 +1,39 @@
+name: Sync platform packages from -develop/ to -stable/
+
+on:
+  workflow_dispatch:
+    inputs:
+      stack:
+        description: 'Stack to sync'
+        type: choice
+        options:
+        - heroku-18
+        - heroku-20
+        - heroku-22
+        required: true
+      dry-run:
+        description: 'Only list package changes, without syncing'
+        type: boolean
+        default: false
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    runs-on: ubuntu-22.04
+    env:
+      AWS_ACCESS_KEY_ID:  ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Build Docker image
+        run: docker build --tag heroku-php-build-${{inputs.stack}}:${{github.sha}} --file support/build/_docker/${{inputs.stack}}.Dockerfile .
+      - name: Dry-run sync.sh to show package changes available for syncing to production bucket
+        if: ${{ inputs.dry-run == true }}
+        run: yes n 2>/dev/null | docker run --rm -i --env-file=support/build/_docker/env.default heroku-php-build-${{inputs.stack}}:${{github.sha}} sync.sh lang-php dist-${{inputs.stack}}-stable/
+      - name: Sync changed packages to production bucket
+        if: ${{ inputs.dry-run == false }}
+        run: yes 2>/dev/null | docker run --rm -i --env-file=support/build/_docker/env.default heroku-php-build-${{inputs.stack}}:${{github.sha}} sync.sh lang-php dist-${{inputs.stack}}-stable/

--- a/.github/workflows/platform-sync.yml
+++ b/.github/workflows/platform-sync.yml
@@ -29,8 +29,26 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Restore cached Docker image
+        id: restore-docker
+        uses: actions/cache/restore@v3
+        with:
+          key: docker-cache-heroku-php-build-${{inputs.stack}}.${{github.sha}}
+          path: /tmp/docker-cache.tar.gz
+      - name: Load cached Docker image
+        if: steps.restore-docker.outputs.cache-hit == 'true'
+        run: docker load -i /tmp/docker-cache.tar.gz
       - name: Build Docker image
+        if: steps.restore-docker.outputs.cache-hit != 'true'
         run: docker build --tag heroku-php-build-${{inputs.stack}}:${{github.sha}} --file support/build/_docker/${{inputs.stack}}.Dockerfile .
+      - name: Save built Docker image
+        if: steps.restore-docker.outputs.cache-hit != 'true'
+        run: docker save heroku-php-build-${{inputs.stack}}:${{github.sha}} | gzip -1 > /tmp/docker-cache.tar.gz
+      - name: Cache built Docker image
+        uses: actions/cache/save@v3
+        with:
+          key: ${{ steps.restore-docker.outputs.cache-primary-key }}
+          path: /tmp/docker-cache.tar.gz
       - name: Dry-run sync.sh to show package changes available for syncing to production bucket
         if: ${{ inputs.dry-run == true }}
         run: yes n 2>/dev/null | docker run --rm -i --env-file=support/build/_docker/env.default heroku-php-build-${{inputs.stack}}:${{github.sha}} sync.sh lang-php dist-${{inputs.stack}}-stable/

--- a/.github/workflows/platform-sync.yml
+++ b/.github/workflows/platform-sync.yml
@@ -1,4 +1,4 @@
-name: Sync platform packages from -develop/ to -stable/
+name: Platform packages sync from -develop/ to -stable/
 
 on:
   workflow_dispatch:

--- a/support/build/_util/include/manifest.sh
+++ b/support/build/_util/include/manifest.sh
@@ -9,7 +9,7 @@ print_or_export_manifest_cmd() {
 }
 
 generate_manifest_cmd() {
-	echo "s3cmd --host=${S3_REGION:-s3}.amazonaws.com --host-bucket='%(bucket)s.${S3_REGION:-s3}.amazonaws.com' --ssl --acl-public -m application/json put $(pwd)/${1} s3://${S3_BUCKET}/${S3_PREFIX}${1}"
+	echo "s3cmd --host=${S3_REGION:-s3}.amazonaws.com --host-bucket='%(bucket)s.${S3_REGION:-s3}.amazonaws.com' --ssl -m application/json put $(pwd)/${1} s3://${S3_BUCKET}/${S3_PREFIX}${1}"
 }
 
 soname_version() {

--- a/support/build/_util/mkrepo.sh
+++ b/support/build/_util/mkrepo.sh
@@ -125,7 +125,7 @@ if $redir; then
 	exec 1>&3 3>&-
 fi
 
-cmd="s3cmd --host=${S3_REGION}.amazonaws.com --host-bucket='%(bucket)s.${S3_REGION}.amazonaws.com' --ssl --acl-public -m application/json put packages.json s3://${S3_BUCKET}/${S3_PREFIX}packages.json"
+cmd="s3cmd --host=${S3_REGION}.amazonaws.com --host-bucket='%(bucket)s.${S3_REGION}.amazonaws.com' --ssl -m application/json put packages.json s3://${S3_BUCKET}/${S3_PREFIX}packages.json"
 if $upload; then
 	echo "-----> Uploading packages.json..." >&2
 	eval "$cmd 1>&2"

--- a/support/build/_util/remove.sh
+++ b/support/build/_util/remove.sh
@@ -148,7 +148,7 @@ for manifest in "$manifests_tmp/"*".composer.json"; do
 		echo "  - WARNING: not removing '$filename' (in manifest 'dist.url')!" >&2
 	fi
 	echo -n "  - removing manifest file '$(basename "$manifest")'... " >&2
-	out=$(s3cmd --host=${S3_REGION}.amazonaws.com --host-bucket="%(bucket)s.${S3_REGION}.amazonaws.com" rm --ssl "s3://${S3_BUCKET}/${S3_PREFIX}$(basename "$manifest")" 2>&1) || { echo -e "failed! Error:\n$out" >&2; exit 1; }
+	out=$(s3cmd --host=${S3_REGION}.amazonaws.com --host-bucket="%(bucket)s.${S3_REGION}.amazonaws.com" --ssl rm "s3://${S3_BUCKET}/${S3_PREFIX}$(basename "$manifest")" 2>&1) || { echo -e "failed! Error:\n$out" >&2; exit 1; }
 	rm $manifest
 	echo "done." >&2
 done
@@ -169,7 +169,7 @@ if [[ "${#remove_files[@]}" != "0" ]]; then
 	echo "Removing files queued for deletion from bucket:" >&2
 	for filename in "${remove_files[@]}"; do
 		echo -n "  - removing '$filename'... " >&2
-		out=$(s3cmd --host=${S3_REGION}.amazonaws.com --host-bucket="%(bucket)s.${S3_REGION}.amazonaws.com" rm --ssl s3://${S3_BUCKET}/${S3_PREFIX}${filename} 2>&1) && echo "done." >&2 || echo -e "failed! Error:\n$out" >&2
+		out=$(s3cmd --host=${S3_REGION}.amazonaws.com --host-bucket="%(bucket)s.${S3_REGION}.amazonaws.com" --ssl rm s3://${S3_BUCKET}/${S3_PREFIX}${filename} 2>&1) && echo "done." >&2 || echo -e "failed! Error:\n$out" >&2
 	done
 	echo "" >&2
 fi

--- a/support/build/_util/sync.sh
+++ b/support/build/_util/sync.sh
@@ -294,7 +294,7 @@ for manifest in $remove_manifests; do
 		echo "  - WARNING: not removing '$filename' (in manifest 'dist.url')!" >&2
 	fi
 	echo -n "  - removing manifest file '$manifest'... " >&2
-	out=$(s3cmd ${s3cmd_dst_host_options} rm --ssl s3://${dst_bucket}/${dst_prefix}${manifest} 2>&1) || { echo -e "failed! Error:\n$out" >&2; exit 1; }
+	out=$(s3cmd ${s3cmd_dst_host_options} --ssl rm s3://${dst_bucket}/${dst_prefix}${manifest} 2>&1) || { echo -e "failed! Error:\n$out" >&2; exit 1; }
 	rm ${dst_tmp}/${manifest}
 	echo "done." >&2
 done
@@ -311,7 +311,7 @@ if [[ "${#remove_files[@]}" != "0" ]]; then
 	echo "Removing files queued for deletion from destination:" >&2
 	for filename in "${remove_files[@]}"; do
 		echo -n "  - removing '$filename'... " >&2
-		out=$(s3cmd ${s3cmd_dst_host_options} rm --ssl s3://${dst_bucket}/${dst_prefix}${filename} 2>&1) && echo "done." >&2 || echo -e "failed! Error:\n$out" >&2
+		out=$(s3cmd ${s3cmd_dst_host_options} --ssl rm s3://${dst_bucket}/${dst_prefix}${filename} 2>&1) && echo "done." >&2 || echo -e "failed! Error:\n$out" >&2
 	done
 	echo "" >&2
 fi

--- a/support/build/_util/sync.sh
+++ b/support/build/_util/sync.sh
@@ -244,7 +244,7 @@ for manifest in $add_manifests ${update_manifests[@]:-}; do
 	then
 		# the dist URL in the source's manifest points to the source bucket, so we copy the file to the dest bucket
 		echo -n "  - copying '$filename'... " >&2
-		out=$(s3cmd ${s3cmd_cp_host_options} --ssl --acl-public cp s3://${src_bucket}/${src_prefix}${filename} s3://${dst_bucket}/${dst_prefix}${filename} 2>&1) || { echo -e "failed! Error:\n$out" >&2; exit 1; }
+		out=$(s3cmd ${s3cmd_cp_host_options} --ssl cp s3://${src_bucket}/${src_prefix}${filename} s3://${dst_bucket}/${dst_prefix}${filename} 2>&1) || { echo -e "failed! Error:\n$out" >&2; exit 1; }
 		copied_files+=("$filename")
 		echo "done." >&2
 	else
@@ -254,7 +254,7 @@ for manifest in $add_manifests ${update_manifests[@]:-}; do
 		cp ${src_tmp}/${manifest} ${dst_tmp}/${manifest}
 	fi
 	echo -n "  - copying manifest file '$manifest'... " >&2
-	out=$(s3cmd ${s3cmd_cp_host_options} --ssl --acl-public -m application/json put ${dst_tmp}/${manifest} s3://${dst_bucket}/${dst_prefix}${manifest} 2>&1) || { echo -e "failed! Error:\n$out" >&2; exit 1; }
+	out=$(s3cmd ${s3cmd_cp_host_options} --ssl -m application/json put ${dst_tmp}/${manifest} s3://${dst_bucket}/${dst_prefix}${manifest} 2>&1) || { echo -e "failed! Error:\n$out" >&2; exit 1; }
 	echo "done." >&2
 done
 


### PR DESCRIPTION
Three workflows, dispatched manually, for:
- building and deploying packages to the `dist-${STACK}-develop/` platform repository;
- removing obsolete (think point releases) packages from the `dist-${STACK}-develop/` platform repository
- syncing packages from the `dist-${STACK}-develop/` to the `dist-${STACK}-stable/` platform repository

GUS-W-12730826