### PR TITLE
Drop lang-common S3 bucket dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # heroku-buildpack-php CHANGELOG
 
+## v238 (2023-08-??)
+
+### CHG
+
+- Import telemetry helper shell functions previously vendored from 'lang-common' S3 bucket [David Zuelke]
+
 ## v237 (2023-08-04)
 
 ### ADD

--- a/bin/compile
+++ b/bin/compile
@@ -26,20 +26,6 @@ source $bp_dir/bin/util/common.sh
 # we do not 'set -o errtrace', because that would cause subshell failures to fire the trap twice, e.g. with someval=$(func_that_fails)
 trap 'err_trap' ERR
 
-# stdlib
-# download to a file first, as the function restarts the entire download on code 18 connection reset (not all servers support -C)
-curl_retry_on_18 --retry-connrefused --retry 3 --connect-timeout 5 --fail --silent --location -o $bp_dir/bin/util/stdlib.sh https://lang-common.s3.us-east-1.amazonaws.com/buildpack-stdlib/v8/stdlib.sh || {
-	error <<-EOF
-		Failed to download standard library for bootstrapping!
-		
-		This is most likely a temporary internal error. If the problem
-		persists, make sure that you are not running a custom or forked
-		version of the Heroku PHP buildpack which may need updating.
-	EOF
-}
-source $bp_dir/bin/util/stdlib.sh
-rm $bp_dir/bin/util/stdlib.sh
-
 # failure counting
 source $bp_dir/bin/util/failures.sh
 

--- a/bin/util/common.sh
+++ b/bin/util/common.sh
@@ -144,3 +144,52 @@ err_trap() {
 		)
 	EOF
 }
+
+# Logging
+# -------
+
+# These functions expect BPLOG_PREFIX and BUILDPACK_LOG_FILE to be defined (BUILDPACK_LOG_FILE can point to /dev/null if not provided by the buildpack).
+# Example: BUILDPACK_LOG_FILE=${BUILDPACK_LOG_FILE:-/dev/null}; BPLOG_PREFIX="buildpack.go"
+
+# Returns now, in milleseconds. Useful for logging.
+# Example: $ let start=$(nowms); sleep 30; mtime "glide.install.time" "${start}"
+nowms() {
+	date +%s%3N
+}
+
+# Measures time elapsed for a specific build step.
+# Usage: $ let start=$(nowms); mtime "glide.install.time" "${start}"
+# https://github.com/heroku/engineering-docs/blob/master/guides/logs-as-data.md#distributions-measure
+mtime() {
+	local key="${BPLOG_PREFIX}.${1}"
+	local start="${2}"
+	local end="${3:-$(nowms)}"
+	echo "${key} ${start} ${end}" | awk '{ printf "measure#%s=%.3f\n", $1, ($3 - $2)/1000 }' >> "${BUILDPACK_LOG_FILE}"
+}
+
+# Logs a count for a specific built step.
+# Usage: $ mcount "tool.govendor"
+# https://github.com/heroku/engineering-docs/blob/master/guides/logs-as-data.md#counting-count
+mcount() {
+	local k="${BPLOG_PREFIX}.${1}"
+	local v="${2:-1}"
+	echo "count#${k}=${v}" >> "${BUILDPACK_LOG_FILE}"
+}
+
+# Logs a measure for a specific build step.
+# Usage: $ mmeasure "tool.installed_dependencies" 42
+# https://github.com/heroku/engineering-docs/blob/master/guides/logs-as-data.md#distributions-measure
+mmeasure() {
+	local k="${BPLOG_PREFIX}.${1}"
+	local v="${2}"
+	echo "measure#${k}=${v}" >> "${BUILDPACK_LOG_FILE}"
+}
+
+# Logs a unuique measurement build step.
+# Usage: $ munique "versions.count" 2.7.13
+# https://github.com/heroku/engineering-docs/blob/master/guides/logs-as-data.md#uniques-unique
+munique() {
+	local k="${BPLOG_PREFIX}.${1}"
+	local v="${2}"
+	echo "unique#${k}=${v}" >> "${BUILDPACK_LOG_FILE}"
+}


### PR DESCRIPTION
This imports the relevant (to this buildpack) telemetry helper functions from https://lang-common.s3.us-east-1.amazonaws.com/buildpack-stdlib/v8/stdlib.sh

GUS-W-13958512