### PR TITLE
Apache HTTP touch-ups for Dev Center changelog generator

### DIFF
--- a/support/devcenter/changelog.twig
+++ b/support/devcenter/changelog.twig
@@ -28,7 +28,7 @@ The following new [Composer versions](https://devcenter.heroku.com/articles/php-
 {% endif -%}
 
 {% if apache %}
-The Apache HTTP [web server](https://devcenter.heroku.com/articles/php-support#web-servers) has been updated to version [{{apache.version}}](https://downloads.apache.org/httpd/CHANGES_{{apache.version}}).
+The Apache HTTP [web server](https://devcenter.heroku.com/articles/php-support#web-servers) has been updated to version [{{apache.version}}](https://archive.apache.org/dist/httpd/CHANGES_{{apache.version}}).
 
 {% endif -%}
 

--- a/support/devcenter/changelog.twig
+++ b/support/devcenter/changelog.twig
@@ -28,7 +28,7 @@ The following new [Composer versions](https://devcenter.heroku.com/articles/php-
 {% endif -%}
 
 {% if apache %}
-The Apache HTTPD [web server](https://devcenter.heroku.com/articles/php-support#web-servers) has been updated to version [{{apache.version}}](https://downloads.apache.org/httpd/CHANGES_{{apache.version}}).
+The Apache HTTP [web server](https://devcenter.heroku.com/articles/php-support#web-servers) has been updated to version [{{apache.version}}](https://downloads.apache.org/httpd/CHANGES_{{apache.version}}).
 
 {% endif -%}
 

--- a/test/fixtures/devcenter/changelog/changelog.md
+++ b/test/fixtures/devcenter/changelog/changelog.md
@@ -17,7 +17,7 @@ The following new [Composer versions](https://devcenter.heroku.com/articles/php-
 
 - [Composer 2.8.0](https://getcomposer.org/changelog/2.8.0)
 
-The Apache HTTP [web server](https://devcenter.heroku.com/articles/php-support#web-servers) has been updated to version [2.4.4](https://downloads.apache.org/httpd/CHANGES_2.4.4).
+The Apache HTTP [web server](https://devcenter.heroku.com/articles/php-support#web-servers) has been updated to version [2.4.4](https://archive.apache.org/dist/httpd/CHANGES_2.4.4).
 
 The Nginx [web server](https://devcenter.heroku.com/articles/php-support#web-servers) has been updated to version [2.9.0](https://nginx.org/en/CHANGES-2.9).
 

--- a/test/fixtures/devcenter/changelog/changelog.md
+++ b/test/fixtures/devcenter/changelog/changelog.md
@@ -17,7 +17,7 @@ The following new [Composer versions](https://devcenter.heroku.com/articles/php-
 
 - [Composer 2.8.0](https://getcomposer.org/changelog/2.8.0)
 
-The Apache HTTPD [web server](https://devcenter.heroku.com/articles/php-support#web-servers) has been updated to version [2.4.4](https://downloads.apache.org/httpd/CHANGES_2.4.4).
+The Apache HTTP [web server](https://devcenter.heroku.com/articles/php-support#web-servers) has been updated to version [2.4.4](https://downloads.apache.org/httpd/CHANGES_2.4.4).
 
 The Nginx [web server](https://devcenter.heroku.com/articles/php-support#web-servers) has been updated to version [2.9.0](https://nginx.org/en/CHANGES-2.9).
 


### PR DESCRIPTION
Call it "Apache HTTP" like upstream does, and link to archive.apache.org for `CHANGES` files, as only those links are stable.