### PR TITLE
Dev Center Changelog generator based on platform package sync

### DIFF
--- a/.github/workflows/platform-sync.yml
+++ b/.github/workflows/platform-sync.yml
@@ -98,13 +98,18 @@ jobs:
           # yes gets "n" to print for dry-runs so the sync aborts
           # errors are redirected to /dev/null, and we || true, to suppress SIGPIPE errors from 'docker run' exiting eventually
           # we need -i for Docker to accept input on stdin, but must not use -t for the pipeline to work
-          (yes "${{ inputs.dry-run == true && 'n' || 'y' }}" 2>/dev/null || true) | docker run --rm -i --env-file=support/build/_docker/env.default heroku-php-build-${{matrix.stack}}:${{github.sha}} sync.sh lang-php dist-${{matrix.stack}}-stable/ 2>&1 | tee sync.out
+          (yes "${{ inputs.dry-run == true && 'n' || 'y' }}" 2>/dev/null || true) | docker run --rm -i --env-file=support/build/_docker/env.default heroku-php-build-${{matrix.stack}}:${{github.sha}} sync.sh lang-php dist-${{matrix.stack}}-stable/ 2>&1 | tee sync-${{matrix.stack}}.log
+      - name: Upload sync log as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: synclog-${{matrix.stack}}
+          path: sync-${{matrix.stack}}.log
       - name: Output job summary
         run: |
           echo '## Package changes ${{ inputs.dry-run == true && 'available for syncing' || 'synced' }} to ${{matrix.stack}} production bucket' >> "$GITHUB_STEP_SUMMARY"
           echo "${{ inputs.dry-run == true && '**This is output from a dry-run**, no changes have been synced to production:' || '-n' }}" >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
-          sed -n '/The following packages will/,$p' sync.out >> "$GITHUB_STEP_SUMMARY"
+          sed -n '/The following packages will/,$p' sync-${{matrix.stack}}.log >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
   devcenter-generate:
     needs: sync
@@ -226,4 +231,45 @@ jobs:
           # convert back to the original CRLF if dos2unix ran in an earlier step (have_crlf.txt will be empty if not, and xargs will not run due to -r)
           cat have_crlf.txt | xargs -r0 unix2dos
           cat php-support.md >> "$GITHUB_STEP_SUMMARY"
+          echo '``````' >> "$GITHUB_STEP_SUMMARY" # six instead of three backticks because our output is likely to also contain series of backticks
+  changelog-generate:
+    needs: sync
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install PHP and Composer
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.2"
+          tools: "composer:2.6"
+      - name: Install Dev Center generator dependencies
+        run: |
+          composer install -d support/devcenter/
+      - name: Download all sync log artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: synclogs
+          pattern: synclog-*
+          merge-multiple: true
+      - name: Generate Changelog markdown
+        run: |
+          set -o pipefail
+          # concatenate all sync logs and feed them to changelog.php
+          # immediately split changelog title and body (separated by a "----" line) for easier copy/paste
+          # this also lets us detect if there even is anything to output in the next step (there won't be a changelog-01.md if the changelog is empty)
+          # the '{*}' pattern works around a bug in older coreutils csplits: https://github.com/coreutils/coreutils/commit/7cf45f4f6a093a927d3139c87f52999dd2c750ec
+          cat synclogs/sync-*.log | support/devcenter/changelog.php | csplit -s -z -f 'changelog-' -b '%02d.md' --suppress-matched - '/^----$/' '{*}'
+      - name: Output Changelog markdown
+        if: ${{ hashFiles('changelog-01.md') != '' }}
+        run: |
+          shopt -s extglob
+          echo '## Markdown for package Changelog entry' >> "$GITHUB_STEP_SUMMARY"
+          echo '### Title' >> "$GITHUB_STEP_SUMMARY"
+          echo '``````markdown' >> "$GITHUB_STEP_SUMMARY" # six instead of three backticks because our output is likely to also contain series of backticks
+          cat changelog-00.md >> "$GITHUB_STEP_SUMMARY"
+          echo '``````' >> "$GITHUB_STEP_SUMMARY" # six instead of three backticks because our output is likely to also contain series of backticks
+          echo '### Content' >> "$GITHUB_STEP_SUMMARY"
+          echo '``````markdown' >> "$GITHUB_STEP_SUMMARY" # six instead of three backticks because our output is likely to also contain series of backticks
+          cat changelog-!(00).md >> "$GITHUB_STEP_SUMMARY"
           echo '``````' >> "$GITHUB_STEP_SUMMARY" # six instead of three backticks because our output is likely to also contain series of backticks

--- a/support/devcenter/README.md
+++ b/support/devcenter/README.md
@@ -1,6 +1,8 @@
-# Dev Center PHP Support Article Generator
+# Dev Center PHP Support Article and Changelog Generators
 
-This `generate.php` tool will, given platform repository URLs as arguments, generate:
+## PHP Support Generator
+
+The `generate.php` tool will, given platform repository URLs as arguments, generate:
 
 - the list of PHP runtimes, per stack
 - the list of built-in extensions, per PHP runtime series
@@ -16,7 +18,7 @@ The third-party extensions list will list major version series (e.g. 2.x and 3.x
 
 For the "Composers" and web servers, only the latest release of each major version series is listed per stack.
 
-## Invocation
+### Invocation
 
 First, `composer install` the dependencies.
 
@@ -34,6 +36,22 @@ $ ./generate.php --third-party-extensions https://lang-php.s3.us-east-1.amazonaw
 
 You'd usually pipe the output into e.g. `pbcopy` and then update the Dev Center article.
 
-## Updating stacks and versions
+### Updating stacks and versions
 
 To add a new stack or PHP runtime series, add them to the respective lists at the top of `generate.php`. Stacks or series that are no longer in use will not be output, but it's still a good idea to periodically remove EOL stacks or series from the list.
+
+## Changelog Generator
+
+The `changelog.php` tool expects the output from one or more `sync.sh` runs as input on STDIN.
+
+It will then generate a list of new PHP releases, extensions, Composer versions, webservers, and other packages.
+
+### Invocation
+
+First, `composer install` the dependencies.
+
+Assuming you ran a `sync.sh` job for two stacks (say, heroku-20 and heroku-22) and `tee`d the outputs into `sync-heroku-{20,22}.log`:
+
+```ShellSession
+cat `sync-heroku-{20,22}.log | ./changelog.php`
+```

--- a/support/devcenter/changelog.php
+++ b/support/devcenter/changelog.php
@@ -1,0 +1,68 @@
+#!/usr/bin/env php
+<?php
+
+require('vendor/autoload.php');
+
+$sync = file_get_contents("php://stdin");
+
+// first, split the output from sync.sh by its section headers
+// we want the "kind" of operation to be captured as well, since we only care about additions
+$sections = "(IGNORED|ADDED|UPDATED|REMOVED)";
+$splits = preg_split("/^The following packages will be $sections/m", $sync, 0, PREG_SPLIT_DELIM_CAPTURE);
+
+$package_pattern = "/^\s*-\s+(?P<name>(?P<ext>ext-)?[^-]+)-(?P<version>\d+(\.\d+)+)(?(2)_php-(?P<series>\d+\.\d))\s*$/m";
+
+// the result from the splitting is a list of section outputs and captured delimiters
+// think, roughly: ["maybe some prologue text", "IGNORED", "- (none)", "ADDED", "Blah Blah\n- php-8.9.10", "UPDATED", "- (none)", "REMOVED", "- (none)"]
+// we now iterate over these, remember the section header we see, and get info out of all "ADDED" blocks we encounter (might be several!)
+$additions = [];
+$section = null;
+
+foreach($splits as $split) {
+	if(preg_match("/^$sections$/", $split, $section_match)) {
+		$section = $section_match[1];
+		continue;
+	}
+	if($section == "ADDED") {
+		preg_match_all($package_pattern, $split, $packages, PREG_SET_ORDER);
+		foreach($packages as $package) {
+			$additions[] = [
+				"name" => $package["name"],
+				"version" => $package["version"],
+				"is_ext" => (bool)$package["ext"],
+				"series" => match($package["name"]) {
+					"php" => preg_filter("/^(\d+)\..+/", '$1', $package["version"]),
+					"nginx" => preg_filter("/^(\d+\.\d+)\..+$/", '$1', $package["version"]),
+					default => $package["series"] ?? null,
+				},
+			];
+		}
+	}
+}
+
+// naive deduplication, we don't care about PHP version ranges for extensions for now
+$additions = array_combine(array_map(fn($package) => $package["name"]."-".$package["version"], $additions), $additions);
+
+$latest_version = fn($carry, $package) => version_compare($carry["version"] ?? 0, $package["version"], ">") ? $carry : $package;
+
+$data = [
+	"phps" => array_filter($additions, fn($package) => $package["name"] == "php"),
+	"extensions" => array_filter($additions, fn($package) => $package["is_ext"]),
+	"composers" => array_filter($additions, fn($package) => $package["name"] == "composer"),
+	"apache" => array_reduce(
+		array_filter($additions, fn($package) => $package["name"] == "apache"),
+		$latest_version
+	),
+	"nginx" => array_reduce(
+		array_filter($additions, fn($package) => $package["name"] == "nginx"),
+		$latest_version
+	),
+	"libraries" => array_filter($additions, fn($package) => strpos($package["name"], "lib") === 0),
+	"blackfire" => array_reduce( //
+		array_filter($additions, fn($package) => $package["name"] == "blackfire"),
+		$latest_version
+	),
+];
+
+$twig = new Twig\Environment(new \Twig\Loader\FilesystemLoader(__DIR__));
+echo $twig->render("changelog.twig", $data);

--- a/support/devcenter/changelog.twig
+++ b/support/devcenter/changelog.twig
@@ -1,0 +1,47 @@
+{{"now"|date("F Y", "UTC")}} PHP Updates
+----
+{% if phps %}
+The following new [PHP runtime versions](https://devcenter.heroku.com/articles/php-support#available-versions) are now available:
+
+{% for php in phps %}
+- [PHP {{php.version}}](https://www.php.net/ChangeLog-{{php.series}}.php#{{php.version}})
+{% endfor %}
+
+{% endif -%}
+
+{% if extensions %}
+The following [PHP extensions](https://devcenter.heroku.com/articles/php-support#extensions) have been added or updated:
+
+{% for extension in extensions %}
+- `{{extension.name}}` {{extension.version}}
+{% endfor %}
+
+{% endif -%}
+
+{% if composers %}
+The following new [Composer versions](https://devcenter.heroku.com/articles/php-support#available-composer-versions) are now available [for use during builds](https://devcenter.heroku.com/articles/php-support#installation-of-dependencies):
+
+{% for composer in composers %}
+- [Composer {{composer.version}}](https://getcomposer.org/changelog/{{composer.version}})
+{% endfor %}
+
+{% endif -%}
+
+{% if apache %}
+The Apache HTTPD [web server](https://devcenter.heroku.com/articles/php-support#web-servers) has been updated to version [{{apache.version}}](https://downloads.apache.org/httpd/CHANGES_{{apache.version}}).
+
+{% endif -%}
+
+{% if nginx %}
+The Nginx [web server](https://devcenter.heroku.com/articles/php-support#web-servers) has been updated to version [{{nginx.version}}](https://nginx.org/en/CHANGES-{{nginx.series}}).
+
+{% endif -%}
+
+{% if blackfire %}
+The `blackfire` CLI agent program used by `ext-blackfire` has been updated to version {{blackfire.version}}.
+
+{% endif -%}
+
+{% for library in libraries %}
+The `{{library.name}}` library has been updated to version {{library.version}}.
+{% endfor %}

--- a/test/fixtures/devcenter/changelog/changelog-nothingnew.md
+++ b/test/fixtures/devcenter/changelog/changelog-nothingnew.md
@@ -1,0 +1,2 @@
+%B %Y PHP Updates
+----

--- a/test/fixtures/devcenter/changelog/changelog.md
+++ b/test/fixtures/devcenter/changelog/changelog.md
@@ -1,0 +1,27 @@
+%B %Y PHP Updates
+----
+The following new [PHP runtime versions](https://devcenter.heroku.com/articles/php-support#available-versions) are now available:
+
+- [PHP 8.2.15](https://www.php.net/ChangeLog-8.php#8.2.15)
+- [PHP 8.3.2](https://www.php.net/ChangeLog-8.php#8.3.2)
+
+The following [PHP extensions](https://devcenter.heroku.com/articles/php-support#extensions) have been added or updated:
+
+- `ext-amqp` 1.9.99
+- `ext-amqp` 2.1.2
+- `ext-blackfire` 1.92.8
+- `ext-event` 3.1.1
+- `ext-phalcon` 5.6.0
+
+The following new [Composer versions](https://devcenter.heroku.com/articles/php-support#available-composer-versions) are now available [for use during builds](https://devcenter.heroku.com/articles/php-support#installation-of-dependencies):
+
+- [Composer 2.8.0](https://getcomposer.org/changelog/2.8.0)
+
+The Apache HTTPD [web server](https://devcenter.heroku.com/articles/php-support#web-servers) has been updated to version [2.4.4](https://downloads.apache.org/httpd/CHANGES_2.4.4).
+
+The Nginx [web server](https://devcenter.heroku.com/articles/php-support#web-servers) has been updated to version [2.9.0](https://nginx.org/en/CHANGES-2.9).
+
+The `blackfire` CLI agent program used by `ext-blackfire` has been updated to version 2.24.4.
+
+The `libcassandra` library has been updated to version 1.2.3.
+The `librdkafka` library has been updated to version 1.9.1.

--- a/test/fixtures/devcenter/changelog/sync-nothingnew.log
+++ b/test/fixtures/devcenter/changelog/sync-nothingnew.log
@@ -1,0 +1,61 @@
+The following packages will be IGNORED:
+  - (none)
+
+The following packages will be ADDED
+ from s3://lang-php/dist-heroku-20-develop/
+   to s3://lang-php/dist-heroku-20-stable/:
+  - (none)
+
+The following packages will be UPDATED (source manifest is newer)
+ from s3://lang-php/dist-heroku-20-develop/
+   to s3://lang-php/dist-heroku-20-stable/:
+  - php-8.2.15
+  - php-8.3.2
+
+The following packages will be REMOVED
+ from s3://lang-php/dist-heroku-20-stable/:
+  - (none)
+
+
+Copying php-8.2.15:
+  - copying 'php-8.2.15.tar.gz'... done.
+  - copying manifest file 'php-8.2.15.composer.json'... done.
+Copying php-8.3.2:
+  - copying 'php-8.3.2.tar.gz'... done.
+  - copying manifest file 'php-8.3.2.composer.json'... done.
+
+Generating and uploading packages.json... done!
+
+
+Sync complete.
+
+The following packages will be IGNORED:
+  - (none)
+
+The following packages will be ADDED
+ from s3://lang-php/dist-heroku-20-develop/
+   to s3://lang-php/dist-heroku-20-stable/:
+  - (none)
+
+The following packages will be UPDATED (source manifest is newer)
+ from s3://lang-php/dist-heroku-20-develop/
+   to s3://lang-php/dist-heroku-20-stable/:
+  - php-8.2.15
+  - php-8.3.2
+
+The following packages will be REMOVED
+ from s3://lang-php/dist-heroku-20-stable/:
+  - (none)
+
+
+Copying php-8.2.15:
+  - copying 'php-8.2.15.tar.gz'... done.
+  - copying manifest file 'php-8.2.15.composer.json'... done.
+Copying php-8.3.2:
+  - copying 'php-8.3.2.tar.gz'... done.
+  - copying manifest file 'php-8.3.2.composer.json'... done.
+
+Generating and uploading packages.json... done!
+
+
+Sync complete.

--- a/test/fixtures/devcenter/changelog/sync.log
+++ b/test/fixtures/devcenter/changelog/sync.log
@@ -1,0 +1,206 @@
+The following packages will be IGNORED:
+  - (none)
+
+The following packages will be ADDED
+ from s3://lang-php/dist-heroku-20-develop/
+   to s3://lang-php/dist-heroku-20-stable/:
+  - blackfire-2.24.4
+  - ext-amqp-1.9.99_php-8.0
+  - ext-amqp-2.1.2_php-8.0
+  - ext-amqp-2.1.2_php-8.1
+  - ext-amqp-2.1.2_php-8.2
+  - ext-amqp-2.1.2_php-8.3
+  - ext-blackfire-1.92.8_php-7.3
+  - ext-blackfire-1.92.8_php-7.4
+  - ext-blackfire-1.92.8_php-8.0
+  - ext-blackfire-1.92.8_php-8.1
+  - ext-blackfire-1.92.8_php-8.2
+  - ext-blackfire-1.92.8_php-8.3
+  - ext-event-3.1.1_php-7.3
+  - ext-event-3.1.1_php-7.4
+  - ext-event-3.1.1_php-8.0
+  - ext-event-3.1.1_php-8.1
+  - ext-event-3.1.1_php-8.2
+  - ext-event-3.1.1_php-8.3
+  - ext-phalcon-5.6.0_php-8.0
+  - ext-phalcon-5.6.0_php-8.1
+  - ext-phalcon-5.6.0_php-8.2
+  - ext-phalcon-5.6.0_php-8.3
+  - php-8.2.15
+  - php-8.3.2
+  - pkg-php-min-8.1.27
+  - libcassandra-1.2.3
+
+The following packages will be UPDATED (source manifest is newer)
+ from s3://lang-php/dist-heroku-20-develop/
+   to s3://lang-php/dist-heroku-20-stable/:
+  - (none)
+
+The following packages will be REMOVED
+ from s3://lang-php/dist-heroku-20-stable/:
+  - (none)
+
+
+Copying blackfire-2.24.4:
+  - copying 'blackfire-2.24.4.tar.gz'... done.
+  - copying manifest file 'blackfire-2.24.4.composer.json'... done.
+Copying ext-amqp-2.1.2_php-8.0:
+  - copying 'extensions/no-debug-non-zts-20200930/amqp-2.1.2.tar.gz'... done.
+  - copying manifest file 'ext-amqp-2.1.2_php-8.0.composer.json'... done.
+Copying ext-amqp-2.1.2_php-8.1:
+  - copying 'extensions/no-debug-non-zts-20210902/amqp-2.1.2.tar.gz'... done.
+  - copying manifest file 'ext-amqp-2.1.2_php-8.1.composer.json'... done.
+Copying ext-amqp-2.1.2_php-8.2:
+  - copying 'extensions/no-debug-non-zts-20220829/amqp-2.1.2.tar.gz'... done.
+  - copying manifest file 'ext-amqp-2.1.2_php-8.2.composer.json'... done.
+Copying ext-amqp-2.1.2_php-8.3:
+  - copying 'extensions/no-debug-non-zts-20230831/amqp-2.1.2.tar.gz'... done.
+  - copying manifest file 'ext-amqp-2.1.2_php-8.3.composer.json'... done.
+Copying ext-blackfire-1.92.8_php-7.3:
+  - copying 'extensions/no-debug-non-zts-20180731/blackfire-1.92.8.tar.gz'... done.
+  - copying manifest file 'ext-blackfire-1.92.8_php-7.3.composer.json'... done.
+Copying ext-blackfire-1.92.8_php-7.4:
+  - copying 'extensions/no-debug-non-zts-20190902/blackfire-1.92.8.tar.gz'... done.
+  - copying manifest file 'ext-blackfire-1.92.8_php-7.4.composer.json'... done.
+Copying ext-blackfire-1.92.8_php-8.0:
+  - copying 'extensions/no-debug-non-zts-20200930/blackfire-1.92.8.tar.gz'... done.
+  - copying manifest file 'ext-blackfire-1.92.8_php-8.0.composer.json'... done.
+Copying ext-blackfire-1.92.8_php-8.1:
+  - copying 'extensions/no-debug-non-zts-20210902/blackfire-1.92.8.tar.gz'... done.
+  - copying manifest file 'ext-blackfire-1.92.8_php-8.1.composer.json'... done.
+Copying ext-blackfire-1.92.8_php-8.2:
+  - copying 'extensions/no-debug-non-zts-20220829/blackfire-1.92.8.tar.gz'... done.
+  - copying manifest file 'ext-blackfire-1.92.8_php-8.2.composer.json'... done.
+Copying ext-blackfire-1.92.8_php-8.3:
+  - copying 'extensions/no-debug-non-zts-20230831/blackfire-1.92.8.tar.gz'... done.
+  - copying manifest file 'ext-blackfire-1.92.8_php-8.3.composer.json'... done.
+Copying ext-event-3.1.1_php-7.3:
+  - copying 'extensions/no-debug-non-zts-20180731/event-3.1.1.tar.gz'... done.
+  - copying manifest file 'ext-event-3.1.1_php-7.3.composer.json'... done.
+Copying ext-event-3.1.1_php-7.4:
+  - copying 'extensions/no-debug-non-zts-20190902/event-3.1.1.tar.gz'... done.
+  - copying manifest file 'ext-event-3.1.1_php-7.4.composer.json'... done.
+Copying ext-event-3.1.1_php-8.0:
+  - copying 'extensions/no-debug-non-zts-20200930/event-3.1.1.tar.gz'... done.
+  - copying manifest file 'ext-event-3.1.1_php-8.0.composer.json'... done.
+Copying ext-event-3.1.1_php-8.1:
+  - copying 'extensions/no-debug-non-zts-20210902/event-3.1.1.tar.gz'... done.
+  - copying manifest file 'ext-event-3.1.1_php-8.1.composer.json'... done.
+Copying ext-event-3.1.1_php-8.2:
+  - copying 'extensions/no-debug-non-zts-20220829/event-3.1.1.tar.gz'... done.
+  - copying manifest file 'ext-event-3.1.1_php-8.2.composer.json'... done.
+Copying ext-event-3.1.1_php-8.3:
+  - copying 'extensions/no-debug-non-zts-20230831/event-3.1.1.tar.gz'... done.
+  - copying manifest file 'ext-event-3.1.1_php-8.3.composer.json'... done.
+Copying ext-phalcon-5.6.0_php-8.0:
+  - copying 'extensions/no-debug-non-zts-20200930/phalcon-5.6.0.tar.gz'... done.
+  - copying manifest file 'ext-phalcon-5.6.0_php-8.0.composer.json'... done.
+Copying ext-phalcon-5.6.0_php-8.1:
+  - copying 'extensions/no-debug-non-zts-20210902/phalcon-5.6.0.tar.gz'... done.
+  - copying manifest file 'ext-phalcon-5.6.0_php-8.1.composer.json'... done.
+Copying ext-phalcon-5.6.0_php-8.2:
+  - copying 'extensions/no-debug-non-zts-20220829/phalcon-5.6.0.tar.gz'... done.
+  - copying manifest file 'ext-phalcon-5.6.0_php-8.2.composer.json'... done.
+Copying ext-phalcon-5.6.0_php-8.3:
+  - copying 'extensions/no-debug-non-zts-20230831/phalcon-5.6.0.tar.gz'... done.
+  - copying manifest file 'ext-phalcon-5.6.0_php-8.3.composer.json'... done.
+Copying php-8.2.15:
+  - copying 'php-8.2.15.tar.gz'... done.
+  - copying manifest file 'php-8.2.15.composer.json'... done.
+Copying php-8.3.2:
+  - copying 'php-8.3.2.tar.gz'... done.
+  - copying manifest file 'php-8.3.2.composer.json'... done.
+
+Generating and uploading packages.json... done!
+
+
+Sync complete.
+
+The following packages will be IGNORED:
+  - (none)
+
+The following packages will be ADDED
+ from s3://lang-php/dist-heroku-22-develop/
+   to s3://lang-php/dist-heroku-22-stable/:
+  - blackfire-2.24.4
+  - ext-amqp-2.1.2_php-8.1
+  - ext-amqp-2.1.2_php-8.2
+  - ext-amqp-2.1.2_php-8.3
+  - ext-blackfire-1.92.8_php-8.1
+  - ext-blackfire-1.92.8_php-8.2
+  - ext-blackfire-1.92.8_php-8.3
+  - ext-event-3.1.1_php-8.1
+  - ext-event-3.1.1_php-8.2
+  - ext-event-3.1.1_php-8.3
+  - ext-phalcon-5.6.0_php-8.1
+  - ext-phalcon-5.6.0_php-8.2
+  - ext-phalcon-5.6.0_php-8.3
+  - php-8.2.15
+  - php-8.3.2
+  - pkg-php-min-8.1.27
+  - composer-2.8.0
+  - composer-2.8.0RC2
+  - librdkafka-1.9.1
+  - nginx-2.9.0
+  - apache-2.4.4
+
+The following packages will be UPDATED (source manifest is newer)
+ from s3://lang-php/dist-heroku-22-develop/
+   to s3://lang-php/dist-heroku-22-stable/:
+  - (none)
+
+The following packages will be REMOVED
+ from s3://lang-php/dist-heroku-22-stable/:
+  - (none)
+
+
+Copying blackfire-2.24.4:
+  - copying 'blackfire-2.24.4.tar.gz'... done.
+  - copying manifest file 'blackfire-2.24.4.composer.json'... done.
+Copying ext-amqp-2.1.2_php-8.1:
+  - copying 'extensions/no-debug-non-zts-20210902/amqp-2.1.2.tar.gz'... done.
+  - copying manifest file 'ext-amqp-2.1.2_php-8.1.composer.json'... done.
+Copying ext-amqp-2.1.2_php-8.2:
+  - copying 'extensions/no-debug-non-zts-20220829/amqp-2.1.2.tar.gz'... done.
+  - copying manifest file 'ext-amqp-2.1.2_php-8.2.composer.json'... done.
+Copying ext-amqp-2.1.2_php-8.3:
+  - copying 'extensions/no-debug-non-zts-20230831/amqp-2.1.2.tar.gz'... done.
+  - copying manifest file 'ext-amqp-2.1.2_php-8.3.composer.json'... done.
+Copying ext-blackfire-1.92.8_php-8.1:
+  - copying 'extensions/no-debug-non-zts-20210902/blackfire-1.92.8.tar.gz'... done.
+  - copying manifest file 'ext-blackfire-1.92.8_php-8.1.composer.json'... done.
+Copying ext-blackfire-1.92.8_php-8.2:
+  - copying 'extensions/no-debug-non-zts-20220829/blackfire-1.92.8.tar.gz'... done.
+  - copying manifest file 'ext-blackfire-1.92.8_php-8.2.composer.json'... done.
+Copying ext-blackfire-1.92.8_php-8.3:
+  - copying 'extensions/no-debug-non-zts-20230831/blackfire-1.92.8.tar.gz'... done.
+  - copying manifest file 'ext-blackfire-1.92.8_php-8.3.composer.json'... done.
+Copying ext-event-3.1.1_php-8.1:
+  - copying 'extensions/no-debug-non-zts-20210902/event-3.1.1.tar.gz'... done.
+  - copying manifest file 'ext-event-3.1.1_php-8.1.composer.json'... done.
+Copying ext-event-3.1.1_php-8.2:
+  - copying 'extensions/no-debug-non-zts-20220829/event-3.1.1.tar.gz'... done.
+  - copying manifest file 'ext-event-3.1.1_php-8.2.composer.json'... done.
+Copying ext-event-3.1.1_php-8.3:
+  - copying 'extensions/no-debug-non-zts-20230831/event-3.1.1.tar.gz'... done.
+  - copying manifest file 'ext-event-3.1.1_php-8.3.composer.json'... done.
+Copying ext-phalcon-5.6.0_php-8.1:
+  - copying 'extensions/no-debug-non-zts-20210902/phalcon-5.6.0.tar.gz'... done.
+  - copying manifest file 'ext-phalcon-5.6.0_php-8.1.composer.json'... done.
+Copying ext-phalcon-5.6.0_php-8.2:
+  - copying 'extensions/no-debug-non-zts-20220829/phalcon-5.6.0.tar.gz'... done.
+  - copying manifest file 'ext-phalcon-5.6.0_php-8.2.composer.json'... done.
+Copying ext-phalcon-5.6.0_php-8.3:
+  - copying 'extensions/no-debug-non-zts-20230831/phalcon-5.6.0.tar.gz'... done.
+  - copying manifest file 'ext-phalcon-5.6.0_php-8.3.composer.json'... done.
+Copying php-8.2.15:
+  - copying 'php-8.2.15.tar.gz'... done.
+  - copying manifest file 'php-8.2.15.composer.json'... done.
+Copying php-8.3.2:
+  - copying 'php-8.3.2.tar.gz'... done.
+  - copying manifest file 'php-8.3.2.composer.json'... done.
+
+Generating and uploading packages.json... done!
+
+
+Sync complete.

--- a/test/spec/devcenter_spec.rb
+++ b/test/spec/devcenter_spec.rb
@@ -1,0 +1,41 @@
+require_relative "spec_helper"
+
+require "open3"
+require "shellwords"
+require "time"
+
+devcenter_fixtures_subdir = "test/fixtures/devcenter"
+devcenter_tooling_subdir = "support/devcenter"
+
+describe "The Dev Center support tooling" do
+	before(:all) do
+		system("composer install -n -d #{devcenter_tooling_subdir}") or raise "Failed to install Dev Center support tooling dependencies"
+	end
+	
+	describe "Changelog generator script" do
+		it "produces the expected Markdown" do
+			cmd = "cat #{devcenter_fixtures_subdir}/changelog/sync.log | #{devcenter_tooling_subdir}/changelog.php"
+			stdout, stderr, status = Open3.capture3("bash -c #{Shellwords.escape(cmd)}")
+			generated_markdown = stdout
+			
+			expect(status.exitstatus).to eq(0), "changelog.php exited with status #{status.exitstatus}; stderr: #{stderr}, stdout: #{stdout}"
+			
+			expected_markdown = File.read("#{devcenter_fixtures_subdir}/changelog/changelog.md")
+			# the expected markdown contains "%B %Y" strftime directives at the top
+			expected_markdown = Time.now.utc.strftime(expected_markdown)
+			expect(expected_markdown).to eq(generated_markdown)
+		end
+		it "produces a near-empty document if there are no additions" do
+			cmd = "cat #{devcenter_fixtures_subdir}/changelog/sync-nothingnew.log | #{devcenter_tooling_subdir}/changelog.php"
+			stdout, stderr, status = Open3.capture3("bash -c #{Shellwords.escape(cmd)}")
+			generated_markdown = stdout
+			
+			expect(status.exitstatus).to eq(0), "changelog.php exited with status #{status.exitstatus}; stderr: #{stderr}, stdout: #{stdout}"
+			
+			expected_markdown = File.read("#{devcenter_fixtures_subdir}/changelog/changelog-nothingnew.md")
+			# the expected markdown contains "%B %Y" strftime directives at the top
+			expected_markdown = Time.now.utc.strftime(expected_markdown)
+			expect(expected_markdown).to eq(generated_markdown)
+		end
+	end
+end

--- a/test/var/log/parallel_runtime_rspec.heroku-20.log
+++ b/test/var/log/parallel_runtime_rspec.heroku-20.log
@@ -4,6 +4,7 @@ test/spec/bugs_spec.rb:30
 test/spec/ci_frameworks_spec.rb:190
 test/spec/ci_spec.rb:130
 test/spec/composer_spec.rb:135
+test/spec/devcenter_spec.rb:5
 test/spec/httpd_spec.rb:18
 test/spec/newrelic_spec.rb:110
 test/spec/nginx_spec.rb:49

--- a/test/var/log/parallel_runtime_rspec.heroku-22.log
+++ b/test/var/log/parallel_runtime_rspec.heroku-22.log
@@ -4,6 +4,7 @@ test/spec/bugs_spec.rb:30
 test/spec/ci_frameworks_spec.rb:190
 test/spec/ci_spec.rb:130
 test/spec/composer_spec.rb:120
+test/spec/devcenter_spec.rb:5
 test/spec/httpd_spec.rb:18
 test/spec/newrelic_spec.rb:110
 test/spec/nginx_spec.rb:49


### PR DESCRIPTION
Consumes the log of packages synced by `sync.sh`, gets run automatically at the end of a platform packages sync workflow.

Result can then be copy/pasted easily:

<img width="1074" alt="Screenshot 2024-02-27 at 16 13 04" src="https://github.com/heroku/heroku-buildpack-php/assets/27900/a9e656b1-c18f-4d4f-91ab-7271864b611a">

[GUS-W-15123669](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-15123669)