### PR TITLE
bump heroku_hatchet to address a heroku run timeout issue

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/heroku/hatchet.git
-  revision: 69e268f694acd5876ff47810bdbd8467b35f8249
+  revision: 4dff977ab2cd0db87230c448503b1472d369ba37
   branch: timeouts-etc
   specs:
     heroku_hatchet (8.0.4)
@@ -30,7 +30,7 @@ GEM
     parallel (1.26.3)
     parallel_tests (5.1.0)
       parallel
-    platform-api (3.7.0)
+    platform-api (3.8.0)
       heroics (~> 0.1.1)
       moneta (~> 1.0.0)
       rate_throttle_client (~> 0.1.0)


### PR DESCRIPTION
Tests have recently (on occasion) been hanging for 60+ minutes (until the Heroku CLI timed out); as it turns out, the logic in Hatchet that terminates the run after a given timeout did not kick in correctly.

Fixed by bumping to newer revision that contains fixes for this (https://github.com/heroku/hatchet/commit/8918f5ecddf3b4c9068e32820fbe54dfb31682d3 and https://github.com/heroku/hatchet/commit/9d66c48502f0d11d705babfbc1bccf9f4c084046).

GUS-W-18270382