### PR TITLE
Work around Bash buffering bug causing test failures

### DIFF
--- a/test/utils/waitforit.sh
+++ b/test/utils/waitforit.sh
@@ -55,8 +55,9 @@ duration=$1; shift
 text=$1; shift
 
 pipeout=
-# check if stdout is a pipeline (we can't -p /dev/stdout, so a TTY check on FD 1 is the next closest thing), in which case we'll behave differently
-[[ -t 1 ]] || pipeout=1
+# check if stdout is a pipeline, in which case we'll behave differently (another program can "attach" to us and execute something after a match)
+# we use -p on FD 1 so that redirecting our output to a file does not change behavior
+[[ -p /proc/$$/fd/1 ]] && pipeout=1
 
 if [[ $pipeout ]]; then
 	grepargs="-m1"


### PR DESCRIPTION
The boot tests run several iterations inside a single `heroku run`, as this drastically reduces the overall time taken for tests.

Some Bash 5.0 bug (it seems to happen only on heroku-20) causes output from a command (that is still running through a `tee` process substitution) to arrive a bit after the next `echo` statement, and as a result, sometimes, the last line of a delimited chunk is not the exit status, but output from the program, causing the test to fail.

So we just write outputs to files, and `cat` them together at the end.

GUS-W-17294876