### PR TITLE
Improve GHA build/sync/remove workflow names/outputs

### DIFF
--- a/.github/workflows/platform-build.yml
+++ b/.github/workflows/platform-build.yml
@@ -55,9 +55,11 @@ jobs:
         name: Expand list of given formulae
         run: |
           cd support/build
+          echo '## Formulae input for building' >> "$GITHUB_STEP_SUMMARY"
           echo -n "matrix=" >> "$GITHUB_OUTPUT"
           set -o pipefail
           shopt -s nullglob
+          ls -f ${{inputs.formulae}} | xargs -n 1 echo - >> "$GITHUB_STEP_SUMMARY"
           ls -f ${{inputs.formulae}} | jq -jcRn '[inputs|select(length>0)]' >> "$GITHUB_OUTPUT"
   docker-build:
     runs-on: ubuntu-22.04

--- a/.github/workflows/platform-build.yml
+++ b/.github/workflows/platform-build.yml
@@ -1,4 +1,5 @@
 name: Platform packages build and deploy to -develop/
+run-name: Build ${{ inputs.dry-run == true && 'w/o deploy' || '& deploy' }}${{ inputs.overwrite == true && '(+overwrite)' || '' }} to dist-${{inputs.stack}}-develop/ ${{ inputs.publish == false && 'w/o publishing packages into Composer platform repository' || '' }}
 
 on:
   workflow_dispatch:

--- a/.github/workflows/platform-build.yml
+++ b/.github/workflows/platform-build.yml
@@ -128,4 +128,13 @@ jobs:
       - name: Re-generate platform package repository
         run: docker run --rm --env-file=support/build/_docker/env.default heroku-php-build-${{inputs.stack}}:${{github.sha}} mkrepo.sh --upload
       - name: Dry-run sync.sh to show package changes available for syncing to production bucket
-        run: yes n 2>/dev/null | docker run --rm -i --env-file=support/build/_docker/env.default heroku-php-build-${{inputs.stack}}:${{github.sha}} sync.sh lang-php dist-${{inputs.stack}}-stable/
+        run: |
+          set -o pipefail
+          (yes n 2>/dev/null || true) | docker run --rm -i --env-file=support/build/_docker/env.default heroku-php-build-${{inputs.stack}}:${{github.sha}} sync.sh lang-php dist-${{inputs.stack}}-stable/ 2>&1 | tee sync.out
+      - name: Output job summary
+        run: |
+          echo '## Package changes available for syncing to production bucket' >> "$GITHUB_STEP_SUMMARY"
+          echo '**This is output from a dry-run**, no changes have been synced to production:' >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          sed -n '/The following packages will/,$p' sync.out >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/platform-remove.yml
+++ b/.github/workflows/platform-remove.yml
@@ -60,7 +60,20 @@ jobs:
           path: /tmp/docker-cache.tar.gz
       - name: List packages for removal using given input list
         if: ${{ inputs.dry-run == true }}
-        run: yes n 2>/dev/null | docker run --rm -i --env-file=support/build/_docker/env.default heroku-php-build-${{inputs.stack}}:${{github.sha}} remove.sh ${{inputs.manifests}}
+        run: |
+          set -f
+          set -o pipefail
+          (yes n 2>/dev/null || true) | docker run --rm -i --env-file=support/build/_docker/env.default heroku-php-build-${{inputs.stack}}:${{github.sha}} remove.sh ${{inputs.manifests}} 2>&1 | tee remove.out
       - name: Remove packages from repository
         if: ${{ inputs.dry-run == false }}
-        run: yes 2>/dev/null | docker run --rm -i --env-file=support/build/_docker/env.default heroku-php-build-${{inputs.stack}}:${{github.sha}} remove.sh ${{inputs.manifests}}
+        run: |
+          set -f
+          set -o pipefail
+          (yes 2>/dev/null || true) | docker run --rm -i --env-file=support/build/_docker/env.default heroku-php-build-${{inputs.stack}}:${{github.sha}} remove.sh ${{inputs.manifests}} 2>&1 | tee remove.out
+      - name: Output job summary
+        run: |
+          echo '## Packages${{ inputs.dry-run == true && ' which would be' }} removed from production bucket' >> "$GITHUB_STEP_SUMMARY"
+          echo "${{ inputs.dry-run == true && '**This is output from a dry-run**, no packages have been removed:' || '-n' }}" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          sed -n '/The following packages will/,$p' remove.out >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/platform-remove.yml
+++ b/.github/workflows/platform-remove.yml
@@ -33,6 +33,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Expand list of manifests to remove
+        run: |
+          echo '## Manifests input for removal' >> "$GITHUB_STEP_SUMMARY"
+          set -f
+          echo ${{inputs.manifests}} | xargs -n 1 echo - >> "$GITHUB_STEP_SUMMARY"
       - name: Restore cached Docker image
         id: restore-docker
         uses: actions/cache/restore@v3

--- a/.github/workflows/platform-remove.yml
+++ b/.github/workflows/platform-remove.yml
@@ -55,6 +55,7 @@ jobs:
         if: steps.restore-docker.outputs.cache-hit != 'true'
         run: docker save heroku-php-build-${{inputs.stack}}:${{github.sha}} | gzip -1 > /tmp/docker-cache.tar.gz
       - name: Cache built Docker image
+        if: steps.restore-docker.outputs.cache-hit != 'true'
         uses: actions/cache/save@v3
         with:
           key: ${{ steps.restore-docker.outputs.cache-primary-key }}

--- a/.github/workflows/platform-remove.yml
+++ b/.github/workflows/platform-remove.yml
@@ -1,4 +1,5 @@
 name: Platform packages removal from -develop/
+run-name: Removal${{ inputs.dry-run == true && ' dry-run' || '' }} from dist-${{inputs.stack}}-develop/
 
 on:
   workflow_dispatch:

--- a/.github/workflows/platform-sync.yml
+++ b/.github/workflows/platform-sync.yml
@@ -46,6 +46,7 @@ jobs:
         if: steps.restore-docker.outputs.cache-hit != 'true'
         run: docker save heroku-php-build-${{inputs.stack}}:${{github.sha}} | gzip -1 > /tmp/docker-cache.tar.gz
       - name: Cache built Docker image
+        if: steps.restore-docker.outputs.cache-hit != 'true'
         uses: actions/cache/save@v3
         with:
           key: ${{ steps.restore-docker.outputs.cache-primary-key }}

--- a/.github/workflows/platform-sync.yml
+++ b/.github/workflows/platform-sync.yml
@@ -51,7 +51,18 @@ jobs:
           path: /tmp/docker-cache.tar.gz
       - name: Dry-run sync.sh to show package changes available for syncing to production bucket
         if: ${{ inputs.dry-run == true }}
-        run: yes n 2>/dev/null | docker run --rm -i --env-file=support/build/_docker/env.default heroku-php-build-${{inputs.stack}}:${{github.sha}} sync.sh lang-php dist-${{inputs.stack}}-stable/
+        run: |
+          set -o pipefail
+          (yes n 2>/dev/null || true) | docker run --rm -i --env-file=support/build/_docker/env.default heroku-php-build-${{inputs.stack}}:${{github.sha}} sync.sh lang-php dist-${{inputs.stack}}-stable/ 2>&1 | tee sync.out
       - name: Sync changed packages to production bucket
         if: ${{ inputs.dry-run == false }}
-        run: yes 2>/dev/null | docker run --rm -i --env-file=support/build/_docker/env.default heroku-php-build-${{inputs.stack}}:${{github.sha}} sync.sh lang-php dist-${{inputs.stack}}-stable/
+        run: |
+          set -o pipefail
+          (yes 2>/dev/null || true) | docker run --rm -i --env-file=support/build/_docker/env.default heroku-php-build-${{inputs.stack}}:${{github.sha}} sync.sh lang-php dist-${{inputs.stack}}-stable/ 2>&1 | tee sync.out
+      - name: Output job summary
+        run: |
+          echo '## Package changes ${{ inputs.dry-run == true && 'available for syncing' || 'synced' }} to production bucket' >> "$GITHUB_STEP_SUMMARY"
+          echo "${{ inputs.dry-run == true && '**This is output from a dry-run**, no changes have been synced to production:' || '-n' }}" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          sed -n '/The following packages will/,$p' sync.out >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/platform-sync.yml
+++ b/.github/workflows/platform-sync.yml
@@ -1,4 +1,5 @@
 name: Platform packages sync from -develop/ to -stable/
+run-name: Sync${{ inputs.dry-run == true && ' dry-run' || '' }} from dist-${{inputs.stack}}-develop/ to dist-${{inputs.stack}}-stable/
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Workflow runs have the same name regardless of stack, so it's hard to figure out what's what:

<img width="942" alt="Screenshot 2023-03-29 at 20 42 37" src="https://user-images.githubusercontent.com/27900/228636982-a96b2752-d228-464d-91e4-393b1dd168b4.png">

The stack, and some other parameters (e.g. is it a dry run, overwrite, etc) are now in the run title for all workflows:

<img width="956" alt="Screenshot 2023-03-29 at 20 44 00" src="https://user-images.githubusercontent.com/27900/228637485-87c1221c-fa74-4bcc-a2bd-0d0bebc632b7.png">

---

It's also not possible to see inputs for a run in the GitHub UI, so it's hard to tell what the parameters were for building (list of formulae) and removal (list of manifests).

It's also necessary to dig into certain step outputs to see the ultimate result of a deployed batch of packages (what's ready for syncing to production), a sync (what got synced), or a removal (what got removed).

This change adds these bits of information to the job summaries:

<img width="1280" alt="Screenshot 2023-03-29 at 20 46 55" src="https://user-images.githubusercontent.com/27900/228638638-77a9d28c-3ee8-415f-83f4-0e5bb8302339.png">

<img width="1280" alt="Screenshot 2023-03-29 at 20 49 39" src="https://user-images.githubusercontent.com/27900/228638647-7f5e80cb-d840-4637-9adc-9277262424aa.png">

<img width="1280" alt="Screenshot 2023-03-29 at 20 47 56" src="https://user-images.githubusercontent.com/27900/228638650-b2c84de6-ec65-482e-bf41-1abd026c3dce.png">

(The warning about the failing cache save is also addressed by this PR).

GUS-W-12730826