### PR TITLE
Pre-heroku-24 cleanup

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -80,7 +80,7 @@ composer_lock_parse_error=$(
 
 # a bunch of sanity checks first
 if [[ -s "$COMPOSER" ]]; then
-	cat "$COMPOSER" | python -mjson.tool &> /dev/null || {
+	cat "$COMPOSER" | python3 -mjson.tool &> /dev/null || {
 		mcount "failures.composer_json.lint"
 		error <<-EOF
 			Basic validation for '$COMPOSER' failed!
@@ -98,7 +98,7 @@ if [[ -s "$COMPOSER" ]]; then
 		EOF
 	}
 	if [[ ! -f "$COMPOSER_LOCK" ]]; then
-		cat "$COMPOSER" | python -c 'import sys, json; sys.exit(bool(json.load(sys.stdin).get("require", {})))' 2> /dev/null || {
+		cat "$COMPOSER" | python3 -c 'import sys, json; sys.exit(bool(json.load(sys.stdin).get("require", {})))' 2> /dev/null || {
 			mcount "failures.composer_lock.missing"
 			error <<-EOF
 				No '$COMPOSER_LOCK' found!
@@ -130,7 +130,7 @@ if [[ -s "$COMPOSER" ]]; then
 			EOF
 		}
 	else
-		cat "$COMPOSER_LOCK" | python -mjson.tool &> /dev/null || {
+		cat "$COMPOSER_LOCK" | python3 -mjson.tool &> /dev/null || {
 			mcount "failures.composer_lock.lint"
 			error "$composer_lock_parse_error"
 		}
@@ -320,7 +320,7 @@ composer validate --no-plugins --no-check-publish --no-check-all --quiet "$COMPO
 }
 
 # if prefer-stable is false and minimum-stability is not stable, warn about potential unstable platform installs
-[[ ! -f "$COMPOSER_LOCK" ]] || minimum_stability=$(cat "$COMPOSER_LOCK" | python -c 'import sys, json; l = json.load(sys.stdin); print(l.get("minimum-stability")); sys.exit(l.get("minimum-stability", "stable") != "stable" and l.get("prefer-stable", False) == False);' 2> /dev/null) || {
+[[ ! -f "$COMPOSER_LOCK" ]] || minimum_stability=$(cat "$COMPOSER_LOCK" | python3 -c 'import sys, json; l = json.load(sys.stdin); print(l.get("minimum-stability")); sys.exit(l.get("minimum-stability", "stable") != "stable" and l.get("prefer-stable", False) == False);' 2> /dev/null) || {
 	possible_stabilities="dev, alpha, beta, or RC"
 	case $minimum_stability in
 		alpha)
@@ -670,7 +670,7 @@ unset COMPOSER_GITHUB_OAUTH_TOKEN
 
 # install dependencies unless composer.json is completely empty (in which case it'd talk to packagist.org which may be slow and is unnecessary)
 export_env_dir "$env_dir" '^[A-Z_][A-Z0-9_]*$' '^(HOME|PATH|GIT_DIR|CPATH|CPPATH|LD_PRELOAD|LIBRARY_PATH|LD_LIBRARY_PATH|STACK|REQUEST_ID|IFS|HEROKU_PHP_INSTALL_DEV|BPLOG_PREFIX|BUILDPACK_LOG_FILE|PHP_INI_SCAN_DIR)$'
-if cat "$COMPOSER" | python -c 'import sys,json; sys.exit(not json.load(sys.stdin));'; then
+if cat "$COMPOSER" | python3 -c 'import sys,json; sys.exit(not json.load(sys.stdin));'; then
 	install_log=$(mktemp -t heroku-buildpack-php-composer-install-log-XXXX)
 	composer install ${HEROKU_PHP_INSTALL_DEV-"--no-dev"} --prefer-dist --optimize-autoloader --no-progress --no-interaction 2>&1 | tee "$install_log" | indent || {
 		code=$?
@@ -728,7 +728,7 @@ fi
 # log number of installed dependencies
 mmeasure "dependencies.count" $(composer show --installed 2> /dev/null | wc -l)
 
-if cat "$COMPOSER" | python -c 'import sys,json; sys.exit("compile" not in json.load(sys.stdin).get("scripts", {}));'; then
+if cat "$COMPOSER" | python3 -c 'import sys,json; sys.exit("compile" not in json.load(sys.stdin).get("scripts", {}));'; then
 	status "Running 'composer compile'..."
 	composer run-script ${HEROKU_PHP_INSTALL_DEV-"--no-dev"} --no-interaction compile 2>&1 | indent || {
 		mcount "failures.compile_step"
@@ -756,15 +756,15 @@ status "Preparing runtime environment..."
 # TODO: warn if require-dev has the package using a different branch
 shopt -u dotglob # we don't want .git, .gitignore et al
 # figure out the package dir name to write to and copy to it
-hbpdir="$composer_vendordir/$(cat $bp_dir/composer.json | python -c 'import sys, json; print(json.load(sys.stdin)["name"])')"
+hbpdir="$composer_vendordir/$(cat $bp_dir/composer.json | python3 -c 'import sys, json; print(json.load(sys.stdin)["name"])')"
 mkdir -p "$build_dir/$hbpdir"
 cp -r "$bp_dir"/* "$build_dir/$hbpdir/"
 # make bin dir, just in case
 mkdir -p "$build_dir/$composer_bindir"
 # figure out shortest relative path from vendor/heroku/heroku-buildpack-php to vendor/bin (or whatever the bin dir is)
-relbin=$(python -c "import os.path; print(os.path.relpath('$hbpdir', '$composer_bindir'))")
+relbin=$(python3 -c "import os.path; print(os.path.relpath('$hbpdir', '$composer_bindir'))")
 # collect bin names from composer.json
-relbins=$(cat $bp_dir/composer.json | python -c 'from __future__ import print_function; import sys, json; { print(sys.argv[1]+"/"+bin) for bin in json.load(sys.stdin)["bin"] }' $relbin)
+relbins=$(cat $bp_dir/composer.json | python3 -c 'import sys, json; { print(sys.argv[1]+"/"+bin) for bin in json.load(sys.stdin)["bin"] }' $relbin)
 # link to bins
 cd $build_dir/$composer_bindir
 ln -fs $relbins .

--- a/bin/heroku-php-apache2
+++ b/bin/heroku-php-apache2
@@ -310,10 +310,11 @@ composer() {
 	# check if the composer binary is executable by PHP
 	if file --brief --dereference "$composer_bin" | grep -e "shell" -e "bash" > /dev/null ; then # newer versions of file return "data" for .phar
 		# run it directly; it's probably a bash script or similar (homebrew-php does this)
+		# disable interactive mode just in case our environment doesn't have that set (or 'composer config vendor-dir' will hang with a prompt if there is no composer.json in the cwd)
 		# re-set COMPOSER_AUTH to ensure a malformed `heroku config:set` will not cause immediate outage
-		COMPOSER_AUTH= "$composer_bin" "$@"
+		COMPOSER_NO_INTERACTION=1 COMPOSER_AUTH= "$composer_bin" "$@"
 	else
-		COMPOSER_AUTH= php "$composer_bin" "$@"
+		COMPOSER_NO_INTERACTION=1 COMPOSER_AUTH= php "$composer_bin" "$@"
 	fi
 }
 # these exports are used in default web server configs to lock down access to composer directories

--- a/bin/heroku-php-apache2
+++ b/bin/heroku-php-apache2
@@ -10,11 +10,11 @@ shopt -s extglob
 shopt -s nullglob
 
 if ! type -p "realpath" > /dev/null; then
-	# macOS doesn't have realpath
+	# old macOSes don't have realpath
 	# readlink is not an option because BSD readlink does not have the GNU -f option
 	# must be a function so subshells, including $(…), can use it
 	realpath() {
-		python -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$@"
+		python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$@"
 	}
 fi
 

--- a/bin/heroku-php-nginx
+++ b/bin/heroku-php-nginx
@@ -308,10 +308,11 @@ composer() {
 	# check if the composer binary is executable by PHP
 	if file --brief --dereference "$composer_bin" | grep -e "shell" -e "bash" > /dev/null ; then # newer versions of file return "data" for .phar
 		# run it directly; it's probably a bash script or similar (homebrew-php does this)
+		# disable interactive mode just in case our environment doesn't have that set (or 'composer config vendor-dir' will hang with a prompt if there is no composer.json in the cwd)
 		# re-set COMPOSER_AUTH to ensure a malformed `heroku config:set` will not cause immediate outage
-		COMPOSER_AUTH= "$composer_bin" "$@"
+		COMPOSER_NO_INTERACTION=1 COMPOSER_AUTH= "$composer_bin" "$@"
 	else
-		COMPOSER_AUTH= php "$composer_bin" "$@"
+		COMPOSER_NO_INTERACTION=1 COMPOSER_AUTH= php "$composer_bin" "$@"
 	fi
 }
 # these exports are used in default web server configs to lock down access to composer directories

--- a/bin/heroku-php-nginx
+++ b/bin/heroku-php-nginx
@@ -10,11 +10,11 @@ shopt -s extglob
 shopt -s nullglob
 
 if ! type -p "realpath" > /dev/null; then
-	# macOS doesn't have realpath
+	# old macOSes don't have realpath
 	# readlink is not an option because BSD readlink does not have the GNU -f option
 	# must be a function so subshells, including $(…), can use it
 	realpath() {
-		python -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$@"
+		python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$@"
 	}
 fi
 

--- a/test/spec/bugs_spec.rb
+++ b/test/spec/bugs_spec.rb
@@ -34,7 +34,7 @@ describe "A PHP application" do
 		context "because the buildpack ran twice" do
 			it "fails the build" do
 				buildpacks = [
-					"heroku/php",
+					:default,
 					:default
 				]
 				app = new_app_with_stack_and_platrepo("test/fixtures/default", buildpacks: buildpacks, allow_failure: true)

--- a/test/spec/platform_spec.rb
+++ b/test/spec/platform_spec.rb
@@ -179,7 +179,7 @@ describe "The PHP Platform Installer" do
 				bp_root = [".."].cycle("#{manifest_fixtures_subdir}/#{testcase}".count("/")+1).to_a.join("/") # right "../.." sequence to get us back to the root of the buildpack
 				Dir.chdir("#{manifest_fixtures_subdir}/#{testcase}") do |cwd|
 					cmd = File.read("ENV") # any env vars for the test (manifest.py needs STACK, S3_BUCKET, S3_PREFIX, TIME)
-					cmd << " python #{bp_root}/support/build/_util/include/manifest.py "
+					cmd << " python3 #{bp_root}/support/build/_util/include/manifest.py "
 					cmd << File.read("ARGS")
 					stdout, stderr, status = Open3.capture3("bash -c #{Shellwords.escape(cmd)}")
 				


### PR DESCRIPTION
Just three little fixes:
- explicitly set `COMPOSER_NO_INTERACTION=1` inside boot scripts (this is only relevant when testing them locally, as the buildpack sets this during builds and runtime)
- use `python3` throughout for invocation of Python, since that's what most environments now have
- adjust "fail build if buildpack ran twice" test to use the actual currently tested branch twice, and not `heroku/php` once, which might not succeed a build on e.g. a new stack