### PR TITLE
Auto-install ext-blackfire/ext-newrelic even if userland polyfill is present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### CHG
 
 - Use bootstrapped Composer and minimal PHP for internal operations even after platform packages installation [David Zuelke]
+- Ensure auto-installation of ext-blackfire and ext-newrelic even if userland polyfills are present [David Zuelke]
 
 ## [v269] - 2025-07-04
 

--- a/bin/compile
+++ b/bin/compile
@@ -834,6 +834,9 @@ fi
 
 # unless we're running a CI build...
 if [[ "${HEROKU_PHP_INSTALL_DEV+CI}" != "CI" ]]; then
+	# see if we want to auto-enable blackfire and newrelic extensions
+	# we do this at the end because even with our apm ext "do not start" overrides via PHP_INI_SCAN_DIR,
+	# there can still be startup messages that clobber output during userland composer install etc
 	status "Checking for additional extensions to install..."
 	# special treatment for Blackfire; we enable it if we detect a server id and a server token for it
 	install_blackfire_ext

--- a/bin/util/blackfire.sh
+++ b/bin/util/blackfire.sh
@@ -6,7 +6,7 @@ install_blackfire_ext() {
 	BLACKFIRE_SERVER_ID=${BLACKFIRE_SERVER_ID:-}
 	BLACKFIRE_SERVER_TOKEN=${BLACKFIRE_SERVER_TOKEN:-}
 	if [[ -n "$BLACKFIRE_SERVER_TOKEN" && -n "$BLACKFIRE_SERVER_ID" ]] && ! platform-composer show --installed --quiet heroku-sys/ext-blackfire 2>/dev/null; then
-		if platform-composer require --update-no-dev -- "heroku-sys/ext-blackfire:*" >> $build_dir/.heroku/php/install.log 2>&1; then
+		if platform-composer require --update-no-dev -- "heroku-sys/ext-blackfire:*" "heroku-sys/ext-blackfire.native:*" >> $build_dir/.heroku/php/install.log 2>&1; then
 			echo "- Blackfire detected, installed ext-blackfire" | indent
 		else
 			mcount "warnings.addons.blackfire.extension_missing"

--- a/bin/util/newrelic.sh
+++ b/bin/util/newrelic.sh
@@ -5,7 +5,7 @@ install_newrelic_ext() {
 	# otherwise users would have to have it in their require section, which is annoying in development environments
 	NEW_RELIC_LICENSE_KEY=${NEW_RELIC_LICENSE_KEY:-}
 	if [[ -n "$NEW_RELIC_LICENSE_KEY" ]] && ! platform-composer show --installed --quiet heroku-sys/ext-newrelic 2>/dev/null; then
-		if platform-composer require --update-no-dev -- "heroku-sys/ext-newrelic:*" >> $build_dir/.heroku/php/install.log 2>&1; then
+		if platform-composer require --update-no-dev -- "heroku-sys/ext-newrelic:*" "heroku-sys/ext-newrelic.native:*" >> $build_dir/.heroku/php/install.log 2>&1; then
 			echo "- New Relic detected, installed ext-newrelic" | indent
 		else
 			mcount "warnings.addons.newrelic.extension_missing"

--- a/test/fixtures/apm/blackfire-conflict/composer.json
+++ b/test/fixtures/apm/blackfire-conflict/composer.json
@@ -1,0 +1,22 @@
+{
+	"repositories": [
+		{
+			"type": "package",
+			"package": {
+				"name": "my-conflict/blackfire",
+				"version": "1.0.0",
+				"type": "metapackage",
+				"require": {
+					"php": "*"
+				},
+				"conflict": {
+					"ext-blackfire": "*"
+				}
+			}
+		}
+	],
+	"require": {
+		"php": "*",
+		"my-conflict/blackfire": "1.0.0"
+	}
+}

--- a/test/fixtures/apm/blackfire-conflict/composer.lock
+++ b/test/fixtures/apm/blackfire-conflict/composer.lock
@@ -1,0 +1,32 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "7e86a7faa0f76793a7157b433a034eab",
+    "packages": [
+        {
+            "name": "my-conflict/blackfire",
+            "version": "1.0.0",
+            "require": {
+                "php": "*"
+            },
+            "conflict": {
+                "ext-blackfire": "*"
+            },
+            "type": "metapackage"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": "*"
+    },
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
+}

--- a/test/fixtures/apm/blackfire-polyfill/composer.json
+++ b/test/fixtures/apm/blackfire-polyfill/composer.json
@@ -1,0 +1,22 @@
+{
+	"repositories": [
+		{
+			"type": "package",
+			"package": {
+				"name": "my-polyfill/blackfire",
+				"version": "1.0.0",
+				"type": "metapackage",
+				"require": {
+					"php": "*"
+				},
+				"provide": {
+					"ext-blackfire": "1.99.0"
+				}
+			}
+		}
+	],
+	"require": {
+		"php": "*",
+		"my-polyfill/blackfire": "1.0.0"
+	}
+}

--- a/test/fixtures/apm/blackfire-polyfill/composer.lock
+++ b/test/fixtures/apm/blackfire-polyfill/composer.lock
@@ -1,0 +1,32 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "9695543fbe66ebdb43110fd212523297",
+    "packages": [
+        {
+            "name": "my-polyfill/blackfire",
+            "version": "1.0.0",
+            "require": {
+                "php": "*"
+            },
+            "provide": {
+                "ext-blackfire": "1.99.0"
+            },
+            "type": "metapackage"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": "*"
+    },
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
+}

--- a/test/fixtures/apm/newrelic-conflict/composer.json
+++ b/test/fixtures/apm/newrelic-conflict/composer.json
@@ -1,0 +1,22 @@
+{
+	"repositories": [
+		{
+			"type": "package",
+			"package": {
+				"name": "my-conflict/newrelic",
+				"version": "1.0.0",
+				"type": "metapackage",
+				"require": {
+					"php": "*"
+				},
+				"conflict": {
+					"ext-newrelic": "*"
+				}
+			}
+		}
+	],
+	"require": {
+		"php": "*",
+		"my-conflict/newrelic": "1.0.0"
+	}
+}

--- a/test/fixtures/apm/newrelic-conflict/composer.lock
+++ b/test/fixtures/apm/newrelic-conflict/composer.lock
@@ -1,0 +1,32 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "cc46e47397663aff978393939fd953f7",
+    "packages": [
+        {
+            "name": "my-conflict/newrelic",
+            "version": "1.0.0",
+            "require": {
+                "php": "*"
+            },
+            "conflict": {
+                "ext-newrelic": "*"
+            },
+            "type": "metapackage"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": "*"
+    },
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
+}

--- a/test/fixtures/apm/newrelic-polyfill/composer.json
+++ b/test/fixtures/apm/newrelic-polyfill/composer.json
@@ -1,0 +1,22 @@
+{
+	"repositories": [
+		{
+			"type": "package",
+			"package": {
+				"name": "my-polyfill/newrelic",
+				"version": "1.0.0",
+				"type": "metapackage",
+				"require": {
+					"php": "*"
+				},
+				"provide": {
+					"ext-newrelic": "1.99.0"
+				}
+			}
+		}
+	],
+	"require": {
+		"php": "*",
+		"my-polyfill/newrelic": "1.0.0"
+	}
+}

--- a/test/fixtures/apm/newrelic-polyfill/composer.lock
+++ b/test/fixtures/apm/newrelic-polyfill/composer.lock
@@ -1,0 +1,32 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "322d0d1010d436c1f49911e1d0705bb5",
+    "packages": [
+        {
+            "name": "my-polyfill/newrelic",
+            "version": "1.0.0",
+            "require": {
+                "php": "*"
+            },
+            "provide": {
+                "ext-newrelic": "1.99.0"
+            },
+            "type": "metapackage"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": "*"
+    },
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
+}

--- a/test/spec/blackfire-buildpackagent_spec.rb
+++ b/test/spec/blackfire-buildpackagent_spec.rb
@@ -2,4 +2,24 @@ require_relative "blackfire_shared"
 
 describe "A PHP application using ext-blackfire and, as its agent, buildpack" do
 	include_examples "A PHP application using ext-blackfire and", "blackfireio/integration-heroku"
+	
+	# we do not have to test the following for both agent variants, and this buildpack agent variant runs slightly fewer cases in the included examples above
+	
+	context "with dependencies that prevent automatic installation of the extension" do
+		it "receives a warning but completes the build" do
+			app = new_app_with_stack_and_platrepo(
+				"test/fixtures/apm/blackfire-conflict",
+				config: {
+					"BLACKFIRE_CLIENT_ID": ENV["BLACKFIRE_CLIENT_ID"],
+					"BLACKFIRE_CLIENT_TOKEN": ENV["BLACKFIRE_CLIENT_TOKEN"],
+					"BLACKFIRE_SERVER_ID": ENV["BLACKFIRE_SERVER_ID"],
+					"BLACKFIRE_SERVER_TOKEN": ENV["BLACKFIRE_SERVER_TOKEN"],
+				}
+			)
+			app.deploy do |app|
+				expect(app.output).to match(/Blackfire detected, but no suitable extension available/)
+				expect(app.output).not_to match(/Blackfire detected, installed ext-blackfire/)
+			end
+		end
+	end
 end

--- a/test/spec/blackfire-buildpackagent_spec.rb
+++ b/test/spec/blackfire-buildpackagent_spec.rb
@@ -22,4 +22,22 @@ describe "A PHP application using ext-blackfire and, as its agent, buildpack" do
 			end
 		end
 	end
+	
+	context "with dependencies that polyfill the extension" do
+		it "gets the native extension auto-installed despite the polyfill" do
+			app = new_app_with_stack_and_platrepo(
+				"test/fixtures/apm/blackfire-polyfill",
+				config: {
+					"BLACKFIRE_CLIENT_ID": ENV["BLACKFIRE_CLIENT_ID"],
+					"BLACKFIRE_CLIENT_TOKEN": ENV["BLACKFIRE_CLIENT_TOKEN"],
+					"BLACKFIRE_SERVER_ID": ENV["BLACKFIRE_SERVER_ID"],
+					"BLACKFIRE_SERVER_TOKEN": ENV["BLACKFIRE_SERVER_TOKEN"],
+				}
+			)
+			app.deploy do |app|
+				expect(app.output).not_to match(/Blackfire detected, but no suitable extension available/)
+				expect(app.output).to match(/Blackfire detected, installed ext-blackfire/)
+			end
+		end
+	end
 end

--- a/test/spec/blackfire_shared.rb
+++ b/test/spec/blackfire_shared.rb
@@ -63,12 +63,12 @@ shared_examples "A PHP application using ext-blackfire and" do |agent|
 						expect(apm_installs).to match(/Blackfire detected, installed ext-blackfire/) # auto-install at the end
 					else
 						if agent == "our blackfire package"
-							expect(platform_installs).to match(/- blackfire/)
+							expect(platform_installs).to match(/- blackfire \(\d+\.\d+\.\d+/)
 						else
-							expect(platform_installs).not_to match(/- blackfire/)
+							expect(platform_installs).not_to match(/- blackfire \(\d+\.\d+\.\d+/)
 						end
 						
-						expect(platform_installs).to match(/- ext-blackfire/)
+						expect(platform_installs).to match(/- ext-blackfire \(\d+\.\d+\.\d+/)
 						
 						if mode == "with default BLACKFIRE_LOG_LEVEL"
 							expect(@app.output).not_to match(/\[Debug\] APM: disabled/) # this message should not occur if defaults are applied correctly at build time

--- a/test/spec/blackfire_shared.rb
+++ b/test/spec/blackfire_shared.rb
@@ -58,16 +58,17 @@ shared_examples "A PHP application using ext-blackfire and" do |agent|
 						expect(@app.output).to match(/Blackfire CLI version \d+\.\d+\.\d+ detected/)
 					end
 					
+					platform_installs, apm_installs = @app.output.split("Checking for additional extensions to install", 2)
 					if mode == "implicitly"
-						expect(@app.output).to match(/Blackfire detected, installed ext-blackfire/) # auto-install at the end
+						expect(apm_installs).to match(/Blackfire detected, installed ext-blackfire/) # auto-install at the end
 					else
 						if agent == "our blackfire package"
-							expect(@app.output).to match(/- blackfire/)
+							expect(platform_installs).to match(/- blackfire/)
 						else
-							expect(@app.output).not_to match(/- blackfire/)
+							expect(platform_installs).not_to match(/- blackfire/)
 						end
 						
-						expect(@app.output).to match(/- ext-blackfire/)
+						expect(platform_installs).to match(/- ext-blackfire/)
 						
 						if mode == "with default BLACKFIRE_LOG_LEVEL"
 							expect(@app.output).not_to match(/\[Debug\] APM: disabled/) # this message should not occur if defaults are applied correctly at build time

--- a/test/spec/newrelic_spec.rb
+++ b/test/spec/newrelic_spec.rb
@@ -38,11 +38,12 @@ describe "A PHP application using New Relic" do
 			end
 			
 			it "installs New Relic" do
+				platform_installs, apm_installs = @app.output.split("Checking for additional extensions to install", 2)
 				if mode == "implicitly"
 					expect(@app.output).not_to match(/New Relic PHP Agent globally disabled/) # NR daemon should never start, since NR is installed at the very end
-					expect(@app.output).to match(/New Relic detected, installed ext-newrelic/) # auto-install at the end
+					expect(apm_installs).to match(/New Relic detected, installed ext-newrelic/) # auto-install at the end
 				else
-					expect(@app.output).to match(/- ext-newrelic/)
+					expect(platform_installs).to match(/- ext-newrelic/)
 					if mode == "with default NEW_RELIC_LOG_LEVEL"
 						expect(@app.output).not_to match(/New Relic PHP Agent globally disabled/) # this message should not occur if defaults are applied correctly even at build time
 					else

--- a/test/spec/newrelic_spec.rb
+++ b/test/spec/newrelic_spec.rb
@@ -123,4 +123,19 @@ describe "A PHP application using New Relic" do
 			end
 		end
 	end
+	
+	context "with dependencies that polyfill the extension" do
+		it "gets the native extension auto-installed despite the polyfill" do
+			app = new_app_with_stack_and_platrepo(
+				"test/fixtures/apm/newrelic-polyfill",
+				config: {
+					"NEW_RELIC_LICENSE_KEY": "somethingfake",
+				}
+			)
+			app.deploy do |app|
+				expect(app.output).not_to match(/New Relic detected, but no suitable extension available/)
+				expect(app.output).to match(/New Relic detected, installed ext-newrelic/)
+			end
+		end
+	end
 end

--- a/test/spec/newrelic_spec.rb
+++ b/test/spec/newrelic_spec.rb
@@ -43,7 +43,7 @@ describe "A PHP application using New Relic" do
 					expect(@app.output).not_to match(/New Relic PHP Agent globally disabled/) # NR daemon should never start, since NR is installed at the very end
 					expect(apm_installs).to match(/New Relic detected, installed ext-newrelic/) # auto-install at the end
 				else
-					expect(platform_installs).to match(/- ext-newrelic/)
+					expect(platform_installs).to match(/- ext-newrelic \(\d+\.\d+\.\d+/)
 					if mode == "with default NEW_RELIC_LOG_LEVEL"
 						expect(@app.output).not_to match(/New Relic PHP Agent globally disabled/) # this message should not occur if defaults are applied correctly even at build time
 					else

--- a/test/spec/newrelic_spec.rb
+++ b/test/spec/newrelic_spec.rb
@@ -108,4 +108,19 @@ describe "A PHP application using New Relic" do
 			end
 		end
 	end
+	
+	context "with dependencies that prevent automatic installation of the extension" do
+		it "receives a warning but completes the build" do
+			app = new_app_with_stack_and_platrepo(
+				"test/fixtures/apm/newrelic-conflict",
+				config: {
+					"NEW_RELIC_LICENSE_KEY": "somethingfake",
+				}
+			)
+			app.deploy do |app|
+				expect(app.output).to match(/New Relic detected, but no suitable extension available/)
+				expect(app.output).not_to match(/New Relic detected, installed ext-newrelic/)
+			end
+		end
+	end
 end


### PR DESCRIPTION
Should there be a userland provide for either ext-blackfire or ext-newrelic, the previous command would have accepted that; we now use the .native variant to ensure the native extension actually gets installed if it's available.

GUS-W-19126223