### PR TITLE
Update PHP version support info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### CHG
+
+- Update internal PHP EOL info to align with 2024 updates laid out in https://wiki.php.net/rfc/release_cycle_update [David Zuelke]
 
 ## [v258] - 2024-10-31
 

--- a/bin/util/eol.php
+++ b/bin/util/eol.php
@@ -2,6 +2,7 @@
 
 $eol = array(
 	// security fixes EOL and full EOL dates
+	// https://www.php.net/supported-versions.php
 	"5.5" => array("2015-07-21", "2016-07-21"),
 	"5.6" => array("2017-01-19", "2018-12-31"),
 	"7.0" => array("2017-12-03", "2018-12-03"),
@@ -10,9 +11,9 @@ $eol = array(
 	"7.3" => array("2020-12-06", "2021-12-06"),
 	"7.4" => array("2021-11-28", "2022-11-28"),
 	"8.0" => array("2022-11-26", "2023-11-26"),
-	"8.1" => array("2023-11-25", "2024-11-25"),
-	"8.2" => array("2024-12-08", "2025-12-08"),
-	"8.3" => array("2025-11-23", "2026-11-23"),
+	"8.1" => array("2023-11-25", "2025-12-31"),
+	"8.2" => array("2024-12-31", "2026-12-31"),
+	"8.3" => array("2025-12-31", "2027-12-31"),
 );
 
 if(basename(__FILE__) != basename($_SERVER["PHP_SELF"])) return $eol; // we're being included, just return the data


### PR DESCRIPTION
The dates for bug fix and security releases were streamlined earlier this year, and security fixes were extended by another year: https://wiki.php.net/rfc/release_cycle_update

PHP 8.1-8.3 all get an extra year of security fixes (until Dec 31), while 8.2 and 8.3 also get their bug fix windows extended until the end of their respective previously defined years: https://www.php.net/supported-versions.php

GUS-W-17226457