### PR TITLE
Add the proper Nginx mime type for mjs files

### DIFF
--- a/conf/nginx/mime.types
+++ b/conf/nginx/mime.types
@@ -5,7 +5,7 @@ types {
     text/xml                                         xml;
     image/gif                                        gif;
     image/jpeg                                       jpeg jpg;
-    application/javascript                           js;
+    application/javascript                           js mjs;
     application/atom+xml                             atom;
     application/rss+xml                              rss;
 


### PR DESCRIPTION
The HTML spec requires getting a content-type of `application/javascript` for ES modules, rejecting them otherwise. And browsers are respecting this spec.
As it is common to use the `.mjs` for ES modules (because of the convention introduced in node.js, which has also been adopted by some frontend packages when they want to start shipping a version using modules), having the right mime types for it in the nginx config is a must-have IMO.

This matches the configuration used in the [h5bp nginx configuration](https://github.com/h5bp/server-configs-nginx/blob/242badb6eaffa28cefc5d100d2826bf369f3adb1/mime.types#L22)
