### PR TITLE
Link to exts in generated Dev Center Changelog

### DIFF
--- a/support/devcenter/changelog.twig
+++ b/support/devcenter/changelog.twig
@@ -4,7 +4,7 @@
 The following new [PHP runtime versions](https://devcenter.heroku.com/articles/php-support#available-versions) are now available:
 
 {% for php in phps %}
-- [PHP {{php.version}}](https://www.php.net/ChangeLog-{{php.series}}.php#{{php.version}})
+- [PHP {{php.version}}]({{php.link|raw}})
 {% endfor %}
 
 {% endif -%}
@@ -13,7 +13,11 @@ The following new [PHP runtime versions](https://devcenter.heroku.com/articles/p
 The following [PHP extensions](https://devcenter.heroku.com/articles/php-support#extensions) have been added or updated:
 
 {% for extension in extensions %}
+{% if extension.link %}
+- [`{{extension.name}}` {{extension.version}}]({{extension.link|raw}})
+{% else %}
 - `{{extension.name}}` {{extension.version}}
+{% endif -%}
 {% endfor %}
 
 {% endif -%}
@@ -22,18 +26,18 @@ The following [PHP extensions](https://devcenter.heroku.com/articles/php-support
 The following new [Composer versions](https://devcenter.heroku.com/articles/php-support#available-composer-versions) are now available [for use during builds](https://devcenter.heroku.com/articles/php-support#installation-of-dependencies):
 
 {% for composer in composers %}
-- [Composer {{composer.version}}](https://getcomposer.org/changelog/{{composer.version}})
+- [Composer {{composer.version}}]({{composer.link|raw}})
 {% endfor %}
 
 {% endif -%}
 
 {% if apache %}
-The Apache HTTP [web server](https://devcenter.heroku.com/articles/php-support#web-servers) has been updated to version [{{apache.version}}](https://archive.apache.org/dist/httpd/CHANGES_{{apache.version}}).
+The Apache HTTP [web server](https://devcenter.heroku.com/articles/php-support#web-servers) has been updated to version [{{apache.version}}]({{apache.link|raw}}).
 
 {% endif -%}
 
 {% if nginx %}
-The Nginx [web server](https://devcenter.heroku.com/articles/php-support#web-servers) has been updated to version [{{nginx.version}}](https://nginx.org/en/CHANGES-{{nginx.series}}).
+The Nginx [web server](https://devcenter.heroku.com/articles/php-support#web-servers) has been updated to version [{{nginx.version}}]({{nginx.link|raw}}).
 
 {% endif -%}
 
@@ -43,5 +47,5 @@ The `blackfire` CLI agent program used by `ext-blackfire` has been updated to ve
 {% endif -%}
 
 {% for library in libraries %}
-The `{{library.name}}` library has been updated to version {{library.version}}.
+The `{{library.name}}` library has been updated to version {% if library.link %}[{{library.version}}]({{library.link|raw}}){% else %}{{library.version}}{% endif -%}.
 {% endfor %}

--- a/test/fixtures/devcenter/changelog/changelog.md
+++ b/test/fixtures/devcenter/changelog/changelog.md
@@ -7,11 +7,12 @@ The following new [PHP runtime versions](https://devcenter.heroku.com/articles/p
 
 The following [PHP extensions](https://devcenter.heroku.com/articles/php-support#extensions) have been added or updated:
 
-- `ext-amqp` 1.9.99
-- `ext-amqp` 2.1.2
+- [`ext-amqp` 1.9.99](https://pecl.php.net/package-changelog.php?package=amqp&release=1.9.99)
+- [`ext-amqp` 2.1.2](https://pecl.php.net/package-changelog.php?package=amqp&release=2.1.2)
 - `ext-blackfire` 1.92.8
-- `ext-event` 3.1.1
-- `ext-phalcon` 5.6.0
+- [`ext-event` 3.1.1](https://pecl.php.net/package-changelog.php?package=event&release=3.1.1)
+- [`ext-newrelic` 11.0.0.13](https://docs.newrelic.com/docs/release-notes/agent-release-notes/php-release-notes/php-agent-11-0-0-13/)
+- [`ext-phalcon` 5.6.0](https://pecl.php.net/package-changelog.php?package=phalcon&release=5.6.0)
 
 The following new [Composer versions](https://devcenter.heroku.com/articles/php-support#available-composer-versions) are now available [for use during builds](https://devcenter.heroku.com/articles/php-support#installation-of-dependencies):
 
@@ -24,4 +25,4 @@ The Nginx [web server](https://devcenter.heroku.com/articles/php-support#web-ser
 The `blackfire` CLI agent program used by `ext-blackfire` has been updated to version 2.24.4.
 
 The `libcassandra` library has been updated to version 1.2.3.
-The `librdkafka` library has been updated to version 1.9.1.
+The `librdkafka` library has been updated to version [1.9.1](https://github.com/confluentinc/librdkafka/releases/tag/v1.9.1).

--- a/test/fixtures/devcenter/changelog/sync.log
+++ b/test/fixtures/devcenter/changelog/sync.log
@@ -22,6 +22,12 @@ The following packages will be ADDED
   - ext-event-3.1.1_php-8.1
   - ext-event-3.1.1_php-8.2
   - ext-event-3.1.1_php-8.3
+  - ext-newrelic-11.0.0.13_php-7.3
+  - ext-newrelic-11.0.0.13_php-7.4
+  - ext-newrelic-11.0.0.13_php-8.0
+  - ext-newrelic-11.0.0.13_php-8.1
+  - ext-newrelic-11.0.0.13_php-8.2
+  - ext-newrelic-11.0.0.13_php-8.3
   - ext-phalcon-5.6.0_php-8.0
   - ext-phalcon-5.6.0_php-8.1
   - ext-phalcon-5.6.0_php-8.2
@@ -132,6 +138,9 @@ The following packages will be ADDED
   - ext-event-3.1.1_php-8.1
   - ext-event-3.1.1_php-8.2
   - ext-event-3.1.1_php-8.3
+  - ext-newrelic-11.0.0.13_php-8.1
+  - ext-newrelic-11.0.0.13_php-8.2
+  - ext-newrelic-11.0.0.13_php-8.3
   - ext-phalcon-5.6.0_php-8.1
   - ext-phalcon-5.6.0_php-8.2
   - ext-phalcon-5.6.0_php-8.3


### PR DESCRIPTION
When generating the changelog, we currently link to update notes for PHP, Composer, Apache, and Nginx, but we can do the same for most extensions.

Blackfire doesn't have a public changelog, New Relic's is on their site, and all others are from PECL.

We can also link to librdkafka release info on GH; libcassandra is irrelevant because the extension is EOL and we don't update it anymore.

GUS-W-16626388