### PR TITLE
Update Hatchet to 8.0 based branch and add cleanup workflow

### DIFF
--- a/.github/workflows/ci-cleanup.yml
+++ b/.github/workflows/ci-cleanup.yml
@@ -1,0 +1,32 @@
+name: Hatchet App Cleaner
+
+on:
+  schedule:
+    # Daily at 6am UTC.
+    - cron: "0 6 * * *"
+  # Allow the workflow to be manually triggered too.
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  hatchet-app-cleaner:
+    runs-on: ubuntu-latest
+    env:
+      HATCHET_APP_PREFIX: "htcht-"
+      HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+      HEROKU_API_USER: ${{ secrets.HEROKU_API_USER }}
+      HEROKU_DISABLE_AUTOUPDATE: 1
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Ruby and dependencies
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          ruby-version: "3.2"
+      - name: Run Hatchet destroy
+        # Only apps older than 10 minutes are destroyed, to ensure that any
+        # in progress CI runs are not interrupted.
+        run: bundle exec hatchet destroy --older-than 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-          ruby-version: "2.7"
+          ruby-version: "3.2"
       - name: Install PHP and Composer
         uses: shivammathur/setup-php@v2
         with:
@@ -59,19 +59,3 @@ jobs:
         run: bundle exec parallel_rspec --group-by runtime --unknown-runtime 1 --allowed-missing 100 --runtime-log "test/var/log/parallel_runtime_rspec.${STACK}.log" --verbose-command --combine-stderr --prefix-output-with-test-env-number test/spec/
       - name: Print parallel_runtime_rspec.log
         run: cat parallel_runtime_rspec.log | grep -E '^test/spec/[a-z0-9_/\.-]+\.rb:[0-9]+\.[0-9]+$' | sort
-  post-integration-test:
-    if: always()
-    needs: [integration-test]
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Install Ruby and Bundler
-        uses: ruby/setup-ruby@v1
-        with:
-          bundler-cache: true
-          ruby-version: "2.7"
-      - name: Hatchet setup
-        run: bundle exec hatchet ci:setup
-      - name: Clean up test apps
-        run: bundle exec hatchet destroy --all

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source "https://rubygems.org"
 
+ruby '>= 3.1', '< 3.4'
+
 gem 'heroku_hatchet', git: 'https://github.com/heroku/hatchet.git', branch: 'timeouts-etc'
 gem 'rspec-retry'
 gem 'rspec-expectations'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/heroku/hatchet.git
-  revision: a4635c048f87ecdb032c32f0fdf0fed9d8acf577
+  revision: 0de04fcc3c2125efb07060445e058b643de99d49
   branch: timeouts-etc
   specs:
-    heroku_hatchet (7.4.0)
+    heroku_hatchet (8.0.2)
       excon (~> 0)
       platform-api (~> 3)
       rrrretry (~> 1)
@@ -16,7 +16,7 @@ GEM
     ansi (1.5.0)
     diff-lcs (1.5.1)
     erubis (2.7.0)
-    excon (0.104.0)
+    excon (0.109.0)
     heroics (0.1.2)
       erubis (~> 2.0)
       excon
@@ -28,7 +28,7 @@ GEM
     parallel (1.24.0)
     parallel_tests (4.5.1)
       parallel
-    platform-api (3.5.0)
+    platform-api (3.6.0)
       heroics (~> 0.1.1)
       moneta (~> 1.0.0)
       rate_throttle_client (~> 0.1.0)
@@ -44,7 +44,7 @@ GEM
       rspec-core (> 3.3)
     rspec-support (3.13.1)
     sem_version (2.0.1)
-    thor (1.2.2)
+    thor (1.3.1)
     threaded (0.0.4)
     webrick (1.8.1)
 
@@ -60,5 +60,8 @@ DEPENDENCIES
   rspec-retry
   sem_version
 
+RUBY VERSION
+   ruby 3.2.3p157
+
 BUNDLED WITH
-   1.17.3
+   2.4.19


### PR DESCRIPTION
Use Ruby 3.2 throughout.

Remove Hatchet app cleanup from end of CI workflow, because since v8.x, Hatchet now:
- Removes the apps it creates after each test runs, rather than only enabling maintenance mode. This occurs even if an individual test fails.
- Cleans up older apps iff it runs into the app limit. (This is only done when the app limit is hit, in order to prevent hundreds of unnecessary API requests, when test concurrency is high.)

However, leftover apps can still occur in the following cases:
- The GitHub Actions run is cancelled, or aborts in a non-clean way.
- If a Hatchet bug (or a mis-use of Hatchet by the tests) cause Hatchet to exit non-cleanly.
- If there is a platform incident causing the Heroku API to not be available.

Therefore, a scheduled cleanup job has been added to catch any such leftover apps. It runs daily at 6am UTC, and can also be triggered manually via the GitHub dashboard.

The cleanup job only deletes apps older than 10 minutes, so that it doesn't break any in progress CI jobs.

GUS-W-15173507