### PR TITLE
Human-readable "display output" to alternate FD inside installer plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ env:
   HATCHET_BUILDPACK_BRANCH: ${{ github.head_ref || github.ref_name }}
   HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
   HEROKU_API_USER: ${{ secrets.HEROKU_API_USER }}
+  GIT_HTTP_LOW_SPEED_LIMIT: 1000
+  GIT_HTTP_LOW_SPEED_TIME: 60
 
 jobs:
   integration-test:

--- a/bin/compile
+++ b/bin/compile
@@ -429,8 +429,12 @@ status "Installing platform packages..."
 export export_file_path=$bp_dir/export
 export profile_dir_path=$build_dir/.profile.d
 export providedextensionslog_file_path=$(mktemp -t "provided-extensions.log.XXXXXX" -u)
-# grep and sed in a subshell with || true, or a failing grep match will cause the exit code to be 1 if "composer install" fails with code 2
-if composer install -d "$build_dir/.heroku/php" ${HEROKU_PHP_INSTALL_DEV-"--no-dev"} 2>&1 | tee $build_dir/.heroku/php/install.log | ( grep --line-buffered -E '^  - (Instal|Enab)ling heroku-sys/' | sed -u -E -e 's/^  - (Instal|Enab)ling /- /' -e 's/heroku-sys\///g' || true ) | indent; then
+# we make a new file descriptor for the installer plugin to log "human readable" display output to, duplicated to stdout (via indent)
+exec {PHP_PLATFORM_INSTALLER_DISPLAY_OUTPUT_FDNO}> >(indent)
+# the installer picks up the FD number in this env var, and writes a "display output" log to it
+# meanwhile, the "raw" output of 'composer install' goes to install.log in case we need it later
+export PHP_PLATFORM_INSTALLER_DISPLAY_OUTPUT_FDNO
+if composer install -d "$build_dir/.heroku/php" ${HEROKU_PHP_INSTALL_DEV-"--no-dev"} > $build_dir/.heroku/php/install.log 2>&1; then
 	:
 else
 	code=$?
@@ -506,6 +510,9 @@ else
 	EOF
 fi
 
+# close display output FD (we make new ones for each iteration next)
+exec {PHP_PLATFORM_INSTALLER_DISPLAY_OUTPUT_FDNO}>&-
+
 export -n providedextensionslog_file_path # export no longer needed
 if [[ -s "$providedextensionslog_file_path" ]]; then
 	notice_inline "detected userland polyfill packages for PHP extensions"
@@ -523,9 +530,11 @@ if [[ -s "$providedextensionslog_file_path" ]]; then
 			ext_name=${ext_package#"heroku-sys/"} # no "heroku-sys/" prefix for human output
 			echo -n "- ${ext_name}... " | indent
 			# run a `composer require`, confined to the package we're attempting, allowing any version
-			# we're appending to install.log using tee, and using the same grep/sed filtering of packages as for regular installs
-			# we're letting sed begin the line with a \r character, so that the above `echo -n` gets overwritten
-			if composer require -d "$build_dir/.heroku/php" "${ext_package}.native:*" 2>&1 | tee -a $build_dir/.heroku/php/install.log | ( grep --line-buffered -E '^  - (Instal|Enab)ling heroku-sys/' | sed -u -E -e 's/^  - (Instal|Enab)ling /- /' -e 's/heroku-sys\///g' || true ) | tee "$current_install_log" | indent "" $'\r       '; then
+			# we're appending to install.log using tee, and using another new "display output" FD to redirect to a new single-step log (tee truncates for us)
+			# this log is checked later to see if a package install actually happened, or if it was already enabled (since both exit status 0)
+			# we're letting the indents begin the line with a \r character, so that the above `echo -n` gets overwritten
+			exec {PHP_PLATFORM_INSTALLER_DISPLAY_OUTPUT_FDNO}> >(tee "$current_install_log" | indent "" $'\r       ')
+			if composer require -d "$build_dir/.heroku/php" "${ext_package}.native:*" >> $build_dir/.heroku/php/install.log 2>&1; then
 				# package added successfully
 				[[ -s "$current_install_log" ]] || { echo -e "- ${ext_name} (already enabled)" | indent "" $'\r       '; } # if nothing was actually installed above, that means the dependency was already satisfied (i.e. extension is statically built into PHP); we need to echo something to that effect
 			else
@@ -533,10 +542,14 @@ if [[ -s "$providedextensionslog_file_path" ]]; then
 				echo -n -e "\r" # reset the line
 				notice_inline "no suitable native version of ${ext_name} available"
 			fi
+			exec {PHP_PLATFORM_INSTALLER_DISPLAY_OUTPUT_FDNO}>&-
 		done
 	done {fd_num}< "$providedextensionslog_file_path" # use bash 4.1+ automatic file descriptor allocation (better than hardcoding e.g. "3<"), otherwise this loop's stdin (the lines of the file) will be consumed by programs called inside the loop
 	rm "$current_install_log"
+	exec {fd_num}>&-
 fi
+
+unset PHP_PLATFORM_INSTALLER_DISPLAY_OUTPUT_FDNO
 
 # log number of installed platform packages
 mmeasure "platform.count" $(composer show -d "$build_dir/.heroku/php" --installed "heroku-sys/*" 2> /dev/null | wc -l)

--- a/support/installer/composer.json
+++ b/support/installer/composer.json
@@ -1,7 +1,7 @@
 {
 	"type": "composer-plugin",
 	"name": "heroku/installer-plugin",
-	"version": "1.7.2",
+	"version": "1.7.3",
 	"autoload": {
 		"psr-4": {
 			"Heroku\\Buildpack\\PHP\\": "src/"

--- a/support/installer/src/ComposerInstaller.php
+++ b/support/installer/src/ComposerInstaller.php
@@ -13,7 +13,12 @@ class ComposerInstaller extends LibraryInstaller
 		// we return the cwd here (sine we get invoked in the destination base directory); the Downloader takes care of the "merging" part by extracting packages into the existing structure
 		return realpath('./');
 	}
-
+	
+	public static function formatHerokuSysName(string $name): string
+	{
+		return sscanf($name, "heroku-sys/%s")[0] ?? $name;
+	}
+	
 	/**
 	 * {@inheritDoc}
 	 */

--- a/support/installer/src/Downloader.php
+++ b/support/installer/src/Downloader.php
@@ -7,12 +7,23 @@ use Composer\IO\IOInterface;
 use Composer\Config;
 use Composer\EventDispatcher\EventDispatcher;
 use Composer\Cache;
+use Composer\DependencyResolver\Operation\InstallOperation;
+use Composer\Util\Filesystem;
+use Composer\Util\HttpDownloader;
 use Composer\Util\ProcessExecutor;
 use Composer\Package\PackageInterface;
 use React\Promise\PromiseInterface;
 
 class Downloader extends TarDownloader
 {
+	protected $displayIo;
+	
+	public function __construct(IOInterface $io, IOInterface $displayIo, Config $config, HttpDownloader $httpDownloader, ?EventDispatcher $eventDispatcher = null, ?Cache $cache = null, ?Filesystem $filesystem = null, ?ProcessExecutor $process = null)
+	{
+		$this->displayIo = $displayIo;
+		return parent::__construct($io, $config, $httpDownloader, $eventDispatcher, $cache, $filesystem, $process);
+	}
+	
 	// extract using workarounds for TarDownloader and ArchiveDownloader behavior
 	protected function extract(PackageInterface $package, string $file, string $path): PromiseInterface
 	{
@@ -48,6 +59,7 @@ class Downloader extends TarDownloader
 		$fn = str_replace('/', '$', $package->getPrettyName());
 		$marker = "$path/$fn.extracted";
 		$this->addCleanupPath($package, $marker);
+		$this->displayIo->write(sprintf('- <info>%s</info> (<comment>%s</comment>)', ComposerInstaller::formatHerokuSysName($package->getPrettyName()), $package->getFullPrettyVersion()));
 		return parent::install($package, $path, $output);
 	}
 }


### PR DESCRIPTION
The buildpack currently takes the "raw" output from several `composer install` executions of the platform packages, and filters them through a few `grep` and `sed` calls to ultimately turn the full log like this:

```
No composer.lock file present. Updating dependencies to latest instead of installing from lock file. See https://getcomposer.org/install for more information.
Loading composer repositories with package information
Updating dependencies
Lock file operations: 19 installs, 0 updates, 0 removals
  - Locking composer.json/composer.lock (dev-3811af274175a9aa6fe447104a8c371b)
  - Locking heroku-sys/apache (2.4.63)
  - Locking heroku-sys/composer (2.8.8)
  - Locking heroku-sys/ext-bcmath (8.3.20)
  - Locking heroku-sys/ext-gd (8.3.20)
  - Locking heroku-sys/ext-imagick (3.8.0)
  - Locking heroku-sys/ext-intl (8.3.20)
  - Locking heroku-sys/ext-oauth (2.0.9)
  - Locking heroku-sys/ext-redis (6.2.0)
  - Locking heroku-sys/ext-soap (8.3.20)
  - Locking heroku-sys/nginx (1.26.3)
  - Locking heroku-sys/php (8.3.20)
  - Locking heroku/installer-plugin (1.7.3)
  - Locking paragonie/constant_time_encoding (v3.0.0)
  - Locking paragonie/random_compat (v9.99.100)
  - Locking phpseclib/mcrypt_compat (2.0.6)
  - Locking phpseclib/phpseclib (3.0.43)
  - Locking symfony/polyfill-ctype (v1.32.0)
  - Locking symfony/polyfill-mbstring (v1.32.0)
Writing lock file
Installing dependencies from lock file
Package operations: 19 installs, 0 updates, 0 removals
  - Installing heroku/installer-plugin (1.7.3): Mirroring from /tmp/codon/tmp/buildpacks/e9b3e6b63ced7a93c49e3a1fca36cc5e44e50d9d/support/installer
More deprecation notices were hidden, run again with `-v` to show them.
  - Downloading heroku-sys/php (8.3.20)
  - Downloading heroku-sys/ext-redis (6.2.0)
  - Downloading heroku-sys/ext-oauth (2.0.9)
  - Downloading heroku-sys/ext-imagick (3.8.0)
  - Downloading heroku-sys/apache (2.4.63)
  - Downloading heroku-sys/composer (2.8.8)
  - Downloading heroku-sys/nginx (1.26.3)
 0/7 [>---------------------------]   0%
 6/7 [========================>---]  85%
 7/7 [============================] 100%
  - Installing heroku-sys/php (8.3.20)
  - Enabling heroku-sys/ext-soap (bundled with php)
  - Installing heroku-sys/ext-redis (6.2.0)
  - Installing heroku-sys/ext-oauth (2.0.9)
  - Installing phpseclib/mcrypt_compat (2.0.6)
  - Installing symfony/polyfill-mbstring (v1.32.0)
  - Enabling heroku-sys/ext-intl (bundled with php)
  - Installing heroku-sys/ext-imagick (3.8.0)
  - Enabling heroku-sys/ext-gd (bundled with php)
  - Installing symfony/polyfill-ctype (v1.32.0)
  - Enabling heroku-sys/ext-bcmath (bundled with php)
  - Installing composer.json/composer.lock (dev-3811af274175a9aa6fe447104a8c371b)
  - Installing heroku-sys/apache (2.4.63)
  - Installing heroku-sys/composer (2.8.8)
  - Installing heroku-sys/nginx (1.26.3)
  - Installing paragonie/constant_time_encoding (v3.0.0)
  - Installing paragonie/random_compat (v9.99.100)
  - Installing phpseclib/phpseclib (3.0.43)
    0 [>---------------------------]    0 [->--------------------------]
Generating autoload files
More deprecation notices were hidden, run again with `-v` to show them.
composer.json has been updated
Running composer update heroku-sys/ext-mcrypt.native
Loading composer repositories with package information
Updating dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires heroku-sys/ext-mcrypt.native, it could not be found in any version, there may be a typo in the package name.

Potential causes:
 - A typo in the package name
 - The package is not available in a stable-enough version according to your minimum-stability setting
   see <https://getcomposer.org/doc/04-schema.md#minimum-stability> for more details.
 - It's a private package and you forgot to add a custom repository to find it

Read <https://getcomposer.org/doc/articles/troubleshooting.md> for further common problems.

Installation failed, reverting composer.json and composer.lock to their original content.
More deprecation notices were hidden, run again with `-v` to show them.
composer.json has been updated
Running composer update heroku-sys/ext-mbstring.native
Loading composer repositories with package information
Updating dependencies
Lock file operations: 1 install, 0 updates, 0 removals
  - Locking heroku-sys/ext-mbstring (8.3.20)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 1 install, 0 updates, 0 removals
  - Enabling heroku-sys/ext-mbstring (bundled with php)
Generating autoload files
No security vulnerability advisories found.
More deprecation notices were hidden, run again with `-v` to show them.
composer.json has been updated
Running composer update heroku-sys/ext-ctype.native
Loading composer repositories with package information
Updating dependencies
Nothing to modify in lock file
Writing lock file
Installing dependencies from lock file (including require-dev)
Nothing to install, update or remove
Generating autoload files
No security vulnerability advisories found.
```

Into this:

```
-----> Installing platform packages...
       - php (8.3.20)
       - ext-soap (bundled with php)
       - ext-redis (6.2.0)
       - ext-oauth (2.0.9)
       - ext-intl (bundled with php)
       - ext-imagick (3.8.0)
       - ext-gd (bundled with php)
       - ext-bcmath (bundled with php)
       - apache (2.4.63)
       - composer (2.8.8)
       - nginx (1.26.3)
       NOTICE: detected userland polyfill packages for PHP extensions
       NOTICE: now attempting to install native extension packages
       Installing extensions provided by phpseclib/mcrypt_compat:
       NOTICE: no suitable native version of ext-mcrypt available
       Installing extensions provided by symfony/polyfill-mbstring:
       - ext-mbstring (bundled with php)
       Installing extensions provided by symfony/polyfill-ctype:
       - ext-ctype (already enabled)
```

Instead of grepping and stripping on the caller side, which is repetitive (since we do more than one `composer install` for handling polyfill packages), and prone to breaking should Composer's output ever change, we are now passing an additional file descriptor to the plugin, which writes the "short" display output (just package names and versions, with "`- `" prefixed) of package installs and extension activations to that FD for the buildpack to print (by passing it through a process substitution with `indent`).

The regular full output from Composer and the plugin still goes to `install.log`.

GUS-W-18472789