### PR TITLE
Use the new "Prepare release" GitHub Actions workflow

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,12 @@
+name: Prepare Release
+
+on:
+  workflow_dispatch:
+
+# Disable all GITHUB_TOKEN permissions, since the GitHub App token is used instead.
+permissions: {}
+
+jobs:
+  prepare-release:
+    uses: heroku/languages-github-actions/.github/workflows/_classic-buildpack-prepare-release.yml@latest
+    secrets: inherit


### PR DESCRIPTION
We now have a new reusable GitHub Actions workflow for preparing a new classic buildpack release:
https://github.com/heroku/languages-github-actions/blob/main/.github/workflows/_classic-buildpack-prepare-release.yml

This workflow works similarly to the CNB prepare release workflow, except it does not need any version bump input, since we only ever increment classic buildpack versions by one.

Should any custom file changes be required as part of the PHP classic buildpack release process in the future, a bash command/commands can be passed via the workflow's `custom_update_command` option.

This PR also depends upon #682 landing first, so that the changelog is compatible with the workflow's version replacement regexes.

GUS-W-14905318.