### PR TITLE
Further reduce team review request noise from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,3 +10,4 @@ composer.json @dzuelke
 composer.lock @dzuelke
 Gemfile.lock @dzuelke
 requirements.txt @dzuelke
+/.github/workflows/ @dzuelke


### PR DESCRIPTION
We already request language owner review for various automation and Dependabot related PRs, to reduce the amount of review request notification noise sent to the language owner team alias.

This adds the GitHub Actions workflow directory to this list too, so that Dependabot PRs that bump the Actions versions are treated the same as the language-specific Dependabot PRs.

GUS-W-18951033.