### PR TITLE
Nginx MIME type updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### CHG
 
 - Sync Nginx `mime.types` config with upstream to add `application/wasm` for `.wasm` and `image/avif` for `.avif` files (#738) [David Zuelke]
+- Add MIME type `text/javascript` for `.mjs` files to Nginx config as per RFC 9239; `application/javascript` remains for `.js` from upstream default `mime.types` (#737) [David Zuelke]
 
 ## [v253] - 2024-06-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### CHG
+
+- Sync Nginx `mime.types` config with upstream to add `application/wasm` for `.wasm` and `image/avif` for `.avif` files (#738) [David Zuelke]
 
 ## [v253] - 2024-06-13
 

--- a/conf/nginx/heroku.conf.php
+++ b/conf/nginx/heroku.conf.php
@@ -1,5 +1,6 @@
 http {
 	include       mime.types;
+	include       heroku.types;
 	default_type  application/octet-stream;
 
 	#log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '

--- a/conf/nginx/heroku.types
+++ b/conf/nginx/heroku.types
@@ -1,0 +1,9 @@
+# this file is separate from mime.types to allow easier syncing with upstream
+types {
+	# mime.types still defines "application/javascript" for "js"
+	# We only define "mjs" here to avoid duplicate extension warnings on startup.
+	# In compliance with RFC 9239, we are using "text/javascript" for "mjs"
+	# If and when upsteam ever update their default config, we can drop this.
+	# Also see https://trac.nginx.org/nginx/ticket/2216
+	text/javascript mjs;
+}

--- a/conf/nginx/mime.types
+++ b/conf/nginx/mime.types
@@ -15,6 +15,7 @@ types {
     text/vnd.wap.wml                                 wml;
     text/x-component                                 htc;
 
+    image/avif                                       avif;
     image/png                                        png;
     image/svg+xml                                    svg svgz;
     image/tiff                                       tif tiff;
@@ -51,6 +52,7 @@ types {
     application/vnd.openxmlformats-officedocument.wordprocessingml.document
                                                      docx;
     application/vnd.wap.wmlc                         wmlc;
+    application/wasm                                 wasm;
     application/x-7z-compressed                      7z;
     application/x-cocoa                              cco;
     application/x-java-archive-diff                  jardiff;

--- a/test/spec/nginx_spec.rb
+++ b/test/spec/nginx_spec.rb
@@ -1,35 +1,44 @@
 require_relative "spec_helper"
 
-describe "A PHP application" do
-	it "installs a recent stable nginx with OpenSSL support and expected modules" do
-		new_app_with_stack_and_platrepo('test/fixtures/default').deploy do |app|
-			nginx = app.output.match(/- nginx \((\d+\.\d*[02468]\.\d+)/)
-			expect(nginx).not_to be_nil, "expected nginx install line in build output"
-			expect(Gem::Dependency.new('nginx', '~> 1.14').match?('nginx', nginx[1])).to be == true, "expected nginx version compatible with selector '~> 1.14' but got #{nginx[1]}"
-			retry_until retry: 3, sleep: 5 do
-				nginx_v = app.run('nginx -V')
-				expect(nginx_v).to match(/^built with OpenSSL/)
-				expect(nginx_v).to match(/--with-http_auth_request_module/)
-				expect(nginx_v).to match(/--with-http_realip_module/)
-				expect(nginx_v).to match(/--with-http_ssl_module/)
-				expect(nginx_v).to match(/--with-http_stub_status_module/)
-			end
-		end
-	end
-	it "allows access to /.well-known/ with Nginx" do
-		new_app_with_stack_and_platrepo('test/fixtures/default').tap do |app|
+describe "A PHP application using Nginx" do
+	before(:all) do
+		@app = new_app_with_stack_and_platrepo('test/fixtures/default').tap do |app|
 			app.before_deploy(:append) do
 				FileUtils.mkdir_p(".well-known/acme")
-				File.open(".well-known/acme/foo", "w+") do |f|
-					f.write 'bar'
-				end
-				File.open("Procfile", "w+") do |f|
-					f.write 'web: heroku-php-nginx'
-				end
-			end
-			app.deploy do |app|
-				expect(successful_body(app, path: '/.well-known/acme/foo')).to eq 'bar'
+				File.write(".well-known/acme/foo", "bar")
+				
+				FileUtils.touch("test.mjs")
+				
+				File.write("Procfile", "web: heroku-php-nginx")
 			end
 		end
+		
+		@app.deploy
+	end
+	
+	after(:all) do
+		@app.teardown!
+	end
+	
+	it "gets a recent stable Nginx with OpenSSL support and expected modules" do
+		nginx = @app.output.match(/- nginx \((\d+\.\d*[02468]\.\d+)/)
+		expect(nginx).not_to be_nil, "expected nginx install line in build output"
+		expect(Gem::Dependency.new('nginx', '~> 1.14').match?('nginx', nginx[1])).to be == true, "expected nginx version compatible with selector '~> 1.14' but got #{nginx[1]}"
+		retry_until retry: 3, sleep: 5 do
+			nginx_v = @app.run('nginx -V')
+			expect(nginx_v).to match(/^built with OpenSSL/)
+			expect(nginx_v).to match(/--with-http_auth_request_module/)
+			expect(nginx_v).to match(/--with-http_realip_module/)
+			expect(nginx_v).to match(/--with-http_ssl_module/)
+			expect(nginx_v).to match(/--with-http_stub_status_module/)
+		end
+	end
+	
+	it "allows access to /.well-known/" do
+		expect(successful_body(@app, path: '/.well-known/acme/foo')).to eq 'bar'
+	end
+	
+	it "serves a .mjs file with MIME type text/javascript" do
+		expect(successful_request(@app, path: '/test.mjs').get_header('Content-Type')).to eq 'text/javascript'
 	end
 end

--- a/test/spec/spec_helper.rb
+++ b/test/spec/spec_helper.rb
@@ -34,12 +34,16 @@ RSpec.configure do |config|
 	end
 end
 
-def successful_body(app, options = {})
+def successful_request(app, options = {})
 	retry_limit = options[:retry_limit] || 5
 	retry_interval = options[:retry_interval] || 2
 	path = options[:path] ? "/#{options[:path]}" : ''
 	web_url = app.platform_api.app.info(app.name).fetch("web_url")
-	Excon.get("#{web_url}#{path}", :idempotent => true, :expects => 200, :retry_limit => retry_limit, :retry_interval => retry_interval).body
+	Excon.get("#{web_url}#{path}", :idempotent => true, :expects => 200, :retry_limit => retry_limit, :retry_interval => retry_interval)
+end
+
+def successful_body(app, options = {})
+	successful_request(app, options).body
 end
 
 def expect_exit(expect: :to, operator: :eq, code: 0)

--- a/test/var/log/parallel_runtime_rspec.heroku-20.log
+++ b/test/var/log/parallel_runtime_rspec.heroku-20.log
@@ -9,7 +9,7 @@ test/spec/composer-2_spec.rb:90
 test/spec/devcenter_spec.rb:5
 test/spec/httpd_spec.rb:18
 test/spec/newrelic_spec.rb:115
-test/spec/nginx_spec.rb:49
+test/spec/nginx_spec.rb:25
 test/spec/php-7.3_base_spec.rb:30
 test/spec/php-7.3_boot-apache2_spec.rb:65
 test/spec/php-7.3_boot-nginx_spec.rb:55

--- a/test/var/log/parallel_runtime_rspec.heroku-22.log
+++ b/test/var/log/parallel_runtime_rspec.heroku-22.log
@@ -8,7 +8,7 @@ test/spec/composer-2_spec.rb:90
 test/spec/devcenter_spec.rb:5
 test/spec/httpd_spec.rb:18
 test/spec/newrelic_spec.rb:115
-test/spec/nginx_spec.rb:49
+test/spec/nginx_spec.rb:25
 test/spec/php-8.1_base_spec.rb:30
 test/spec/php-8.1_boot-apache2_spec.rb:65
 test/spec/php-8.1_boot-nginx_spec.rb:55

--- a/test/var/log/parallel_runtime_rspec.heroku-24.log
+++ b/test/var/log/parallel_runtime_rspec.heroku-24.log
@@ -8,7 +8,7 @@ test/spec/composer-2_spec.rb:90
 test/spec/devcenter_spec.rb:5
 test/spec/httpd_spec.rb:18
 test/spec/newrelic_spec.rb:115
-test/spec/nginx_spec.rb:49
+test/spec/nginx_spec.rb:25
 test/spec/php-8.2_base_spec.rb:30
 test/spec/php-8.2_boot-apache2_spec.rb:65
 test/spec/php-8.2_boot-nginx_spec.rb:55


### PR DESCRIPTION
Syncs `mime.types` with upstream to add `application/wasm` for `.wasm` and `image/avif` for `.avif` files.

Closes #738

Adds RFC 9239 `text/javascript` for `.mjs` files in a separate config (to keep `mime.types` "original"). The normal `.js` extension remains on `application/javascript` as defined in the OEM `mime.types` config (also see https://trac.nginx.org/nginx/ticket/2216).

Closes #737

/cc @stof

GUS-W-16142337
