### PR TITLE
Update composer installer signature checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # heroku-buildpack-php CHANGELOG
 
+## v236 (2023-07-??)
+
+### FIX
+
+- PHP binary build formula uses outdated signature for Composer installer (#641) [David Zuelke]
+
 ## v235 (2023-06-09)
 
 ### ADD

--- a/support/build/composer
+++ b/support/build/composer
@@ -19,10 +19,8 @@ echo "-----> Bundling Composer (${dep_version})..."
 
 export PATH=${OUT_PREFIX}/bin:$PATH
 
-EXPECTED_SIGNATURE=$(wget -q -O - https://composer.github.io/installer.sig)
-php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-ACTUAL_SIGNATURE=$(php -r "echo hash_file('SHA384', 'composer-setup.php');")
-if [ "$EXPECTED_SIGNATURE" != "$ACTUAL_SIGNATURE" ]; then
+curl -sL https://getcomposer.org/installer > composer-setup.php
+if ! curl -sL https://composer.github.io/installer.sha384sum | sha384sum --quiet -c -; then
 	>&2 echo 'ERROR: Invalid installer signature'
 	rm composer-setup.php
 	exit 1

--- a/support/build/php
+++ b/support/build/php
@@ -196,8 +196,13 @@ fi
 EOF
 
 # we need composer to extract all extensions with versions
-php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-php -r "if (hash_file('sha384', 'composer-setup.php') === '55ce33d7678c5a611085589f1f3ddf8b3c52d662cd01d4ba75c0ee0459970c2200a51f492d557530c71c15d8dba01eae') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
+curl -sL https://getcomposer.org/installer > composer-setup.php
+if ! curl -sL https://composer.github.io/installer.sha384sum | sha384sum --quiet -c -; then
+	>&2 echo 'ERROR: Invalid installer signature'
+	rm composer-setup.php
+	exit 1
+fi
+
 php composer-setup.php --2.2 # https://github.com/composer/composer/issues/11046
 
 # first, read all platform packages (just "ext-" and "php-") that are already there; could be statically built, or enabled through one of the INIs loaded


### PR DESCRIPTION
Formula for php still had it hard-coded.

Now use purely shell based signature checks in both php and composer formulae.

Fixes #641

GUS-W-13658260