### PR TITLE
Adjust capitalisation of generated changelog entry title

### DIFF
--- a/support/devcenter/changelog.twig
+++ b/support/devcenter/changelog.twig
@@ -1,4 +1,4 @@
-{{"now"|date("F Y", "UTC")}} PHP Updates
+{{"now"|date("F Y", "UTC")}} PHP updates
 ----
 {% if phps %}
 The following new [PHP runtime versions](https://devcenter.heroku.com/articles/php-support#available-versions) are now available:

--- a/test/fixtures/devcenter/changelog/changelog-nothingnew.md
+++ b/test/fixtures/devcenter/changelog/changelog-nothingnew.md
@@ -1,2 +1,2 @@
-%B %Y PHP Updates
+%B %Y PHP updates
 ----

--- a/test/fixtures/devcenter/changelog/changelog.md
+++ b/test/fixtures/devcenter/changelog/changelog.md
@@ -1,4 +1,4 @@
-%B %Y PHP Updates
+%B %Y PHP updates
 ----
 The following new [PHP runtime versions](https://devcenter.heroku.com/articles/php-support#available-versions) are now available:
 


### PR DESCRIPTION
Switches it to sentence case (only the first letter capitalised, unless the word is a proper noun such as a Heroku product name), for consistency with the style used for all other changelog entries:
https://devcenter.heroku.com/changelog

(I'd edited the last few PHP entries by hand to fix the capitalisation, when adding my own changelog entries, but I see now they are coming from this template)