### PR TITLE
Fix bogus suffix warnings in autotune.php

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### FIX
+
+- `WEB_CONCURRENCY` auto-tuning may warn about an invalid suffix for certain available memory values [David Zuelke]
 
 ## [v245] - 2024-02-09
 

--- a/bin/util/autotune.php
+++ b/bin/util/autotune.php
@@ -11,9 +11,10 @@ function stringtobytes($amount) {
 		case 'k':
 			$amount = (int)$amount * 1024;
 			break;
-		case !is_numeric($suffix):
-			fprintf(STDERR, "WARNING: ignoring invalid suffix '%s' in 'memory_limit' value '%s'\n", $suffix, $amount);
 		default:
+			if(!is_numeric($suffix)) {
+				fprintf(STDERR, "WARNING: ignoring invalid suffix '%s' in 'memory_limit' value '%s'\n", $suffix, $amount);
+			}
 			$amount = (int)$amount;
 	}
 	return $amount;


### PR DESCRIPTION
If the `! is_numeric()` case statement evaluates to `false`, and the suffix is a `0` (e.g. because the input value is "2684354560" a.k.a. 2.5 GiB), it matches, and prints the warning.

This is not how case statements work (they simply weak-comparison match the switch value against the case expression). The check was supposed to be in the default block all along.