### PR TITLE
Exclude `support/{build,devcenter}/` from the packaged buildpack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # heroku-buildpack-php CHANGELOG
 
+## Unreleased
+
+### CHG
+
+- Exclude `support/{build,devcenter}/` from the packaged buildpack [Ed Morley]
+
 ## v239 (2023-09-30)
 
 ### ADD

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -6,6 +6,8 @@ name = "PHP"
 		".github/",
 		".gitignore",
 		".rspec_parallel",
+		"support/build/",
+		"support/devcenter/",
 		"test/",
 		"Gemfile",
 		"Gemfile.lock",


### PR DESCRIPTION
Since these directories are not needed at build time, but currently account for two thirds of the size of the packaged buildpack.