### PR TITLE
Platform tooling output touchups

### DIFF
--- a/.github/workflows/platform-remove.yml
+++ b/.github/workflows/platform-remove.yml
@@ -36,8 +36,8 @@ jobs:
       - name: Expand list of manifests to remove
         run: |
           echo '## Manifests input for removal' >> "$GITHUB_STEP_SUMMARY"
-          set -f
-          echo ${{inputs.manifests}} | xargs -n 1 echo - >> "$GITHUB_STEP_SUMMARY"
+          set -f # no expansion of globs to file names, we want to pass * straight on for S3 wildcard matching (but still expand curly braces)
+          printf -- '- `%s`\n' ${{inputs.manifests}} >> "$GITHUB_STEP_SUMMARY"
       - name: Restore cached Docker image
         id: restore-docker
         uses: actions/cache/restore@v4

--- a/.github/workflows/platform-sync.yml
+++ b/.github/workflows/platform-sync.yml
@@ -38,7 +38,7 @@ jobs:
           echo '## Stacks to sync' >> "$GITHUB_STEP_SUMMARY"
           set -o pipefail
           stacks=(${{ inputs.stack-heroku-20 == true && 'heroku-20' || ''}} ${{ inputs.stack-heroku-22 == true && 'heroku-22' || ''}})
-          printf "%s\n" "${stacks[@]}" | xargs -n1 echo -  >> "$GITHUB_STEP_SUMMARY"
+          printf -- "- %s\n" "${stacks[@]}" >> "$GITHUB_STEP_SUMMARY"
           echo -n "matrix=" >> "$GITHUB_OUTPUT"
           printf "%s\n" "${stacks[@]}" | jq -jcRn '[inputs|select(length>0)]' >> "$GITHUB_OUTPUT"
   docker-build:

--- a/support/build/_util/remove.sh
+++ b/support/build/_util/remove.sh
@@ -50,13 +50,10 @@ pushd "$manifests_tmp" > /dev/null
 
 echo "Fetching manifests, excluding given removals... " >&2
 s5cmd "${S5CMD_OPTIONS[@]}" cp ${S3_REGION:+--source-region "$S3_REGION"} "${excludes[@]}" "s3://${S3_BUCKET}/${S3_PREFIX}*.composer.json" "$manifests_tmp" || { echo -e "\nFailed to fetch manifests! See message above for errors." >&2; exit 1; }
-echo "...done, now performing a sync of the differences.
-" >&2
 
-# we now simply treat this as a sync of packages between two folders, passing sync.sh the local and the remote
+echo -e "\nNow performing a sync of the differences:\n" >&2
+
+# we now simply treat this as a sync of packages between two folders, passing sync.sh the local dir as source and the remote as destination
 # the "source" repository will have our matched manifests removed
 
 "${here}/sync.sh" -s "$manifests_tmp" "$S3_BUCKET" "$S3_PREFIX" "$S3_REGION" "$S3_BUCKET" "$S3_PREFIX" "$S3_REGION"
-
-echo "Removal complete.
-" >&2

--- a/support/build/_util/sync.sh
+++ b/support/build/_util/sync.sh
@@ -249,23 +249,23 @@ if [[ $localdst ]] || (( !${#run_manifests_cp[@]} && !${#run_manifests_rm[@]} ))
 	exit
 fi
 
-cat >&2 <<-EOF
-	WARNING: POTENTIALLY DESTRUCTIVE ACTION!
-	
-EOF
-
 (cd "$dst_tmp"; shopt -s nullglob; manifests=( *.composer.json ); (( ${#manifests[@]} < 1 )) ) && {
 	wipe=true
 	prompt="Are you sure you want to remove all packages from destination?"
 	cat >&2 <<-EOF
 		THE REMOVALS ABOVE WILL DELETE THIS REPOSITORY IN ITS ENTIRETY!
-		THIS REPOSITORY'S packages.json WOULD BE EMPTY, SO IT WILL BE REMOVED AS WELL!
+		THE RESULTING EMPTY packages.json WILL BE REMOVED AS WELL!
 		
 	EOF
 } || {
 	wipe=false
 	prompt="Are you sure you want to sync to destination & re-generate packages.json?"
 }
+
+cat >&2 <<-EOF
+	WARNING: POTENTIALLY DESTRUCTIVE ACTION!
+	
+EOF
 
 read -p "${prompt} [yN] " proceed
 


### PR DESCRIPTION
- when "parroting" the given input back to the user as a GHA step summary in `platform-remove.yml`, wrap the given input in backticks, so that e.g. `*` wildcards do not trigger Markdown formatting
- move the "this whole repo will be deleted" notice above the "WARNING: POTENTIALLY DESTRUCTIVE ACTION", so that it's visible in the GHA step summary output for `remove.sh` dry-runs
- shift a few newlines around in `remove.sh` and `sync.sh`, and touch up completion/abortion messages

With an input of `*` for `platform-remove.yml`, before (package list trimmed from HTML for screenshot):
<img width="585" alt="Screenshot 2024-05-30 at 15 31 45" src="https://github.com/heroku/heroku-buildpack-php/assets/27900/ac4a7da4-97cc-42c1-a4c9-131b0aa2ee95">
After:
<img width="585" alt="Screenshot 2024-05-30 at 15 30 23" src="https://github.com/heroku/heroku-buildpack-php/assets/27900/a23fc1c8-f92e-43ac-9ab0-424447d4d699">