### PR TITLE
Colorization and indentation cleanup and fixes

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -520,7 +520,12 @@ else
 		)
 		For reference, the following runtimes are currently available:
 		
-		PHP:  $(platform-composer show --available heroku-sys/php 2>&1 | sed -n 's/^versions : //p' | fold -s -w 58 || true)
+		PHP: $(
+			platform-composer show --available heroku-sys/php 2>&1 |
+			sed -n 's/^versions : //p' | # composer lists them like "versions : 1.2.3, 1.2.4"
+			fold -b -s -w 59 | # 59 characters at a time, wrap on whitespace
+			indent -i5 --no-first-line-indent || true # indent all lines except first to line up with "PHP: "
+		)
 		
 		Please verify that all requirements for runtime versions in
 		'$COMPOSER_LOCK' are compatible with the list above, and ensure

--- a/bin/compile
+++ b/bin/compile
@@ -496,25 +496,26 @@ else
 		
 		$install_log
 		$(
-			$composer_lock_outdated && cat <<-EOF2
-				$(echo -e "\033[1;33m")
+			# via sed, make every line yellow at the start and re-set to red at the end
+			$composer_lock_outdated && cat <<-EOF2 | sed -e $'s/^/\033[1;33m/' -e $'s/$/\033[1;31m/'
+				
 				A possible cause for this error is your '$COMPOSER_LOCK' file,
 				which is currently out of date, as changes have been made to
 				your '$COMPOSER' that are not yet reflected in the lock file.
-		
+				
 				In order to guarantee reliable installation of system packages,
 				Heroku uses information from '$COMPOSER_LOCK'.
-		
+				
 				If you already attempted to fix the error above by updating the
 				requirements in '$COMPOSER', remember to also update the
 				lock file by running 'composer update', followed by a 'git add'
 				and 'git commit' of the changes. The warning message further
 				above contains step-by-step instructions.
-		
+				
 				Please remember to always keep your '$COMPOSER_LOCK' updated in
 				lockstep with '$COMPOSER' to avoid common problems related
 				to dependencies during collaboration and deployment.
-				$(echo -e "\033[1;31m")
+				
 			EOF2
 		)
 		For reference, the following runtimes are currently available:

--- a/bin/util/common.sh
+++ b/bin/util/common.sh
@@ -124,7 +124,7 @@ error() {
 		echo "" | indent -p "$prefix"
 		echo -e "\033[1;33mREMINDER:\033[1;31m the following \033[1;33mwarnings\033[1;31m were emitted during the build;" | indent -p "$prefix"
 		echo "check the details above, as they may be related to this error:" | indent -p "$prefix"
-		cat "$_captured_warnings_file" | indent -p "$prefix"$'\033[1;33m-\033[1;31m '
+		cat "$_captured_warnings_file" | indent -p "${prefix}- "$'\033[1;33m' # print warning messages in yellow
 	fi
 	echo "" | indent -p "$prefix"
 	exit 1

--- a/bin/util/common.sh
+++ b/bin/util/common.sh
@@ -225,10 +225,10 @@ indent() {
 	get_message_config "$@"
 	shift $((OPTIND-1))
 	# if we were given a flag --no-first-line-indent, that indicates we shouldn't indent the first line
-	# we use :+ to tell SED accordingly if that parameter is set, otherwise null string for no range selector prefix (it selects from line 2 onwards and then every 1st line, meaning all lines)
+	# when that is set, we specify a range filter, starting at line 2, ending when regex "!^" matches, which is never (nothing can precede a ^)
 	# option -p can be used to pass a prefix, we default to option -i (or 7 if not given) space characters
 	# with -p, this can be set to e.g. " !     " to decorate each line of an error message
-	local c="${no_first_line_indent:+"2,999"} s/^/$prefix/"
+	local c="${no_first_line_indent:+"2,/!^/"} s/^/$prefix/"
 	local r=$'s/$/\033[0m/' # end of line color/style reset
 	case $(uname) in
 		Darwin) sed -l -e "$c" -e "$r";; # mac/bsd sed: -l buffers on line boundaries

--- a/bin/util/common.sh
+++ b/bin/util/common.sh
@@ -176,15 +176,23 @@ warning_inline() {
 	indent --no-first-line-indent -p "$prefix" | tee >(head -n1 >> "$_captured_warnings_file"; cat > /dev/null)
 }
 
+# indent width can be changed from default 7 using -i
 status() {
+	local OPTIND=1 indent=0 # visible to get_message_config, which will set "return" values
+	local no_first_line_indent prefix rjust # prevent outside scope interference
+	get_message_config "$@"
+	shift $((OPTIND-1))
 	# send all of our output to stderr
 	exec 1>&2
 	# if arguments are given, redirect them to stdin
 	# this allows the funtion to be invoked with a string argument, or with stdin, e.g. via <<-EOF
 	(( $# )) && exec <<< "$@"
-	echo -n "-----> "
+	local arrow="-> " # first character gets repeated below
+	# print $indent-2 zeroes, which get replaced with dashes, followed by "> "
+	printf "%0*d${arrow:1}" $((indent-2)) | tr 0 "${arrow:0:1}"
+	# any remaining lines only get "> " as a right-justified prefix
 	# this will be fed from stdin
-	cat
+	indent --no-first-line-indent --rjust -i "$indent" -p "${arrow:1}"
 }
 
 # indent width can be changed from default 7 using -i

--- a/bin/util/common.sh
+++ b/bin/util/common.sh
@@ -2,54 +2,168 @@
 # it cannot be a variable, because the warnings function may be used in a pipeline, which causes a subshell, which can't modify parent scope variables
 _captured_warnings_file=$(mktemp -t heroku-buildpack-php-captured-warnings-XXXX)
 
+# Get config from caller's args ("$@") and set results into return variables.
+# The following flags and options can be given:
+# --no-first-line-indent
+# -p PREFIXSTRING (e.g. " !", defaults to "")
+# -i INDENTWIDTH (e.g. 7, defaults to 7)
+# It populates the following variables, if non-empty at call time:
+# - OPTIND (for re-setting "$@" using 'shift')
+# - no_first_line_indent (set to '--no-first-line-indent' if present)
+# - indent (the indent width as given in the -i argument)
+# - prefix (the final computed prefix of PREFIXSTRING padded to INDENT width)
+# To call from another function, pass "$@" and declare at least OPTIND and
+# any of the other return variables beforehand as not null, and any non-desired
+# return variables as null, e.g.:
+# > local OPTIND=1 prefix=""
+# > local indent no_first_line_indent # prevent outside scope interference
+# > get_message_config "$@"
+# > shift ((OPTIND-1))
+# > echo "prefix is: '${prefix}'" # "prefix is: '       '"
+# The user of that function can then still e.g. pass an indent: 'mywarning -i3 ...'
+# It is possible to pass e.g. a default value for the prefix that the user of
+# the calling function can still override, e.g. 'mywarning -p " !" ...':
+# > local OPTIND=1 prefix="" # visible to get_message_config, which will set "return" values
+# > local indent no_first_line_indent # prevent outside scope interference
+# > get_message_config -p " !" "$@"
+# > shift ((OPTIND-1-2)) # two fewer args to shift due to -p above
+# > echo "prefix is: '${prefix}'" # "prefix is: ' !     '"
+get_message_config() {
+	local optstring=":-:i:p:"
+	local prefix_arg
+	if [[ -z "${OPTIND+isset}" ]]; then
+		local OPTIND # caller does not have it set, do not leak it outside
+	fi
+	OPTIND=1 # (re-)set the value to what it needs to be for the next getopts call
+	if [[ -z "${indent+isset}" ]]; then
+		local indent # caller does not have it set, do not leak it outside
+	fi
+	indent=7 # (re-)set to our default value
+	# process flags first
+	while getopts "$optstring" opt; do
+		case $opt in
+			-)
+				case "$OPTARG" in
+					no-first-line-indent)
+						if [[ "${no_first_line_indent+isset}" == "isset" ]]; then
+							no_first_line_indent="--${OPTARG}" # available in the caller
+						fi
+						;;
+					*)
+						echo "Invalid option: --$OPTARG" >&2
+						return 2
+						;;
+				esac
+				;;
+		esac
+	done
+	OPTIND=1 # start over with options parsing
+	while getopts "$optstring" opt; do
+		case $opt in
+			i)
+				if [[ $OPTARG != +([0-9]) ]]; then
+					echo "Option -$opt requires a numeric value" >&2
+					return 2
+				fi
+				indent=$OPTARG
+				;;
+			p)
+				prefix_arg="$OPTARG"
+				;;
+			\?)
+				echo "Invalid option: -$OPTARG" >&2
+				return 2
+				;;
+			:)
+				echo "Option -$OPTARG requires an argument" >&2
+				return 2
+				;;
+		esac
+	done
+	if [[ -z "${prefix+isset}" ]]; then
+		# caller does not have this set, do not leak it outside
+		# we did not bail out earlier in case they wanted to know just the indent
+		return
+	fi
+	# finally, assign the computed prefix
+	# this also has to be a "return variable", because echo would require $() by the caller
+	# that resulting subshell then would prevent reading the other variables above
+	printf -v prefix "%-${indent}s" "${prefix_arg-""}"
+}
+
+# indent width can be changed from default 7 using -i
+# prefix can be changed from default " !" using -p
 error() {
+	local OPTIND=1 prefix="" # visible to get_message_config, which will set "return" values
+	local indent no_first_line_indent # prevent outside scope interference
+	get_message_config -p " !" "$@"
+	shift $((OPTIND-1-2)) # two fewer args to shift since we passed -p above
 	# send all of our output to stderr
 	exec 1>&2
 	# if arguments are given, redirect them to stdin
 	# this allows the funtion to be invoked with a string argument, or with stdin, e.g. via <<-EOF
 	(( $# )) && exec <<< "$@"
-	echo -e "\033[1;31m" # bold; red
-	echo -n " !     ERROR: "
+	local color=$'\033[1;31m'
+	prefix="${color}${prefix}" # bold and red
+	echo
+	echo -n "ERROR: " | indent -p "$prefix"
+	echo -n "$color" # turn color on again for rest of line (auto-disabled at end of every line by indent function)
 	# this will be fed from stdin
-	indent no_first_line_indent " !     "
+	indent --no-first-line-indent -p "$prefix"
 	if [[ -s "$_captured_warnings_file" ]]; then
-		echo "" | indent "" " !     "
-		echo -e "\033[1;33mREMINDER:\033[1;31m the following \033[1;33mwarnings\033[1;31m were emitted during the build;" | indent "" " !     "
-		echo "check the details above, as they may be related to this error:" | indent "" " !     "
-		cat "$_captured_warnings_file" | indent "" "$(echo -e " !     \033[1;33m-\033[1;31m ")"
+		echo "" | indent -p "$prefix"
+		echo -e "\033[1;33mREMINDER:\033[1;31m the following \033[1;33mwarnings\033[1;31m were emitted during the build;" | indent -p "$prefix"
+		echo "check the details above, as they may be related to this error:" | indent -p "$prefix"
+		cat "$_captured_warnings_file" | indent -p "$prefix"$'\033[1;33m-\033[1;31m '
 	fi
-	echo -e "\033[0m" # reset style
+	echo
 	exit 1
 }
 
+# indent width can be changed from default 7 using -i
+# prefix can be changed from default " !" using -p
 warning() {
+	local OPTIND=1 prefix="" # visible to get_message_config, which will set "return" values
+	local indent no_first_line_indent # prevent outside scope interference
+	get_message_config -p " !" "$@"
+	shift $((OPTIND-1-2)) # two fewer args to shift since we passed -p above
 	# send all of our output to stderr
 	exec 1>&2
 	# if arguments are given, redirect them to stdin
 	# this allows the funtion to be invoked with a string argument, or with stdin, e.g. via <<-EOF
 	(( $# )) && exec <<< "$@"
-	echo -e "\033[1;33m" # bold; yellow
-	echo -n " !     WARNING: "
+	local color=$'\033[1;33m' # bold and yellow
+	prefix="${color}${prefix}"
+	echo
+	echo -n "WARNING: " | indent -p "$prefix"
+	echo -n "$color" # turn color on again for rest of line (auto-disabled at end of every line by indent function)
 	# indent will be fed from stdin
 	# we tee to FD 5, which is linked to STDOUT, and capture the real stdout into the warnings array
 	# we must cat in the process substitution to read the remaining lines, because head only reads one line, and then the pipe would close, leading tee to fail
-	indent no_first_line_indent " !     " | tee >(head -n1 >> "$_captured_warnings_file"; cat > /dev/null)
-	echo -e "\033[0m" # reset style
+	indent --no-first-line-indent -p "$prefix" | tee >(head -n1 >> "$_captured_warnings_file"; cat > /dev/null)
+	echo
 }
 
+# indent width can be changed from default 7 using -i
+# prefix can be changed from default " !" using -p
 warning_inline() {
+	local OPTIND=1 prefix="" # visible to get_message_config, which will set "return" values
+	local indent no_first_line_indent # prevent outside scope interference
+	get_message_config -p " !" "$@"
+	shift $((OPTIND-1-2)) # two fewer args to shift since we passed -p above
 	# send all of our output to stderr
 	exec 1>&2
 	# if arguments are given, redirect them to stdin
 	# this allows the funtion to be invoked with a string argument, or with stdin, e.g. via <<-EOF
 	(( $# )) && exec <<< "$@"
-	echo -n -e "\033[1;33m" # bold; yellow
-	echo -n " !     WARNING: "
+	local color=$'\033[1;33m' # bold and yellow
+	prefix="${color}${prefix}"
+	echo -n "WARNING: " | indent -p "$prefix"
+	echo -n "$color" # turn color on again for rest of line (auto-disabled at end of every line by indent function)
 	# indent will be fed from stdin
 	# we tee to FD 5, which is linked to STDOUT, and capture the real stdout into the warnings array
 	# we must cat in the process substitution to read the remaining lines, because head only reads one line, and then the pipe would close, leading tee to fail
-	indent no_first_line_indent " !     " | tee >(head -n1 >> "$_captured_warnings_file"; cat > /dev/null)
-	echo -n -e "\033[0m" # reset style
+	indent --no-first-line-indent -p "$prefix" | tee >(head -n1 >> "$_captured_warnings_file"; cat > /dev/null)
 }
 
 status() {
@@ -63,45 +177,62 @@ status() {
 	cat
 }
 
+# indent width can be changed from default 7 using -i
+# prefix can be changed from default "" using -p
 notice() {
+	local OPTIND=1 prefix="" # visible to get_message_config, which will set "return" values
+	local indent no_first_line_indent # prevent outside scope interference
+	get_message_config "$@"
+	shift $((OPTIND-1))
 	# send all of our output to stderr
 	exec 1>&2
 	# if arguments are given, redirect them to stdin
 	# this allows the funtion to be invoked with a string argument, or with stdin, e.g. via <<-EOF
 	(( $# )) && exec <<< "$@"
 	echo
-	echo -n -e "\033[1;33m" # bold; yellow
-	echo -n "       NOTICE: "
-	echo -n -e "\033[0m" # reset style
+	echo -n -e "\033[1;33mNOTICE: \033[0m" | indent -p "$prefix" # bold; yellow
 	# this will be fed from stdin
-	indent no_first_line_indent
+	indent --no-first-line-indent -p "$prefix"
 	echo
 }
 
+# indent width can be changed from default 7 using -i
+# prefix can be changed from default "" using -p
 notice_inline() {
+	local OPTIND=1 prefix="" # visible to get_message_config, which will set "return" values
+	local indent no_first_line_indent # prevent outside scope interference
+	get_message_config "$@"
+	shift $((OPTIND-1))
 	# send all of our output to stderr
 	exec 1>&2
 	# if arguments are given, redirect them to stdin
 	# this allows the funtion to be invoked with a string argument, or with stdin, e.g. via <<-EOF
 	(( $# )) && exec <<< "$@"
-	echo -n -e "\033[1;33m" # bold; yellow
-	echo -n "       NOTICE: "
-	echo -n -e "\033[0m" # reset style
+	echo -n -e "\033[1;33mNOTICE: \033[0m" | indent -p "$prefix" # bold; yellow
 	# this will be fed from stdin
-	indent no_first_line_indent
+	indent --no-first-line-indent -p "$prefix"
 }
 
 # sed -l basically makes sed replace and buffer through stdin to stdout
 # so you get updates while the command runs and dont wait for the end
 # e.g. npm install | indent
+# indent width can be changed from default 7 using -i
+# prefix can be changed from default "" using -p
+# pass --no-first-line-indent as a flag to skip indentation of first line
 indent() {
-	# if any value (e.g. a non-empty string, or true, or false) is given for the first argument, this will act as a flag indicating we shouldn't indent the first line; we use :+ to tell SED accordingly if that parameter is set, otherwise null string for no range selector prefix (it selects from line 2 onwards and then every 1st line, meaning all lines)
-	# if the first argument is an empty string, it's the same as no argument (useful if a second argument is passed)
-	# the second argument is the prefix to use for indenting; defaults to seven space characters, but can be set to e.g. " !     " to decorate each line of an error message
-	local c="${1:+"2,999"} s/^/${2-"       "}/"
+	local no_first_line_indent="" OPTIND=1 prefix="" # visible to get_message_config, which will set "return" values
+	local indent # prevent outside scope interference
+	get_message_config "$@"
+	shift $((OPTIND-1))
+	# if we were given a flag --no-first-line-indent, that indicates we shouldn't indent the first line
+	# we use :+ to tell SED accordingly if that parameter is set, otherwise null string for no range selector prefix (it selects from line 2 onwards and then every 1st line, meaning all lines)
+	# option -p can be used to pass a prefix, we default to option -i (or 7 if not given) space characters
+	# with -p, this can be set to e.g. " !     " to decorate each line of an error message
+	local c="${no_first_line_indent:+"2,999"} s/^/$prefix/"
+	local r=$'s/$/\033[0m/' # end of line color/style reset
 	case $(uname) in
-		Darwin) sed -l "$c";; # mac/bsd sed: -l buffers on line boundaries
-		*)      sed -u "$c";; # unix/gnu sed: -u unbuffered (arbitrary) chunks of data
+		Darwin) sed -l -e "$c" -e "$r";; # mac/bsd sed: -l buffers on line boundaries
+		*)      sed -u -e "$c" -e "$r";; # unix/gnu sed: -u unbuffered (arbitrary) chunks of data
 	esac
 }
 

--- a/bin/util/common.sh
+++ b/bin/util/common.sh
@@ -105,7 +105,7 @@ error() {
 	(( $# )) && exec <<< "$@"
 	local color=$'\033[1;31m'
 	prefix="${color}${prefix}" # bold and red
-	echo
+	echo "" | indent -p "$prefix"
 	echo -n "ERROR: " | indent -p "$prefix"
 	echo -n "$color" # turn color on again for rest of line (auto-disabled at end of every line by indent function)
 	# this will be fed from stdin
@@ -116,7 +116,7 @@ error() {
 		echo "check the details above, as they may be related to this error:" | indent -p "$prefix"
 		cat "$_captured_warnings_file" | indent -p "$prefix"$'\033[1;33m-\033[1;31m '
 	fi
-	echo
+	echo "" | indent -p "$prefix"
 	exit 1
 }
 
@@ -134,14 +134,14 @@ warning() {
 	(( $# )) && exec <<< "$@"
 	local color=$'\033[1;33m' # bold and yellow
 	prefix="${color}${prefix}"
-	echo
+	echo "" | indent -p "$prefix"
 	echo -n "WARNING: " | indent -p "$prefix"
 	echo -n "$color" # turn color on again for rest of line (auto-disabled at end of every line by indent function)
 	# indent will be fed from stdin
 	# we tee to FD 5, which is linked to STDOUT, and capture the real stdout into the warnings array
 	# we must cat in the process substitution to read the remaining lines, because head only reads one line, and then the pipe would close, leading tee to fail
 	indent --no-first-line-indent -p "$prefix" | tee >(head -n1 >> "$_captured_warnings_file"; cat > /dev/null)
-	echo
+	echo "" | indent -p "$prefix"
 }
 
 # indent width can be changed from default 7 using -i
@@ -189,11 +189,11 @@ notice() {
 	# if arguments are given, redirect them to stdin
 	# this allows the funtion to be invoked with a string argument, or with stdin, e.g. via <<-EOF
 	(( $# )) && exec <<< "$@"
-	echo
+	echo "" | indent -p "$prefix"
 	echo -n -e "\033[1;33mNOTICE: \033[0m" | indent -p "$prefix" # bold; yellow
 	# this will be fed from stdin
 	indent --no-first-line-indent -p "$prefix"
-	echo
+	echo "" | indent -p "$prefix"
 }
 
 # indent width can be changed from default 7 using -i

--- a/test/spec/platform_spec.rb
+++ b/test/spec/platform_spec.rb
@@ -332,7 +332,7 @@ describe "The PHP Platform Installer" do
 					run_multi: true,
 					allow_failure: true
 				).deploy do |app|
-					expect(app.output).to include("ERROR: Failed to install system packages!")
+					expect(app.output).to include("Failed to install system packages!")
 					# we want only "clean" package names for all the platform packages, without our "internal" prefix
 					expect(app.output).not_to include("heroku-sys/")
 					expect(app.output).not_to include("No composer.lock file present")


### PR DESCRIPTION
Notices, warnings and errors are currently printed in yellow or red, but the ANSI codes used are supposed to wrap to following lines. This causes very inconsistent output across environments; for instance, a `git push` will have its `remote: ` prefix highlighted in yellow or red for subsequent lines of a warning or error, while the build logs in Heroku Dashboard will not colorize these lines at all (because the ANSI codes do not re-start on the next line):

<img width="565" height="75" alt="Screenshot 2025-07-24 at 16 58 56" src="https://github.com/user-attachments/assets/7c2e4e15-fedb-4d52-bea7-ec77285c8507" />

There are other subtle flaws, too; for instance, empty lines are currently swallowed by the build logs view in Heroku Dashboard (which we can prevent by making them non-empty).

This now allows passing an indentation level to any of the message helpers, as well as a prefix (useful for upcoming changes which need this).

For the `indent` helper, the "do not indent first line" (used in various places) case is now a lot less confusing, since it's a flag argument instead of a magic empty-or-not-empty string.

Color is now handled correctly at line boundaries, meaning warning or error colors do not leak to the next line (where a wrapper, such as Git, might be printing its own prefix).

As a result, colors are now consistently and correctly printed on the CLI and e.g. in the build logs in Heroku Dashboard.

Smaller fixes include warning summaries at the end in case of an error (now printed in yellow which is easier to "spot"), and the list of available runtime versions (indented cleanly).

## Comparisons

### `git push` old vs new:

<img width="377" height="897" alt="terminal git push old" src="https://github.com/user-attachments/assets/7000c135-2794-4e1a-83b4-a5da4d0a9f54" />
<img width="377" height="897" alt="terminal git push new" src="https://github.com/user-attachments/assets/429c6fc1-0e85-4c65-bb6f-65d704eda01f" />

### Dashboard old vs new:

<img width="368" height="1235" alt="Heroku Dashboard build log old" src="https://github.com/user-attachments/assets/4b471352-bd5a-41db-b6bc-04d71cb63653" />
<img width="368" height="1235" alt="Heroku Dashboard build log new" src="https://github.com/user-attachments/assets/32534070-dda7-43eb-9859-b0bb80f334bf" />

GUS-W-19126260
