### PR TITLE
Port all binary build tooling to s5cmd, add sync tests, simplify removals

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ env:
   HATCHET_BUILDPACK_BRANCH: ${{ github.head_ref || github.ref_name }}
   HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
   HEROKU_API_USER: ${{ secrets.HEROKU_API_USER }}
+  S5CMD_VERSION: 2.2.2
+  S5CMD_HASH: "392c385320cd5ffa435759a95af77c215553d967e4b1c0fffe52e4f14c29cf85  s5cmd_2.2.2_linux_amd64.deb"
 
 jobs:
   integration-test:
@@ -47,8 +49,13 @@ jobs:
         with:
           php-version: "8.2"
           tools: "composer:2.7"
-      - name: Install packages from requirements.txt (for some tests)
-        run: pip install -r requirements.txt
+      - name: Install packages from requirements.txt, plus s5cmd (for some tests)
+        run: |
+          pip install -r requirements.txt
+          curl -sSLO https://github.com/peak/s5cmd/releases/download/v${S5CMD_VERSION}/s5cmd_${S5CMD_VERSION}_linux_amd64.deb
+          echo "$S5CMD_HASH" | shasum -c -
+          dpkg -x "s5cmd_${S5CMD_VERSION}_linux_amd64.deb" .
+          echo "$HOME/usr/bin" >> "$GITHUB_PATH"
       - name: Hatchet setup
         run: bundle exec hatchet ci:setup
       - name: Export HEROKU_PHP_PLATFORM_REPOSITORIES to …-develop (since we are not building main or a tag)

--- a/.github/workflows/platform-build.yml
+++ b/.github/workflows/platform-build.yml
@@ -136,5 +136,5 @@ jobs:
           echo '## Package changes available for syncing to production bucket' >> "$GITHUB_STEP_SUMMARY"
           echo '**This is output from a dry-run**, no changes have been synced to production:' >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
-          sed -n '/The following packages will/,$p' sync.out >> "$GITHUB_STEP_SUMMARY"
+          sed -n '/^The following packages will/,/POTENTIALLY DESTRUCTIVE ACTION/{/POTENTIALLY DESTRUCTIVE ACTION/!p}' sync.out >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/platform-remove.yml
+++ b/.github/workflows/platform-remove.yml
@@ -71,10 +71,18 @@ jobs:
           set -f
           set -o pipefail
           (yes 2>/dev/null || true) | docker run --rm -i --env-file=support/build/_docker/env.default heroku-php-build-${{inputs.stack}}:${{github.sha}} remove.sh ${{inputs.manifests}} 2>&1 | tee remove.out
-      - name: Output job summary
+      - name: Output dry-run summary
+        if: ${{ inputs.dry-run == true }}
         run: |
-          echo '## Packages${{ inputs.dry-run == true && ' which would be' || '' }} removed from production bucket' >> "$GITHUB_STEP_SUMMARY"
-          echo "${{ inputs.dry-run == true && '**This is output from a dry-run**, no packages have been removed:' || '-n' }}" >> "$GITHUB_STEP_SUMMARY"
+          echo '## Packages which would be removed from production bucket' >> "$GITHUB_STEP_SUMMARY"
+          echo '**This is output from a dry-run**, no packages have been removed:' >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
-          sed -n '/The following packages will/,$p' remove.out >> "$GITHUB_STEP_SUMMARY"
+          sed -n '/^The following packages will/,/POTENTIALLY DESTRUCTIVE ACTION/{/POTENTIALLY DESTRUCTIVE ACTION/!p}' remove.out >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+      - name: Output removal summary
+        if: ${{ inputs.dry-run == false }}
+        run: |
+          echo '## Packages removed from production bucket' >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          cat remove.out >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/platform-sync.yml
+++ b/.github/workflows/platform-sync.yml
@@ -104,12 +104,20 @@ jobs:
         with:
           name: synclog-${{matrix.stack}}
           path: sync-${{matrix.stack}}.log
-      - name: Output job summary
+      - name: Output dry-run summary
+        if: ${{ inputs.dry-run == true }}
         run: |
-          echo '## Package changes ${{ inputs.dry-run == true && 'available for syncing' || 'synced' }} to ${{matrix.stack}} production bucket' >> "$GITHUB_STEP_SUMMARY"
-          echo "${{ inputs.dry-run == true && '**This is output from a dry-run**, no changes have been synced to production:' || '-n' }}" >> "$GITHUB_STEP_SUMMARY"
+          echo '## Package changes available for syncing to ${{matrix.stack}} production bucket' >> "$GITHUB_STEP_SUMMARY"
+          echo '**This is output from a dry-run**, no changes have been synced to production:' >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
-          sed -n '/The following packages will/,$p' sync-${{matrix.stack}}.log >> "$GITHUB_STEP_SUMMARY"
+          sed -n '/^The following packages will/,/POTENTIALLY DESTRUCTIVE ACTION/{/POTENTIALLY DESTRUCTIVE ACTION/!p}' sync-${{matrix.stack}}.log >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+      - name: Output sync summary
+        if: ${{ inputs.dry-run == false }}
+        run: |
+          echo '## Package changes synced to ${{matrix.stack}} production bucket' >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          cat sync-${{matrix.stack}}.log >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
   devcenter-generate:
     needs: sync

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 bob-builder>=0.0.20
-s3cmd>=1.6.0
 natsort

--- a/support/build/README.md
+++ b/support/build/README.md
@@ -562,7 +562,7 @@ The normal flow is to run `deploy.sh` first to deploy one or more packages, and 
 
     ~ $ mkrepo.sh --upload
 
-This will generate `packages.json` and upload it right away, or, if the `--upload` is not given, print upload instructions for `s3cmd`.
+This will generate `packages.json` and upload it right away, or, if the `--upload` is not given, print upload instructions for `s5cmd`.
 
 Alternatively, `deploy.sh` can be called with `--publish` as the first argument, in which case `mkrepo.sh --upload` will be called after the package deploy and manifest upload was successful:
 

--- a/support/build/_docker/heroku-20.Dockerfile
+++ b/support/build/_docker/heroku-20.Dockerfile
@@ -19,6 +19,7 @@ ENV PATH="/app/support/build/_util:$VIRTUAL_ENV/bin:$PATH"
 
 COPY requirements.txt /app/requirements.txt
 
+RUN pip install wheel
 RUN pip install -r /app/requirements.txt
 
 ARG S5CMD_VERSION=2.2.2

--- a/support/build/_docker/heroku-20.Dockerfile
+++ b/support/build/_docker/heroku-20.Dockerfile
@@ -1,5 +1,7 @@
 FROM heroku/heroku:20-build.v84
 
+ARG TARGETARCH
+
 WORKDIR /app
 ENV WORKSPACE_DIR=/app/support/build
 ENV S3_BUCKET=lang-php
@@ -18,5 +20,15 @@ ENV PATH="/app/support/build/_util:$VIRTUAL_ENV/bin:$PATH"
 COPY requirements.txt /app/requirements.txt
 
 RUN pip install -r /app/requirements.txt
+
+ARG S5CMD_VERSION=2.2.2
+RUN curl -sSLO https://github.com/peak/s5cmd/releases/download/v${S5CMD_VERSION}/s5cmd_${S5CMD_VERSION}_linux_${TARGETARCH}.deb
+# copy/paste relevant shasums from s5cmd_checksums.txt in the release, remember to preserve the "\\n\" at the end of each line
+RUN printf "\
+392c385320cd5ffa435759a95af77c215553d967e4b1c0fffe52e4f14c29cf85  s5cmd_${S5CMD_VERSION}_linux_amd64.deb\\n\
+939bee3cf4b5604ddb00e67f8c157b91d7c7a5b553d1fbb6890fad32894b7b46  s5cmd_${S5CMD_VERSION}_linux_arm64.deb\\n\
+" | shasum -c - --ignore-missing
+
+RUN dpkg -i s5cmd_${S5CMD_VERSION}_linux_${TARGETARCH}.deb
 
 COPY . /app

--- a/support/build/_docker/heroku-22.Dockerfile
+++ b/support/build/_docker/heroku-22.Dockerfile
@@ -19,6 +19,7 @@ ENV PATH="/app/support/build/_util:$VIRTUAL_ENV/bin:$PATH"
 
 COPY requirements.txt /app/requirements.txt
 
+RUN pip install wheel
 RUN pip install -r /app/requirements.txt
 
 ARG S5CMD_VERSION=2.2.2

--- a/support/build/_docker/heroku-22.Dockerfile
+++ b/support/build/_docker/heroku-22.Dockerfile
@@ -1,5 +1,7 @@
 FROM heroku/heroku:22-build.v84
 
+ARG TARGETARCH
+
 WORKDIR /app
 ENV WORKSPACE_DIR=/app/support/build
 ENV S3_BUCKET=lang-php
@@ -18,5 +20,15 @@ ENV PATH="/app/support/build/_util:$VIRTUAL_ENV/bin:$PATH"
 COPY requirements.txt /app/requirements.txt
 
 RUN pip install -r /app/requirements.txt
+
+ARG S5CMD_VERSION=2.2.2
+RUN curl -sSLO https://github.com/peak/s5cmd/releases/download/v${S5CMD_VERSION}/s5cmd_${S5CMD_VERSION}_linux_${TARGETARCH}.deb
+# copy/paste relevant shasums from s5cmd_checksums.txt in the release, remember to preserve the "\\n\" at the end of each line
+RUN printf "\
+392c385320cd5ffa435759a95af77c215553d967e4b1c0fffe52e4f14c29cf85  s5cmd_${S5CMD_VERSION}_linux_amd64.deb\\n\
+939bee3cf4b5604ddb00e67f8c157b91d7c7a5b553d1fbb6890fad32894b7b46  s5cmd_${S5CMD_VERSION}_linux_arm64.deb\\n\
+" | shasum -c - --ignore-missing
+
+RUN dpkg -i s5cmd_${S5CMD_VERSION}_linux_${TARGETARCH}.deb
 
 COPY . /app

--- a/support/build/_util/deploy.sh
+++ b/support/build/_util/deploy.sh
@@ -74,5 +74,5 @@ echo "Uploading manifest..."
 
 if $publish; then
 	echo "Updating repository..."
-	"$(dirname "$BASH_SOURCE")/mkrepo.sh" --upload "$S3_BUCKET" "${S3_PREFIX}"
+	"$(dirname "$BASH_SOURCE")/mkrepo.sh" --upload
 fi

--- a/support/build/_util/include/manifest.sh
+++ b/support/build/_util/include/manifest.sh
@@ -9,7 +9,8 @@ print_or_export_manifest_cmd() {
 }
 
 generate_manifest_cmd() {
-	echo "s3cmd --host=s3.${S3_REGION:-}${S3_REGION:+.}amazonaws.com --host-bucket='%(bucket)s.s3.${S3_REGION:-}${S3_REGION:+.}amazonaws.com' --ssl -m application/json put $(pwd)/${1} s3://${S3_BUCKET}/${S3_PREFIX}${1}"
+	cmd=(s5cmd ${S5CMD_NO_SIGN_REQUEST:+--no-sign-request} ${S5CMD_PROFILE:+--profile "$S5CMD_PROFILE"} cp ${S3_REGION:+--destination-region "$S3_REGION"} --content-type application/json "$(pwd)/${1}" "s3://${S3_BUCKET}/${S3_PREFIX}${1}")
+	echo "${cmd[*]@Q}"
 }
 
 soname_version() {

--- a/support/build/_util/include/sync.py
+++ b/support/build/_util/include/sync.py
@@ -1,0 +1,165 @@
+import sys, json, os, glob, datetime, re, argparse
+from contextlib import contextmanager
+from enum import IntFlag
+from pathlib import Path
+
+class ManifestDifference(IntFlag):
+    CONTENTS = 1
+    SRC_NEWER = 2
+    DST_NEWER = 4
+
+# for Python < 3.10, where glob.glob() has no root_dir kwarg
+@contextmanager
+def chdir(path):
+    cwd = os.getcwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(cwd)
+
+def serialize_datetime(obj):
+    if isinstance(obj, (datetime.datetime, datetime.date)):
+        return obj.strftime("%Y-%m-%d %H:%M:%S")
+    raise TypeError ("Cannot serialize type %s as JSON" % type(obj))
+
+def parse_manifest(path):
+    manifest = json.load(open(path))
+    try:
+        dt = datetime.datetime.strptime(manifest.pop("time"), "%Y-%m-%d %H:%M:%S").replace(tzinfo=datetime.timezone.utc)
+    except (KeyError, ValueError):
+        dt = datetime.datetime.fromtimestamp(os.path.getmtime(path), tz=datetime.timezone.utc)
+        print("WARNING: manifest {} has invalid time entry, using mtime: {}".format(os.path.basename(path), serialize_datetime(dt)), file=sys.stderr)
+    manifest["time"] = dt
+    return manifest
+
+def manifests_difference(src_manifest, dst_manifest):
+    src_copy = src_manifest.copy()
+    dst_copy = dst_manifest.copy()
+    
+    ret = 0
+    
+    # a newer source time means we will copy
+    if src_copy["time"] > dst_copy["time"]:
+        ret |= ManifestDifference.SRC_NEWER
+    elif src_copy["time"] < dst_copy["time"]:
+        ret |= ManifestDifference.DST_NEWER
+    
+    src_copy.pop("time")
+    dst_copy.pop("time")
+    src_copy.pop("dist")
+    dst_copy.pop("dist")
+    
+    if src_copy != dst_copy:
+        ret |= ManifestDifference.CONTENTS
+    
+    return ret
+
+def rewrite_dist(manifest, src_region, src_bucket, src_prefix, dst_region, dst_bucket, dst_prefix):
+    # pattern for basically "https://lang-php.(s3.us-east-1|s3).amazonaws.com/dist-heroku-22-stable/"
+    # this ensures old packages are correctly handled even when they do not contain the region in the URL
+    s3_url_re=re.escape("https://{}.".format(src_bucket))
+    s3_url_re+=r"(?:s3.{}|s3)".format(re.escape(src_region))
+    s3_url_re+=re.escape(".amazonaws.com/{}".format(src_prefix))
+    s3_url_re+=r"([^?]+)(\?.*)?"
+    url=manifest.get("dist",{}).get("url","")
+    r = re.match(s3_url_re, url)
+    if r:
+        # rewrite dist URL in manifest to destination bucket
+        manifest["dist"]["url"] = r.expand("https://{}.s3.{}.amazonaws.com/{}\\1\\2".format(dst_bucket, dst_region, dst_prefix))
+        return {"kind": "dist", "source": "s3://{}/{}{}".format(src_bucket, src_prefix, r.group(1)), "source-region": src_region, "destination": "s3://{}/{}{}".format(dst_bucket, dst_prefix, r.group(1)), "destination-region": dst_region}
+    else:
+        return {"kind": "dist", "skip": True, "source": url, "reason": "file located outside of bucket"}
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--dry-run", action="store_true")
+parser.add_argument("src_region")
+parser.add_argument("src_bucket")
+parser.add_argument("src_prefix")
+parser.add_argument("src_dir")
+parser.add_argument("dst_region")
+parser.add_argument("dst_bucket")
+parser.add_argument("dst_prefix")
+parser.add_argument("dst_dir")
+args = parser.parse_args()
+
+src_region = args.src_region
+src_bucket = args.src_bucket
+src_prefix = args.src_prefix
+src_dir = Path(args.src_dir)
+
+dst_region = args.dst_region
+dst_bucket = args.dst_bucket
+dst_prefix = args.dst_prefix
+dst_dir = Path(args.dst_dir)
+
+# we cannot use Path.glob, since we need the file names only, for comparison
+# using our chdir context manager for compatibility with Python < 3.10, where glob.glob() has no root_dir kwarg
+with chdir(src_dir):
+    src = set(glob.glob("*.composer.json"))
+with chdir(dst_dir):
+    dst = set(glob.glob("*.composer.json"))
+
+add = src - dst
+rem = dst - src
+upd = src & dst
+
+ops = []
+
+# anything not in dst is copied from src
+for manifest_file in add:
+    package = re.sub(r"\.composer\.json$", "", manifest_file)
+    manifest = parse_manifest(src_dir/manifest_file)
+    # rewrite dist.url to point to dst bucket (if it's a URL in src bucket)
+    dist_op = rewrite_dist(manifest, src_region, src_bucket, src_prefix, dst_region, dst_bucket, dst_prefix)
+    dist_op["op"] = "add"
+    dist_op["package"] = package
+    # copy operation for the dist file (might also be an ignore if the URL isn't in the src bucket)
+    ops.append(dist_op)
+    # create dst manifest
+    args.dry_run or json.dump(manifest, open(dst_dir / manifest_file, "w"), sort_keys=True, default=serialize_datetime)
+    # copy operation from local dst manifest to dst bucket
+    ops.append({"kind": "manifest", "op": "add", "package": package, "source": dst_dir/manifest_file, "destination": "s3://{}/{}{}".format(dst_bucket, dst_prefix, manifest_file), "destination-region": dst_region})
+
+for manifest_file in rem:
+    package = re.sub(r"\.composer\.json$", "", manifest_file)
+    manifest = parse_manifest(dst_dir / manifest_file)
+    # we're just checking if this file qualifies for copying - that'll tell us whether we have to remove it or not
+    dist_op = rewrite_dist(manifest, dst_region, dst_bucket, dst_prefix, src_region, src_bucket, src_prefix)
+    if dist_op.get("skip", False) == False:
+        # it would be copied, so it's in the bucket, and we can actually remove it
+        ops.append({"kind": dist_op["kind"], "op": "remove", "package": package, "destination": dist_op["source"], "destination-region": dist_op["source-region"]})
+    else:
+        # it's a URL somewhere else, so we just re-use the ignore operation
+        ops.append({"kind": dist_op["kind"], "op": "remove", "skip": dist_op["skip"], "package": package, "destination": dist_op["source"], "reason": dist_op["reason"]})
+    # drop the package from dst_dir (that's what we'll be syncing up, and what we'll be running mkrepo.sh off of)
+    args.dry_run or (dst_dir/manifest_file).unlink()
+    # removal operation from dst bucket
+    ops.append({"kind": "manifest", "op": "remove", "package": package, "destination": "s3://{}/{}{}".format(dst_bucket, dst_prefix, manifest_file), "destination-region": dst_region})
+
+for manifest_file in upd:
+    package = re.sub(r"\.composer\.json$", "", manifest_file)
+    src_manifest = parse_manifest(src_dir/manifest_file)
+    dst_manifest = parse_manifest(dst_dir/manifest_file)
+    # compare the two manifests
+    diff = manifests_difference(src_manifest, dst_manifest)
+    if diff:
+        # the manifests differ somehow
+        if diff & ManifestDifference.SRC_NEWER:
+            # source is newer than destination, so we copy both dist and manifest
+            # take updated manifest from src
+            dist_op = rewrite_dist(src_manifest, src_region, src_bucket, src_prefix, dst_region, dst_bucket, dst_prefix)
+            dist_op["op"] = "update"
+            dist_op["package"] = package
+            ops.append(dist_op)
+            # write out updated manifest (remember we updated the newer src manifest with a dst dist url)
+            args.dry_run or json.dump(src_manifest, open(dst_dir / manifest_file, "w"), sort_keys=True, default=serialize_datetime)
+            # so we're passing in the dst_dir here
+            ops.append({"kind": "manifest", "op": "update", "package": package, "source": dst_dir/manifest_file, "destination": "s3://{}/{}{}".format(dst_bucket, dst_prefix, manifest_file), "destination-region": dst_region})
+        elif diff & ManifestDifference.DST_NEWER:
+            # destination is newer - do not overwrite
+            ops.append({"kind": "manifest", "op": "update", "skip": True, "package": package, "source": src_dir/manifest_file, "reason": "destination is newer"})
+        elif diff & ManifestDifference.CONTENTS:
+            ops.append({"kind": "manifest", "op": "update", "skip": True, "package": package, "source": src_dir/manifest_file, "reason": "contents differ, but times are identical"})
+
+json.dump(ops, sys.stdout, default=str)

--- a/support/build/_util/sync.sh
+++ b/support/build/_util/sync.sh
@@ -3,25 +3,28 @@
 set -eu
 set -o pipefail
 
-function s3cmd_get_progress() {
-	len=0
-	while read line; do
-		if [[ "$len" -gt 0 ]]; then
-			# repeat a backspace $len times
-			# need to use seq; {1..$len} doesn't work
-			printf '%0.s\b' $(seq 1 $len)
-		fi
-		echo -n "$line"
-		len=${#line}
-	done < <(grep --line-buffered -o -P '(?<=\[)[0-9]+ of [0-9]+(?=\])' | awk -W interactive '{print int($1/$3*100)"% ("$1"/"$3")"}') # filter only the "[1 of 99]" bits from 's3cmd get' output and divide using awk
-}
+# some s5cmd behavior notes
+# `s5cmd run` with one succeeding and one failing cp or ls returns 1
+# progress infos (e.g. lines from cp) go to stdout, also for --json
+# errors go to stderr, also for --json :(
+# when using --progress, no output goes to stdout, but errors are mixed with progress info
+S5CMD_OPTIONS=(${S5CMD_NO_SIGN_REQUEST:+--no-sign-request} ${S5CMD_PROFILE:+--profile "${S5CMD_PROFILE}"} --log error)
+
+localsrc=
+localdst=
 
 remove=true
 
 # process flags
-optstring=":-:"
+optstring=":-:d:s:"
 while getopts "$optstring" opt; do
 	case $opt in
+		d)
+			localdst=$OPTARG
+			;;
+		s)
+			localsrc=$OPTARG
+			;;
 		-)
 			case "$OPTARG" in
 				no-remove)
@@ -39,14 +42,17 @@ shift $((OPTIND-1))
 
 if [[ $# -lt "2" || $# -gt "6" ]]; then
 	cat >&2 <<-EOF
-		Usage: $(basename $0) [--no-remove] DEST_BUCKET DEST_PREFIX [DEST_REGION [SOURCE_BUCKET SOURCE_PREFIX [SOURCE_REGION]]]
+		Usage: $(basename "$0") [--no-remove] [-d DEST_DIR] [-s SRC_DIR] DEST_BUCKET DEST_PREFIX [DEST_REGION [SOURCE_BUCKET SOURCE_PREFIX [SOURCE_REGION]]]
 		  DEST_BUCKET:   destination S3 bucket name.
-		  DEST_REGION:   destination bucket region, e.g. 'us-west-1'; default: '$\S3_REGION'.
 		  DEST_PREFIX:   destination prefix, e.g. '' or 'dist-stable/'.
+		  DEST_REGION:   destination bucket region, e.g. 'us-west-1'; auto-detected if not given.
 		  SOURCE_BUCKET: source S3 bucket name; default: '\$S3_BUCKET'.
-		  SOURCE_REGION: source bucket region; default: <DEST_REGION>.
 		  SOURCE_PREFIX: source prefix; default: '\$S3_PREFIX'.
-		  --no-remove: no removal of destination packages that are not in source bucket.
+		  SOURCE_REGION: source bucket region; default: '\$S3_REGION'; auto-detected if not given.
+		  -d DEST_DIR:   use local directory <DEST_DIR> as destination instead of fetching from S3,
+		                 this will then not perform any operations, only print a summary.
+		  -s SOURCE_DIR: use local directory <SOURCE_DIR> as source instead of fetching from S3.
+		  --no-remove:   no removal of destination packages that are not in source bucket.
 	EOF
 	exit 2
 fi
@@ -56,10 +62,9 @@ dst_prefix=$1; shift
 if [[ $# -gt 2 ]]; then
 	# region name given
 	dst_region=$1; shift
-	dst_region_part=s3.${dst_region}
 else
-	dst_region=${S3_REGION:-}
-	dst_region_part=s3${dst_region:+.}${dst_region:-}
+	# grep out the region (it's there even on 403 responses), and trim whitespace via xargs - important to use grep -o and discard trailing whitespace, otherwise we'll end up with a carriage return at the end of the value
+	dst_region=$(set -o pipefail; curl -sI "https://${dst_bucket}.s3.amazonaws.com/" | grep -E -o -i "^x-amz-bucket-region:\s*\S+" | cut -d: -f2 | xargs || { echo >&2 "Failed to determine region for S3 bucket '$dst_bucket'"; exit 1; })
 fi
 
 src_bucket=${1:-$S3_BUCKET}; shift || true
@@ -67,152 +72,187 @@ src_prefix=${1:-$S3_PREFIX}; shift || true
 if [[ $# == "1" ]]; then
 	# region name given
 	src_region=$1; shift
-	src_region_part=s3.${src_region}; shift
 else
-	src_region=$dst_region
-	src_region_part=s3${src_region:+.}${src_region:-}
+	# grep out the region (it's there even on 403 responses), and trim whitespace via xargs - important to use grep -o and discard trailing whitespace, otherwise we'll end up with a carriage return at the end of the value
+	src_region=${S3_REGION:-$(set -o pipefail; curl -sI "https://${src_bucket}.s3.amazonaws.com/" | grep -E -o -i "^x-amz-bucket-region:\s*\S+" | cut -d: -f2 | xargs || { echo >&2 "Failed to determine region for S3 bucket '$src_bucket'"; exit 1; })}
 fi
-
-s3cmd_src_host_options="--host=${src_region_part}.amazonaws.com --host-bucket=%(bucket)s.${src_region_part}.amazonaws.com"
-s3cmd_dst_host_options="--host=${dst_region_part}.amazonaws.com --host-bucket=%(bucket)s.${dst_region_part}.amazonaws.com"
 
 if [[ "$src_region" != "$dst_region" ]]; then
 	echo "CAUTION: Source and destination regions differ. Sync may run into rate limits." >&2
 	echo "" >&2
-	s3cmd_cp_host_options=""
-else
-	s3cmd_cp_host_options=$s3cmd_src_host_options
 fi
 
-src_tmp=$(mktemp -d -t "src-repo.XXXXX")
-dst_tmp=$(mktemp -d -t "dst-repo.XXXXX")
-here=$(cd $(dirname $0); pwd)
+here=$(cd "$(dirname "$0")"; pwd)
 
-# clean up at the end
-trap 'rm -rf $src_tmp $dst_tmp;' EXIT
+downloads=()
 
-echo -n "Fetching source's manifests
-  from s3://${src_bucket}/${src_prefix}... " >&2
-(
-	cd $src_tmp
-	out=$(s3cmd ${s3cmd_src_host_options} --ssl get s3://${src_bucket}/${src_prefix}packages.json 2>&1) || { echo -e "No packages.json in source repo:\n$out" >&2; exit 1; }
-	s3cmd ${s3cmd_src_host_options} --ssl --progress get s3://${src_bucket}/${src_prefix}*.composer.json 2>&1 | tee download.log | s3cmd_get_progress >&2 || { echo -e "failed! Error:\n$(cat download.log)" >&2; exit 1; }
-	ls *.composer.json 2>/dev/null 1>&2 || { echo "failed; no manifests found!" >&2; exit 1; }
-	rm download.log
-)
+if [[ $localsrc && $localdst ]]; then
+	src_tmp=$localsrc
+	dst_tmp=$localdst
+elif [[ $localsrc ]]; then
+	# clean up at the end
+	trap 'rm -rf "$dst_tmp";' EXIT
+	
+	src_tmp=$localsrc
+	dst_tmp=$(mktemp -d -t "dst-repo.XXXXX")
+elif [[ $localdst ]]; then
+	# clean up at the end
+	trap 'rm -rf "$src_tmp";' EXIT
+	
+	src_tmp=$(mktemp -d -t "src-repo.XXXXX")
+	dst_tmp=$localdst
+else
+	# clean up at the end
+	trap 'rm -rf "$src_tmp" "$dst_tmp";' EXIT
+	
+	src_tmp=$(mktemp -d -t "src-repo.XXXXX")
+	dst_tmp=$(mktemp -d -t "dst-repo.XXXXX")
+fi
+
+if [[ ! $localsrc ]]; then
+	cat >&2 <<-EOF
+		Fetching source repository
+		  from s3://${src_bucket}/${src_prefix}...
+	EOF
+	s5cmd "${S5CMD_OPTIONS[@]}" cp --source-region "$src_region" "s3://${src_bucket}/${src_prefix}packages.json" "$src_tmp" || { echo -e "\nFailed to fetch repository! See message above for errors." >&2; exit 1; }
+	
+	src_manifests="s3://${src_bucket}/${src_prefix}*.composer.json"
+	
+	# this is for an 's5cmd run' later, so we're generating quoted arguments
+	downloads+=("cp --source-region ${src_region@Q} ${src_manifests@Q} ${src_tmp@Q}")
+fi
+
+if [[ ! $localdst ]]; then
+	dst_manifests="s3://${dst_bucket}/${dst_prefix}*.composer.json"
+	
+	cat >&2 <<-EOF
+		Checking destination bucket
+		  s3://${dst_bucket}/${dst_prefix}...
+	EOF
+	dst_ls_json=$(AWS_REGION=$dst_region s5cmd "${S5CMD_OPTIONS[@]}" --json ls "${dst_manifests}" 2>&1) && {
+		# this is for an 's5cmd run' later, so we're generating quoted arguments
+		downloads+=("cp --source-region ${dst_region@Q} ${dst_manifests@Q} ${dst_tmp@Q}")
+	} || {
+		# if we're using a local source, but there is no dest... something is wrong, bail out
+		[[ $localsrc ]] && { echo -e "\nDestination bucket access failed. Error info:\n${dst_ls_json}" >&2; exit 1; }
+		# we encountered an error; let's look at the error output - if it's just a "no object found", then we can proceed
+		jq -e '.error == "no object found"' >/dev/null <<<"$dst_ls_json" || { echo -e "\nDestination bucket access failed. Error info:\n${dst_ls_json}" >&2; exit 1; }
+		echo "Destination is empty; proceeding." >&2
+	}
+fi
+
+if (( ${#downloads[@]} )); then
+	echo "Fetching manifests... " >&2
+	printf "%s\n" "${downloads[@]}" | s5cmd "${S5CMD_OPTIONS[@]}" run || { echo -e "\nFailed to fetch manifests! See message above for errors." >&2; exit 1; }
+fi
+
 echo "" >&2
 
 # this mkrepo.sh call won't actually download, but use the given *.composer.json, and echo a generated packages.json
 # we use this to compare to the downloaded packages.json
-S3_REGION=$src_region $here/mkrepo.sh $src_bucket $src_prefix ${src_tmp}/*.composer.json 2>/dev/null | python -c 'import sys, json; sys.exit(json.load(open(sys.argv[1])) != json.load(sys.stdin))' ${src_tmp}/packages.json || {
+# unless we're using a local source dir, because that can be used for easy removals
+[[ $localsrc ]] || S3_BUCKET=$src_bucket S3_PREFIX=$src_prefix S3_REGION=$src_region "$here/mkrepo.sh" "${src_tmp}"/*.composer.json 2>/dev/null | python -c 'import sys, json; sys.exit(json.load(open(sys.argv[1])) != json.load(sys.stdin))' "${src_tmp}"/packages.json || {
 	cat >&2 <<-EOF
 		WARNING: packages.json from source does not match its list of manifests!
 		 You should run 'mkrepo.sh' to update, or ask the bucket maintainers to do so.
 	EOF
-	read -p "Would you like to abort this operation? [Yn] " proceed
+	read -rp "Would you like to abort this operation? [Yn] " proceed
 	[[ ! $proceed =~ [nN]o* ]] && exit 1 # yes is the default so doing yes | sync.sh won't do something stupid
+	echo "" >&2
 }
 
-echo -n "Fetching destination's manifests
-  from s3://${dst_bucket}/${dst_prefix}... " >&2
-(
-	cd $dst_tmp
-	s3cmd ${s3cmd_dst_host_options} --ssl --progress get s3://${dst_bucket}/${dst_prefix}*.composer.json 2>&1 | tee download.log | s3cmd_get_progress >&2 || { echo -e "failed! Error:\n$(cat download.log)" >&2; exit 1; }
-	rm download.log
-)
-echo "" >&2
+# from the given src and dst, figure out the necessary operations
+# if the destination is a local dir (e.g. for testing purposes), --dry-run will prevent sync.py from mutating the to-be-changed manifests in place (or removing removals)
+# TODO corner cases:
+# - package update changes dist URL (then dst dist needs removal and src dist needs copy)
+# - package removal has same dist URL as addition or update (then removal must be skipped due to the overwrite)
+ops=$(python "$here/include/sync.py" ${localdst:+--dry-run} "$src_region" "$src_bucket" "$src_prefix" "$src_tmp" "$dst_region" "$dst_bucket" "$dst_prefix" "$dst_tmp")
 
-comm=$(comm <(cd $src_tmp; ls -1 *.composer.json) <(cd $dst_tmp; ls -1 *.composer.json 2> /dev/null)) # comm produces three columns of output: entries only in left file, entries only in right file, entries in both
-add_manifests=$(echo "$comm" | grep '^\S' || true) # no tabs means output in col 1 = files only in src
-remove_manifests=$(echo "$comm" | grep '^\s\S' | cut -c2- || true) # one tab means output in col 2 = files only in dst
-common=$(echo "$comm" | grep '^\s\s' | cut -c3- || true) # two tabs means output in col 3 = files in both
-update_manifests=()
-ignore_manifests=()
-for filename in $common; do
-	result=0
-	python <(cat <<-'PYTHON' # beware of single quotes in body
-		from __future__ import print_function
-		import sys, json, os, datetime
-		# for python 2+3 compat
-		def stderrprint(*args, **kwargs):
-		    print(*args, file=sys.stderr, **kwargs)
-		src_manifest = json.load(open(sys.argv[1]))
-		dst_manifest = json.load(open(sys.argv[2]))
-		# remove URLs so they don't interfere with comparison
-		src_manifest.get("dist", {}).pop("url", None)
-		dst_manifest.get("dist", {}).pop("url", None)
-		# same for times, but we'll look at them
-		try:
-		    src_time = datetime.datetime.strptime(src_manifest.pop("time"), "%Y-%m-%d %H:%M:%S") # UTC
-		except (KeyError, ValueError):
-		    src_time = datetime.datetime.fromtimestamp(os.path.getmtime(sys.argv[1]), tz=datetime.timezone.utc)
-		    stderrprint("WARNING: source manifest {} has invalid time entry, using mtime: {}".format(os.path.basename(sys.argv[1]), src_time.isoformat()))
-		try:
-		    dst_time = datetime.datetime.strptime(dst_manifest.pop("time"), "%Y-%m-%d %H:%M:%S") # UTC
-		except (KeyError, ValueError):
-		    dst_time = datetime.datetime.fromtimestamp(os.path.getmtime(sys.argv[2]), tz=datetime.timezone.utc)
-		    stderrprint("WARNING: destination manifest {} has invalid time entry, using mtime: {}".format(os.path.basename(sys.argv[2]), dst_time.isoformat()))
-		# a newer source time means we will copy
-		if src_time > dst_time:
-		    sys.exit(0)
-		else:
-		    # 1 = content identical, src_time = dst_time (up to date)
-		    # 3 = content different, src_time = dst_time (weird)
-		    # 5 = content identical, src_time < dst_time (probably needs sync the other way)
-		    # 7 = content different, src_time < dst_time (probably needs sync the other way)
-		    ret = 1
-		    ret = ret | (src_manifest != dst_manifest)<<1
-		    ret = ret | (src_time < dst_time)<<2
-		    sys.exit(ret)
-		PYTHON
-	) $src_tmp/$filename $dst_tmp/$filename || result=$?
-	if [[ $result -eq 0 ]]; then
-		update_manifests+=($filename)
-	elif [[ $result != "1" ]]; then
-		case $result in
-			3)
-				ignore_manifests+=("$filename (contents differ, time fields identical!?)")
-				;;
-			5)
-				ignore_manifests+=("$filename (contents match, destination manifest newer)")
-				;;
-			7)
-				ignore_manifests+=("$filename (contents differ, destination manifest newer)")
-				;;
-		esac
-	fi
-done
+lookup_ignored_dists='([.[] | select(.kind == "dist" and (.skip // false) == true) | {(.package): (.source // .destination) }] | add) as $lookup'
+human_manifest_message='(if $lookup[.package] then " (manifest only, dist is external)" else "" end) as $dist_note | "\(.package)\($dist_note)"'
 
-cat >&2 <<-EOF
+readarray -t run_dists_cp < <(jq -r '.[] | select((.skip // false) == false) | select(.op == "add" or .op == "update") | select(.kind == "dist") | @sh "cp --source-region \(."source-region") --destination-region \(."destination-region") \(.source) \(.destination)"' <<<"$ops")
+# echo "Dist copies:"
+# printf -- "- %s\n" "${run_dists_cp[@]}"
 
-	WARNING: POTENTIALLY DESTRUCTIVE ACTION!
+manifests_cp_filter='.[] | select((.skip // false) == false) | select(.op == "add" or .op == "update") | select(.kind == "manifest")'
+readarray -t run_manifests_cp < <(jq -r "$manifests_cp_filter"' | @sh "cp --destination-region \(."destination-region") \(.source) \(.destination)"' <<<"$ops")
+readarray -t human_manifests_add < <(jq -r "$lookup_ignored_dists | $manifests_cp_filter"' | select(.op == "add") | '"$human_manifest_message" <<<"$ops" | sort --version-sort)
+readarray -t human_manifests_upd < <(jq -r "$lookup_ignored_dists | $manifests_cp_filter"' | select(.op == "update") |'"$human_manifest_message" <<<"$ops" | sort --version-sort)
+# echo "Manifest copies:"
+# printf -- "- %s\n" "${run_manifests_cp[@]}"
 
+manifests_rm_filter='.[] | select((.skip // false) == false) | select(.op == "remove") | select(.kind == "manifest")'
+readarray -t run_manifests_rm < <(jq -r "$manifests_rm_filter"' | @sh "rm \(.destination)"' <<<"$ops")
+readarray -t human_manifests_rm < <(jq -r "$lookup_ignored_dists | $manifests_rm_filter"' | '"$human_manifest_message" <<<"$ops" | sort --version-sort)
+# echo "Manifest removals:"
+# printf -- "- %s\n" "${run_manifests_rm[@]}"
+
+dists_rm_filter='.[] | select((.skip // false) == false) | select(.op == "remove") | select(.kind == "dist")'
+readarray -t run_dists_rm < <(jq -r "$dists_rm_filter"' | @sh "rm \(.destination)"' <<<"$ops")
+# echo "Dist removals:"
+# printf -- "- %s\n" "${run_dists_rm[@]}"
+
+readarray -t ign_dists_cp < <(jq -r '.[] | select((.skip // false) == true) | select(.op == "add" or .op == "update") | select(.kind == "dist") | @sh "cp \(.source)"' <<<"$ops")
+# echo "Dist copy ignores:"
+# printf -- "- %s\n" "${ign_dists_cp[@]}"
+
+manifests_cp_ign_filter='.[] | select((.skip // false) == true) | select(.op == "add" or .op == "update") | select(.kind == "manifest")'
+readarray -t ign_manifests_cp < <(jq -r "$manifests_cp_ign_filter"' | @sh "cp \(.source)"' <<<"$ops")
+readarray -t human_manifests_ign < <(jq -r "$manifests_cp_ign_filter"' | "\(.package) (\(.reason))"' <<<"$ops" | sort --version-sort)
+# echo "Manifest copy ignores:"
+# printf -- "- %s\n" "${ign_manifests_cp[@]}"
+
+readarray -t ign_manifests_rm < <(jq -r '.[] | select((.skip // false) == true) | select(.op == "remove") | select(.kind == "manifest") | @sh "rm \(.destination)"' <<<"$ops")
+# echo "Manifest removal ignores:"
+# printf -- "- %s\n" "${ign_manifests_rm[@]}"
+
+readarray -t ign_dists_rm < <(jq -r '.[] | select((.skip // false) == true) | select(.op == "remove") | select(.kind == "dist") | @sh "rm \(.destination)"' <<<"$ops")
+# echo "Dist removal ignores:"
+# printf -- "- %s\n" "${ign_dists_rm[@]}"
+
+# we print a summary for folks to confirm the operations
+
+(( ${#human_manifests_ign[@]} )) && cat >&2 <<-EOF
 	The following packages will be IGNORED:
-	$(IFS=$'\n'; echo "${ignore_manifests[*]:-(none)}" | sed -e 's/^/  - /' -e 's/.composer.json//')
+	$(printf -- "  - %s\n" "${human_manifests_ign[@]:-(none)}")
 
+EOF
+(( ${#human_manifests_add[@]} )) && cat >&2 <<-EOF
 	The following packages will be ADDED
 	 from s3://${src_bucket}/${src_prefix}
 	   to s3://${dst_bucket}/${dst_prefix}:
-	$(echo "${add_manifests:-(none)}" | sed -e 's/^/  - /' -e 's/.composer.json$//')
+	$(printf -- "  - %s\n" "${human_manifests_add[@]:-(none)}")
 
+EOF
+(( ${#human_manifests_upd[@]} )) && cat >&2 <<-EOF
 	The following packages will be UPDATED (source manifest is newer)
 	 from s3://${src_bucket}/${src_prefix}
 	   to s3://${dst_bucket}/${dst_prefix}:
-	$(IFS=$'\n'; echo "${update_manifests[*]:-(none)}" | sed -e 's/^/  - /' -e 's/.composer.json$//')
-
-	The following packages will $($remove || echo -n "NOT ")be REMOVED
-	 from s3://${dst_bucket}/${dst_prefix}$($remove && echo -n ":")$($remove || echo -ne "\n because '--no-remove' was given:")
-	$(echo "${remove_manifests:-(none)}" | sed -e 's/^/  - /' -e 's/.composer.json$//')
+	$(printf -- "  - %s\n" "${human_manifests_upd[@]:-(none)}")
 
 EOF
+(( ${#human_manifests_rm[@]} )) && cat >&2 <<-EOF
+	The following packages will $($remove || echo -n "NOT ")be REMOVED
+	 from s3://${dst_bucket}/${dst_prefix}$($remove && echo -n ":")$($remove || echo -ne "\n because '--no-remove' was given:")
+	$(printf -- "  - %s\n" "${human_manifests_rm[@]:-(none)}")
 
-# clear remove_manifests if --no-remove given
-$remove || remove_manifests=
+EOF
+# clear removal jobs if --no-remove given
+$remove || {
+	run_manifests_rm=()
+	run_dists_rm=()
+}
 
-if [[ ! "$add_manifests" && ! "$remove_manifests" && "${#update_manifests[@]}" -eq 0 ]]; then
-	echo "Nothing to do. Aborting." >&2
+if [[ $localdst ]] || (( !${#run_manifests_cp[@]} && !${#run_manifests_rm[@]} )); then
+	echo "Nothing to do" ${localdst:+"with local dir as destination"} "- aborting." >&2
 	exit
 fi
+
+cat >&2 <<-EOF
+	WARNING: POTENTIALLY DESTRUCTIVE ACTION!
+	
+EOF
 
 read -p "Are you sure you want to sync to destination & regenerate packages.json? [yN] " proceed
 
@@ -220,103 +260,35 @@ read -p "Are you sure you want to sync to destination & regenerate packages.json
 
 echo "" >&2
 
-copied_files=()
-for manifest in $add_manifests ${update_manifests[@]:-}; do
-	echo "Copying ${manifest%.composer.json}:" >&2
-	if filename=$(cat ${src_tmp}/${manifest} | python <(cat <<-'PYTHON' # beware of single quotes in body
-		import sys, json, re;
-		manifest=json.load(sys.stdin)
-		# pattern for basically "https://lang-php.(s3.us-east-1|s3).amazonaws.com/dist-heroku-22-stable/"
-		# this ensures old packages are correctly handled even when they do not contain the region in the URL
-		s3_url_re=re.escape("https://{}.".format(sys.argv[1]))
-		s3_url_re+="(?:{}|s3)".format(re.escape(sys.argv[2]))
-		s3_url_re+=re.escape(".amazonaws.com/{}".format(sys.argv[3]))
-		s3_url_re+="(.+)"
-		url=manifest.get("dist",{}).get("url","")
-		r = re.match(s3_url_re, url)
-		if r:
-		    # rewrite dist URL in manifest to destination bucket
-		    manifest["dist"]["url"] = "https://"+sys.argv[4]+"."+sys.argv[5]+".amazonaws.com/"+sys.argv[6]+r.group(1)
-		    json.dump(manifest, open(sys.argv[7], "w"), sort_keys=True)
-		    print(r.group(1))
-		else:
-		    # dist URL does not match https://${dst_bucket}.(${dst_region}|s3).amazonaws.com/${dst_prefix}
-		    print(url)
-		    sys.exit(1)
-		PYTHON
-	) $src_bucket $src_region_part $src_prefix $dst_bucket $dst_region_part $dst_prefix ${dst_tmp}/${manifest})
-	then
-		# the dist URL in the source's manifest points to the source bucket, so we copy the file to the dest bucket
-		echo -n "  - copying '$filename'... " >&2
-		out=$(s3cmd ${s3cmd_cp_host_options} --ssl cp s3://${src_bucket}/${src_prefix}${filename} s3://${dst_bucket}/${dst_prefix}${filename} 2>&1) || { echo -e "failed! Error:\n$out" >&2; exit 1; }
-		copied_files+=("$filename")
-		echo "done." >&2
-	else
-		# the dist URL points somewhere else, so we are not touching that
-		echo "  - WARNING: not copying '$filename' (in manifest 'dist.url')!" >&2
-		# just copy over the manifest (in the above branch, the Python script in the if expression already took care of that)
-		cp ${src_tmp}/${manifest} ${dst_tmp}/${manifest}
-	fi
-	echo -n "  - copying manifest file '$manifest'... " >&2
-	out=$(s3cmd ${s3cmd_cp_host_options} --ssl -m application/json put ${dst_tmp}/${manifest} s3://${dst_bucket}/${dst_prefix}${manifest} 2>&1) || { echo -e "failed! Error:\n$out" >&2; exit 1; }
-	echo "done." >&2
-done
+# we perform our operations in three consecutive groups (each group runs all its tasks in parallel via s5cmd):
+# 1) copy all dists files from src bucket to dst bucket
+# 2) upload all new/changed manifests to dst bucket and remove all removed manifests from dst bucket
+# 3) remove all removed dists from dst bucket
+# the purpose of this is to ensure we do not get into a broken state when e.g. the network is interrupted, process dies, etc
+# if anything goes wrong during 1), the dists will all be copied again when we perform the operation again
+# if anything goes wrong during 2), all the new/changed dists for which manifests were copied are already there from 1), and for removed manifests, no dists are gone yet
+# if anything goes wrong during 3), worst case we'll end up with a few stray dist files that should not be there, but won't be used since their manifests are already gone
 
-remove_files=()
-for manifest in $remove_manifests; do
-	echo "Removing ${manifest%.composer.json}:" >&2
-	if filename=$(cat ${dst_tmp}/${manifest} | python <(cat <<-'PYTHON' # beware of single quotes in body
-		import sys, json, re;
-		manifest=json.load(sys.stdin)
-		# pattern for basically "https://lang-php.(s3.us-east-1|s3).amazonaws.com/dist-heroku-22-stable/"
-		# this ensures old packages are correctly handled even when they do not contain the region in the URL
-		s3_url_re=re.escape("https://{}.".format(sys.argv[1]))
-		s3_url_re+="(?:{}|s3)".format(re.escape(sys.argv[2]))
-		s3_url_re+=re.escape(".amazonaws.com/{}".format(sys.argv[3]))
-		s3_url_re+="(.+)"
-		url=manifest.get("dist",{}).get("url","")
-		r = re.match(s3_url_re, url)
-		if r:
-		    print(r.group(1))
-		else:
-		    # dist URL does not match https://${dst_bucket}.(${dst_region}|s3).amazonaws.com/${dst_prefix}
-		    print(url)
-		    sys.exit(1)
-		PYTHON
-	) $dst_bucket $dst_region_part $dst_prefix)
-	then
-		# the dist URL in the destination manifest points to the destination bucket, so we remove that file at the end of the script...
-		if [[ " ${copied_files[@]:-} " =~ " $filename " ]]; then
-			# ...unless it was copied earlier (may happen if a new/updated manifest points to the same file name that this to-be-removed one is using)
-			echo "  - NOTICE: keeping newly copied '$filename'!" >&2
-		else
-			echo "  - queued '$filename' for removal." >&2
-			remove_files+=("$filename")
-		fi
-	else
-		# the dist URL points somewhere else, so we are not touching that
-		echo "  - WARNING: not removing '$filename' (in manifest 'dist.url')!" >&2
-	fi
-	echo -n "  - removing manifest file '$manifest'... " >&2
-	out=$(s3cmd ${s3cmd_dst_host_options} --ssl rm s3://${dst_bucket}/${dst_prefix}${manifest} 2>&1) || { echo -e "failed! Error:\n$out" >&2; exit 1; }
-	rm ${dst_tmp}/${manifest}
-	echo "done." >&2
-done
+if (( ${#run_dists_cp[@]} )); then
+	echo "Copying ${#run_dists_cp[@]} new or updated dists to destination..." >&2
+	printf -- "%s\n" "${run_dists_cp[@]}" | s5cmd "${S5CMD_OPTIONS[@]}" run || { echo -e "\nOne or more operation(s) failed. In case of transient errors, it is safe to re-run the sync." >&2; exit 1; }
+	echo "" >&2
+fi
 
-echo "" >&2
+if (( ${#run_manifests_cp[@]} || ${#run_manifests_rm[@]} )); then
+	echo "Copying ${#run_manifests_cp[@]} new or updated manifests to, and removing ${#run_manifests_rm[@]} manifests from, destination..." >&2
+	printf -- "%s\n" "${run_manifests_cp[@]}" "${run_manifests_rm[@]}" | s5cmd "${S5CMD_OPTIONS[@]}" run || { echo -e "\nOne or more operation(s) failed. In case of transient errors, it is safe to re-run the sync." >&2; exit 1; }
+	echo "" >&2
+fi
 
 echo -n "Generating and uploading packages.json... " >&2
-out=$(cd $dst_tmp; S3_REGION=$dst_region $here/mkrepo.sh --upload $dst_bucket $dst_prefix *.composer.json 2>&1) || { echo -e "failed! Error:\n$out" >&2; exit 1; }
+out=$(cd "$dst_tmp"; S3_BUCKET=$dst_bucket S3_PREFIX=$dst_prefix S3_REGION=$dst_region "$here/mkrepo.sh" --upload *.composer.json 2>&1) || { echo -e "failed! Error:\n$out\n\nIn case of transient errors, the repository must be re-generated manually." >&2; exit 1; }
 echo "done!
-$(echo "$out" | grep -E '^Public URL' | sed 's/^Public URL of the object is: http:/Public URL of the repository is: https:/')
 " >&2
 
-if [[ "${#remove_files[@]}" != "0" ]]; then
-	echo "Removing files queued for deletion from destination:" >&2
-	for filename in "${remove_files[@]}"; do
-		echo -n "  - removing '$filename'... " >&2
-		out=$(s3cmd ${s3cmd_dst_host_options} --ssl rm s3://${dst_bucket}/${dst_prefix}${filename} 2>&1) && echo "done." >&2 || echo -e "failed! Error:\n$out" >&2
-	done
+if (( ${#run_dists_rm[@]} )); then
+	echo "Removing ${#run_dists_rm[@]} dists from destination..." >&2
+	printf -- "%s\n" "${run_dists_rm[@]}" | s5cmd "${S5CMD_OPTIONS[@]}" run || { echo -e "\nOne or more operation(s) failed. In case of transient errors, failed removals must be performed manually." >&2; exit 1; }
 	echo "" >&2
 fi
 

--- a/test/fixtures/platform/builder/sync/expected_ops.json
+++ b/test/fixtures/platform/builder/sync/expected_ops.json
@@ -1,0 +1,113 @@
+[
+  {
+    "kind": "dist",
+    "source": "s3://lang-php/dist-heroku-24-develop/package-added-1.0.0.tar.gz",
+    "source-region": "us-east-1",
+    "destination": "s3://lang-php/dist-heroku-24-stable/package-added-1.0.0.tar.gz",
+    "destination-region": "us-east-1",
+    "op": "add",
+    "package": "package-added-1.0.0"
+  },
+  {
+    "kind": "manifest",
+    "op": "add",
+    "package": "package-added-1.0.0",
+    "source": "manifests-dst/package-added-1.0.0.composer.json",
+    "destination": "s3://lang-php/dist-heroku-24-stable/package-added-1.0.0.composer.json",
+    "destination-region": "us-east-1"
+  },
+  {
+    "kind": "dist",
+    "skip": true,
+    "source": "https://example.com/heroku-24/package-added-externaldist-1.0.0.tar.gz",
+    "reason": "file located outside of bucket",
+    "op": "add",
+    "package": "package-added-externaldist-1.0.0"
+  },
+  {
+    "kind": "manifest",
+    "op": "add",
+    "package": "package-added-externaldist-1.0.0",
+    "source": "manifests-dst/package-added-externaldist-1.0.0.composer.json",
+    "destination": "s3://lang-php/dist-heroku-24-stable/package-added-externaldist-1.0.0.composer.json",
+    "destination-region": "us-east-1"
+  },
+  {
+    "kind": "dist",
+    "op": "remove",
+    "package": "package-removed-1.0.0",
+    "destination": "s3://lang-php/dist-heroku-24-stable/package-removed-1.0.0.tar.gz",
+    "destination-region": "us-east-1"
+  },
+  {
+    "kind": "manifest",
+    "op": "remove",
+    "package": "package-removed-1.0.0",
+    "destination": "s3://lang-php/dist-heroku-24-stable/package-removed-1.0.0.composer.json",
+    "destination-region": "us-east-1"
+  },
+  {
+    "kind": "dist",
+    "op": "remove",
+    "skip": true,
+    "package": "package-removed-externaldist-1.0.0",
+    "destination": "https://example.com/heroku-24/package-removed-externaldist-1.0.0.tar.gz",
+    "reason": "file located outside of bucket"
+  },
+  {
+    "kind": "manifest",
+    "op": "remove",
+    "package": "package-removed-externaldist-1.0.0",
+    "destination": "s3://lang-php/dist-heroku-24-stable/package-removed-externaldist-1.0.0.composer.json",
+    "destination-region": "us-east-1"
+  },
+  {
+    "kind": "dist",
+    "skip": true,
+    "source": "https://example.com/heroku-24/package-updated-externaldist-1.0.0.tar.gz",
+    "reason": "file located outside of bucket",
+    "op": "update",
+    "package": "package-updated-externaldist-1.0.0"
+  },
+  {
+    "kind": "manifest",
+    "op": "update",
+    "package": "package-updated-externaldist-1.0.0",
+    "source": "manifests-dst/package-updated-externaldist-1.0.0.composer.json",
+    "destination": "s3://lang-php/dist-heroku-24-stable/package-updated-externaldist-1.0.0.composer.json",
+    "destination-region": "us-east-1"
+  },
+  {
+    "kind": "manifest",
+    "op": "update",
+    "skip": true,
+    "package": "package-newer-in-destination-1.0.0",
+    "source": "manifests-src/package-newer-in-destination-1.0.0.composer.json",
+    "reason": "destination is newer"
+  },
+  {
+    "kind": "manifest",
+    "op": "update",
+    "skip": true,
+    "package": "package-differs-only-in-contents-but-not-time-1.0.0",
+    "source": "manifests-src/package-differs-only-in-contents-but-not-time-1.0.0.composer.json",
+    "reason": "contents differ, but times are identical"
+  },
+  {
+    "kind": "dist",
+    "source": "s3://lang-php/dist-heroku-24-develop/package-updated-1.0.0.tar.gz",
+    "source-region": "us-east-1",
+    "destination": "s3://lang-php/dist-heroku-24-stable/package-updated-1.0.0.tar.gz",
+    "destination-region": "us-east-1",
+    "op": "update",
+    "package": "package-updated-1.0.0"
+  },
+  {
+    "kind": "manifest",
+    "op": "update",
+    "package": "package-updated-1.0.0",
+    "source": "manifests-dst/package-updated-1.0.0.composer.json",
+    "destination": "s3://lang-php/dist-heroku-24-stable/package-updated-1.0.0.composer.json",
+    "destination-region": "us-east-1"
+  }
+]

--- a/test/fixtures/platform/builder/sync/manifests-dst/package-differs-only-in-contents-but-not-time-1.0.0.composer.json
+++ b/test/fixtures/platform/builder/sync/manifests-dst/package-differs-only-in-contents-but-not-time-1.0.0.composer.json
@@ -1,0 +1,14 @@
+{
+  "dist": {
+    "type": "heroku-sys-tar",
+    "url": "https://lang-php.s3.us-east-1.amazonaws.com/dist-heroku-24-stable/package-differs-only-in-contents-but-not-time-1.0.0.tar.gz"
+  },
+  "name": "heroku-sys/package-differs-only-in-contents-but-not-time",
+  "require": {
+    "heroku-sys/heroku": "^24.0.0",
+    "heroku/installer-plugin": "^1.6.0"
+  },
+  "time": "2024-04-12 09:00:00",
+  "type": "heroku-sys-package",
+  "version": "1.0.0"
+}

--- a/test/fixtures/platform/builder/sync/manifests-dst/package-newer-in-destination-1.0.0.composer.json
+++ b/test/fixtures/platform/builder/sync/manifests-dst/package-newer-in-destination-1.0.0.composer.json
@@ -1,0 +1,14 @@
+{
+  "dist": {
+    "type": "heroku-sys-tar",
+    "url": "https://lang-php.s3.us-east-1.amazonaws.com/dist-heroku-24-stable/package-newer-in-destination-1.0.0.tar.gz"
+  },
+  "name": "heroku-sys/package-newer-in-destination",
+  "require": {
+    "heroku-sys/heroku": "^24.0.0",
+    "heroku/installer-plugin": "^1.9.0"
+  },
+  "time": "2024-04-12 13:00:00",
+  "type": "heroku-sys-package",
+  "version": "1.0.0"
+}

--- a/test/fixtures/platform/builder/sync/manifests-dst/package-removed-1.0.0.composer.json
+++ b/test/fixtures/platform/builder/sync/manifests-dst/package-removed-1.0.0.composer.json
@@ -1,0 +1,14 @@
+{
+  "dist": {
+    "type": "heroku-sys-tar",
+    "url": "https://lang-php.s3.us-east-1.amazonaws.com/dist-heroku-24-stable/package-removed-1.0.0.tar.gz"
+  },
+  "name": "heroku-sys/package-removed",
+  "require": {
+    "heroku-sys/heroku": "^24.0.0",
+    "heroku/installer-plugin": "^1.9.0"
+  },
+  "time": "2024-04-12 09:00:00",
+  "type": "heroku-sys-package",
+  "version": "1.0.0"
+}

--- a/test/fixtures/platform/builder/sync/manifests-dst/package-removed-externaldist-1.0.0.composer.json
+++ b/test/fixtures/platform/builder/sync/manifests-dst/package-removed-externaldist-1.0.0.composer.json
@@ -1,0 +1,14 @@
+{
+  "dist": {
+    "type": "heroku-sys-tar",
+    "url": "https://example.com/heroku-24/package-removed-externaldist-1.0.0.tar.gz"
+  },
+  "name": "heroku-sys/package-removed-externaldist",
+  "require": {
+    "heroku-sys/heroku": "^24.0.0",
+    "heroku/installer-plugin": "^1.6.0"
+  },
+  "time": "2024-04-12 10:00:00",
+  "type": "heroku-sys-package",
+  "version": "1.0.0"
+}

--- a/test/fixtures/platform/builder/sync/manifests-dst/package-updated-1.0.0.composer.json
+++ b/test/fixtures/platform/builder/sync/manifests-dst/package-updated-1.0.0.composer.json
@@ -1,0 +1,14 @@
+{
+  "dist": {
+    "type": "heroku-sys-tar",
+    "url": "https://lang-php.s3.us-east-1.amazonaws.com/dist-heroku-24-stable/package-updated-1.0.0.tar.gz"
+  },
+  "name": "heroku-sys/package-updated",
+  "require": {
+    "heroku-sys/heroku": "^24.0.0",
+    "heroku/installer-plugin": "^1.9.0"
+  },
+  "time": "2024-04-12 10:00:00",
+  "type": "heroku-sys-package",
+  "version": "1.0.0"
+}

--- a/test/fixtures/platform/builder/sync/manifests-dst/package-updated-externaldist-1.0.0.composer.json
+++ b/test/fixtures/platform/builder/sync/manifests-dst/package-updated-externaldist-1.0.0.composer.json
@@ -1,0 +1,14 @@
+{
+  "dist": {
+    "type": "heroku-sys-tar",
+    "url": "https://example.com/heroku-24/package-updated-externaldist-1.0.0.tar.gz"
+  },
+  "name": "heroku-sys/package-updated-externaldist",
+  "require": {
+    "heroku-sys/heroku": "^24.0.0",
+    "heroku/installer-plugin": "^1.9.0"
+  },
+  "time": "2024-04-12 10:00:00",
+  "type": "heroku-sys-package",
+  "version": "1.0.0"
+}

--- a/test/fixtures/platform/builder/sync/manifests-src/package-added-1.0.0.composer.json
+++ b/test/fixtures/platform/builder/sync/manifests-src/package-added-1.0.0.composer.json
@@ -1,0 +1,14 @@
+{
+  "dist": {
+    "type": "heroku-sys-tar",
+    "url": "https://lang-php.s3.us-east-1.amazonaws.com/dist-heroku-24-develop/package-added-1.0.0.tar.gz"
+  },
+  "name": "heroku-sys/package-added",
+  "require": {
+    "heroku-sys/heroku": "^24.0.0",
+    "heroku/installer-plugin": "^1.6.0"
+  },
+  "time": "2024-04-12 10:00:00",
+  "type": "heroku-sys-package",
+  "version": "1.0.0"
+}

--- a/test/fixtures/platform/builder/sync/manifests-src/package-added-externaldist-1.0.0.composer.json
+++ b/test/fixtures/platform/builder/sync/manifests-src/package-added-externaldist-1.0.0.composer.json
@@ -1,0 +1,14 @@
+{
+  "dist": {
+    "type": "heroku-sys-tar",
+    "url": "https://example.com/heroku-24/package-added-externaldist-1.0.0.tar.gz"
+  },
+  "name": "heroku-sys/package-added-externaldist",
+  "require": {
+    "heroku-sys/heroku": "^24.0.0",
+    "heroku/installer-plugin": "^1.6.0"
+  },
+  "time": "2024-04-12 11:00:00",
+  "type": "heroku-sys-package",
+  "version": "1.0.0"
+}

--- a/test/fixtures/platform/builder/sync/manifests-src/package-differs-only-in-contents-but-not-time-1.0.0.composer.json
+++ b/test/fixtures/platform/builder/sync/manifests-src/package-differs-only-in-contents-but-not-time-1.0.0.composer.json
@@ -1,0 +1,14 @@
+{
+  "dist": {
+    "type": "heroku-sys-tar",
+    "url": "https://lang-php.s3.us-east-1.amazonaws.com/dist-heroku-24-develop/package-differs-only-in-contents-but-not-time-1.0.0.tar.gz"
+  },
+  "name": "heroku-sys/package-differs-only-in-contents-but-not-time",
+  "require": {
+    "heroku-sys/heroku": "^24.0.0",
+    "heroku/installer-plugin": "^1.9.0"
+  },
+  "time": "2024-04-12 09:00:00",
+  "type": "heroku-sys-package",
+  "version": "1.0.0"
+}

--- a/test/fixtures/platform/builder/sync/manifests-src/package-newer-in-destination-1.0.0.composer.json
+++ b/test/fixtures/platform/builder/sync/manifests-src/package-newer-in-destination-1.0.0.composer.json
@@ -1,0 +1,14 @@
+{
+  "dist": {
+    "type": "heroku-sys-tar",
+    "url": "https://lang-php.s3.us-east-1.amazonaws.com/dist-heroku-24-develop/package-newer-in-destination-1.0.0.tar.gz"
+  },
+  "name": "heroku-sys/package-newer-in-destination",
+  "require": {
+    "heroku-sys/heroku": "^24.0.0",
+    "heroku/installer-plugin": "^1.9.0"
+  },
+  "time": "2024-04-12 12:00:00",
+  "type": "heroku-sys-package",
+  "version": "1.0.0"
+}

--- a/test/fixtures/platform/builder/sync/manifests-src/package-updated-1.0.0.composer.json
+++ b/test/fixtures/platform/builder/sync/manifests-src/package-updated-1.0.0.composer.json
@@ -1,0 +1,14 @@
+{
+  "dist": {
+    "type": "heroku-sys-tar",
+    "url": "https://lang-php.s3.us-east-1.amazonaws.com/dist-heroku-24-develop/package-updated-1.0.0.tar.gz"
+  },
+  "name": "heroku-sys/package-updated",
+  "require": {
+    "heroku-sys/heroku": "^24.0.0",
+    "heroku/installer-plugin": "^1.9.0"
+  },
+  "time": "2024-04-12 13:00:00",
+  "type": "heroku-sys-package",
+  "version": "1.0.0"
+}

--- a/test/fixtures/platform/builder/sync/manifests-src/package-updated-externaldist-1.0.0.composer.json
+++ b/test/fixtures/platform/builder/sync/manifests-src/package-updated-externaldist-1.0.0.composer.json
@@ -1,0 +1,14 @@
+{
+  "dist": {
+    "type": "heroku-sys-tar",
+    "url": "https://example.com/heroku-24/package-updated-externaldist-1.0.0.tar.gz"
+  },
+  "name": "heroku-sys/package-updated-externaldist",
+  "require": {
+    "heroku-sys/heroku": "^24.0.0",
+    "heroku/installer-plugin": "^1.9.0"
+  },
+  "time": "2024-04-12 13:00:00",
+  "type": "heroku-sys-package",
+  "version": "1.0.0"
+}

--- a/test/spec/platform_spec.rb
+++ b/test/spec/platform_spec.rb
@@ -199,7 +199,7 @@ describe "The PHP Platform Installer" do
 				bp_root = [".."].cycle("#{mkrepo_fixtures_subdir}/#{testcase}".count("/")+1).to_a.join("/") # right "../.." sequence to get us back to the root of the buildpack
 				Dir.chdir("#{mkrepo_fixtures_subdir}/#{testcase}") do |cwd|
 					
-					cmd = "#{bp_root}/support/build/_util/mkrepo.sh OURS3BUCKET OURS3PREFIX/ *.composer.json"
+					cmd = "S3_BUCKET=OURS3BUCKET S3_PREFIX=OURS3PREFIX/ #{bp_root}/support/build/_util/mkrepo.sh *.composer.json"
 					stdout, stderr, status = Open3.capture3("bash -c #{Shellwords.escape(cmd)}")
 				
 					expect(status.exitstatus).to eq(0), "mkrepo.sh failed, stdout: #{stdout}, stderr: #{stderr}"


### PR DESCRIPTION
`s5cmd` can execute operations in parallel, which will massively speed up our repo generation, syncing, and removal scripts:

Before (actual `mkrepo` step took **2 minutes 15 seconds**) and after (actual `mkrepo` step took **3 seconds**):
<img width="340" alt="Screenshot 2024-05-28 at 13 05 46" src="https://github.com/heroku/heroku-buildpack-php/assets/27900/c3743a94-c732-4694-b8df-3f694b8300f2">       ➡️  <img width="340" alt="Screenshot 2024-05-28 at 13 06 03" src="https://github.com/heroku/heroku-buildpack-php/assets/27900/d2eafb3c-e3be-4ccd-b231-3002a2d12a0b">

Before (actual `sync` dry-run step took **5 minutes 4 seconds**) and after (actual `sync` dry-run step took **4 seconds**):
<img width="360" alt="Screenshot 2024-05-23 at 16 34 29" src="https://github.com/heroku/heroku-buildpack-php/assets/27900/1732b365-19df-422c-ba97-4664ccd5e228">  ➡️  <img width="360" alt="Screenshot 2024-05-23 at 16 34 39" src="https://github.com/heroku/heroku-buildpack-php/assets/27900/1c08945f-d5a9-46ca-b876-e271634390c1">

GUS-W-15794884

---

For syncing, we now generate a "sync plan", from which operations that can be grouped together are then extracted, and executed in parallel using `s5cmd run`, in three groups:
 1. all copies of new/changed dist archives - if anything fails during these, a re-run of the sync will perform them again;
 1. all copies of new/changed manifests, as well as removals - if anything fails during these, only the failed ones will be performed again, including their dists;
 1. all dist archives of removed manifests - worst case, there will be some stray dist archives left behind, but nothing picks them up because their manifests are gone.

GUS-W-15794884

---

As the "sync plan" is now generated separately by a script, we can have some tests that assert the operations are correct, dist archive URL rewrites from source to destination bucket happen properly, etc.

GUS-W-15794893

---

There are now local source and destination dir options for `sync.sh`, which will use the given directory of `.composer.json` manifests, instead of downloading them from the source or destination bucket.

What we can now do is, upon removal, fetch all manifests from the repo, except the given list/wildcards of manifests to remove, and then tell `sync.sh` to use that filtered directory of `.composer.json` files as the local source directory for syncing.

This moves all of the sanity checks, file deletion, error handling, confirmation etc logic into `sync.sh`, and lets us drop most of the logic in `remove.sh`. In addition, the core "sync plan" code of `sync.sh` is also covered by tests, which now extend to `remove.sh`.

GUS-W-15794899

---

Finally, there is currently a bit of a bug in `remove.sh`: when removing all files from a repository (e.g. for certain cleanups, testing, etc), there are no more `.composer.json` files left behind that the code can match, and the subsequent call to `mkrepo.sh` to re-generate the updated repository fails (as there are no files to pass to it), instead of either producing an empty repository file, or removing the repository file altogether.

Instead, the tooling now detects this situation, and removes `packages.json` as well, so that repositories can be fully removed.

GUS-W-15838870