### PR TITLE
Fix herokuapp.com URL usage in tests

### DIFF
--- a/test/spec/spec_helper.rb
+++ b/test/spec/spec_helper.rb
@@ -38,7 +38,8 @@ def successful_body(app, options = {})
 	retry_limit = options[:retry_limit] || 5
 	retry_interval = options[:retry_interval] || 2
 	path = options[:path] ? "/#{options[:path]}" : ''
-	Excon.get("http://#{app.name}.herokuapp.com#{path}", :idempotent => true, :expects => 200, :retry_limit => retry_limit, :retry_interval => retry_interval).body
+	web_url = app.platform_api.app.info(app.name).fetch("web_url")
+	Excon.get("#{web_url}#{path}", :idempotent => true, :expects => 200, :retry_limit => retry_limit, :retry_interval => retry_interval).body
 end
 
 def expect_exit(expect: :to, operator: :eq, code: 0)


### PR DESCRIPTION
Newly created apps now use a hash in the hostname, see https://devcenter.heroku.com/changelog-items/2640

This change fixes the successful_body helper to fetch the right URL via the API.

See e.g. https://github.com/heroku/heroku-buildpack-nodejs/pull/1110 as well.