### PR TITLE
Streamline and unify platform package installation messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Use bootstrapped Composer and minimal PHP for internal operations even after platform packages installation [David Zuelke]
 - Ensure auto-installation of ext-blackfire and ext-newrelic even if userland polyfills are present [David Zuelke]
 - Print full package/version details on auto-installation of ext-blackfire and ext-newrelic [David Zuelke]
+- Streamline formatting and indentation for userland polyfill and ext-blackfire/ext-newrelic installation steps [David Zuelke]
 
 ## [v269] - 2025-07-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Ensure auto-installation of ext-blackfire and ext-newrelic even if userland polyfills are present [David Zuelke]
 - Print full package/version details on auto-installation of ext-blackfire and ext-newrelic [David Zuelke]
 - Streamline formatting and indentation for userland polyfill and ext-blackfire/ext-newrelic installation steps [David Zuelke]
+- Remove redundant printing of Composer version before userland dependency installation [David Zuelke]
 
 ## [v269] - 2025-07-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Use bootstrapped Composer and minimal PHP for internal operations even after platform packages installation [David Zuelke]
 - Ensure auto-installation of ext-blackfire and ext-newrelic even if userland polyfills are present [David Zuelke]
+- Print full package/version details on auto-installation of ext-blackfire and ext-newrelic [David Zuelke]
 
 ## [v269] - 2025-07-04
 

--- a/bin/compile
+++ b/bin/compile
@@ -325,7 +325,7 @@ platform-composer() {
 	profile_dir_path="${build_dir}/.profile.d" \
 	${providedextensionslog_file_path:+"providedextensionslog_file_path=${providedextensionslog_file_path}"} \
 	${PHP_PLATFORM_INSTALLER_DISPLAY_OUTPUT_FDNO:+"PHP_PLATFORM_INSTALLER_DISPLAY_OUTPUT_FDNO=${PHP_PLATFORM_INSTALLER_DISPLAY_OUTPUT_FDNO}"} \
-	PHP_PLATFORM_INSTALLER_DISPLAY_OUTPUT_INDENT=7 \
+	PHP_PLATFORM_INSTALLER_DISPLAY_OUTPUT_INDENT="${PHP_PLATFORM_INSTALLER_DISPLAY_OUTPUT_INDENT:-7}" \
 	NO_COLOR=1 \
 	/app/.heroku/php-min/bin/php /app/.heroku/php-min/bin/composer -d "${build_dir}/.heroku/php" "$@"
 }

--- a/bin/compile
+++ b/bin/compile
@@ -550,15 +550,15 @@ if [[ -s "$providedextensionslog_file_path" ]]; then
 	# this isolated install will not change anything else about the existing dependency graph
 	while read -r -u "$fd_num" line; do # $fd_num comes from the end of the loop
 		read -r -a provides <<< "$line" # read words of line into array
-		echo "Installing extensions provided by ${provides[0]}:" | indent # first "word" is userland package name
+		echo "- Installing extensions provided by ${provides[0]}..." | indent # first "word" is userland package name
 		for extension in "${provides[@]:1}"; do # remaining words in line are native extensions it declares "provide"d
 			ext_package=$(cut -d":" -f1 <<< "$extension") # extract name from "ext-foo:1.2.3" string
 			ext_name=${ext_package#"heroku-sys/"} # no "heroku-sys/" prefix for human output
 			# run a `composer require`, confined to the package we're attempting, allowing any version
 			#   (the .native "replace"d variant in each extension matches the regular version, so the constraint for that regular version is enough)
-			if ! platform-composer require "${ext_package}.native:*" >> $build_dir/.heroku/php/install.log 2>&1; then
+			if ! PHP_PLATFORM_INSTALLER_DISPLAY_OUTPUT_INDENT=9 platform-composer require "${ext_package}.native:*" >> $build_dir/.heroku/php/install.log 2>&1; then
 				# composer did not succeed; this means no package that matches all existing package's requirements was found
-				notice_inline "no suitable native version of ${ext_name} available"
+				notice_inline -i9 "no suitable native version of ${ext_name} available"
 			fi
 		done
 	done {fd_num}< "$providedextensionslog_file_path" # use bash 4.1+ automatic file descriptor allocation (better than hardcoding e.g. "3<"), otherwise this loop's stdin (the lines of the file) will be consumed by programs called inside the loop

--- a/bin/compile
+++ b/bin/compile
@@ -666,10 +666,6 @@ status "Installing dependencies..."
 composer_vendordir=$(composer config --no-plugins vendor-dir 2> /dev/null)
 composer_bindir=$(composer config --no-plugins bin-dir 2> /dev/null)
 
-# echo composer version for info purposes
-# tail to get rid of outdated version warnings (Composer sends those to STDOUT instead of STDERR)
-composer --no-plugins --version 2> /dev/null | tail -n 1 | indent
-
 # throw a notice if people have added their vendor dir to Git; that's bad practice and makes everything slow and cluttered
 if [[ -f "$composer_vendordir/autoload.php" && -d "$composer_vendordir/composer" ]]; then
 	# we should not do this check separately; there is no reliable way of telling whether or not it really is the real Composer bin dir or if it comes from somewhere else

--- a/bin/compile
+++ b/bin/compile
@@ -844,11 +844,17 @@ if [[ "${HEROKU_PHP_INSTALL_DEV+CI}" != "CI" ]]; then
 	# we do this at the end because even with our apm ext "do not start" overrides via PHP_INI_SCAN_DIR,
 	# there can still be startup messages that clobber output during userland composer install etc
 	status "Checking for additional extensions to install..."
+	# again make a FD for display output and export env var for the installer plugin
+	exec {PHP_PLATFORM_INSTALLER_DISPLAY_OUTPUT_FDNO}>&1
+	export PHP_PLATFORM_INSTALLER_DISPLAY_OUTPUT_FDNO
 	# special treatment for Blackfire; we enable it if we detect a server id and a server token for it
 	install_blackfire_ext
 	# special treatment for New Relic; we enable it if we detect a license key for it
 	install_newrelic_ext
 	install_newrelic_userini
+	# final FD cleanup so nothing after us can inherit it for any reason
+	exec {PHP_PLATFORM_INSTALLER_DISPLAY_OUTPUT_FDNO}>&-
+	unset PHP_PLATFORM_INSTALLER_DISPLAY_OUTPUT_FDNO
 fi
 
 # clean up our bootstrapped PHP and Composer

--- a/bin/util/blackfire.sh
+++ b/bin/util/blackfire.sh
@@ -6,9 +6,10 @@ install_blackfire_ext() {
 	BLACKFIRE_SERVER_ID=${BLACKFIRE_SERVER_ID:-}
 	BLACKFIRE_SERVER_TOKEN=${BLACKFIRE_SERVER_TOKEN:-}
 	if [[ -n "$BLACKFIRE_SERVER_TOKEN" && -n "$BLACKFIRE_SERVER_ID" ]] && ! platform-composer show --installed --quiet heroku-sys/ext-blackfire 2>/dev/null; then
-		if ! platform-composer require --update-no-dev -- "heroku-sys/ext-blackfire:*" "heroku-sys/ext-blackfire.native:*" >> $build_dir/.heroku/php/install.log 2>&1; then
+		echo "- Blackfire config vars detected, installing ext-blackfire..." | indent
+		if ! PHP_PLATFORM_INSTALLER_DISPLAY_OUTPUT_INDENT=9 platform-composer require --update-no-dev -- "heroku-sys/ext-blackfire:*" "heroku-sys/ext-blackfire.native:*" >> $build_dir/.heroku/php/install.log 2>&1; then
 			mcount "warnings.addons.blackfire.extension_missing"
-			warning_inline "Blackfire detected, but no suitable extension available"
+			warning_inline -i9 "no suitable version of ext-blackfire available"
 		fi
 	fi
 }

--- a/bin/util/blackfire.sh
+++ b/bin/util/blackfire.sh
@@ -6,9 +6,7 @@ install_blackfire_ext() {
 	BLACKFIRE_SERVER_ID=${BLACKFIRE_SERVER_ID:-}
 	BLACKFIRE_SERVER_TOKEN=${BLACKFIRE_SERVER_TOKEN:-}
 	if [[ -n "$BLACKFIRE_SERVER_TOKEN" && -n "$BLACKFIRE_SERVER_ID" ]] && ! platform-composer show --installed --quiet heroku-sys/ext-blackfire 2>/dev/null; then
-		if platform-composer require --update-no-dev -- "heroku-sys/ext-blackfire:*" "heroku-sys/ext-blackfire.native:*" >> $build_dir/.heroku/php/install.log 2>&1; then
-			echo "- Blackfire detected, installed ext-blackfire" | indent
-		else
+		if ! platform-composer require --update-no-dev -- "heroku-sys/ext-blackfire:*" "heroku-sys/ext-blackfire.native:*" >> $build_dir/.heroku/php/install.log 2>&1; then
 			mcount "warnings.addons.blackfire.extension_missing"
 			warning_inline "Blackfire detected, but no suitable extension available"
 		fi

--- a/bin/util/newrelic.sh
+++ b/bin/util/newrelic.sh
@@ -5,9 +5,7 @@ install_newrelic_ext() {
 	# otherwise users would have to have it in their require section, which is annoying in development environments
 	NEW_RELIC_LICENSE_KEY=${NEW_RELIC_LICENSE_KEY:-}
 	if [[ -n "$NEW_RELIC_LICENSE_KEY" ]] && ! platform-composer show --installed --quiet heroku-sys/ext-newrelic 2>/dev/null; then
-		if platform-composer require --update-no-dev -- "heroku-sys/ext-newrelic:*" "heroku-sys/ext-newrelic.native:*" >> $build_dir/.heroku/php/install.log 2>&1; then
-			echo "- New Relic detected, installed ext-newrelic" | indent
-		else
+		if ! platform-composer require --update-no-dev -- "heroku-sys/ext-newrelic:*" "heroku-sys/ext-newrelic.native:*" >> $build_dir/.heroku/php/install.log 2>&1; then
 			mcount "warnings.addons.newrelic.extension_missing"
 			warning_inline "New Relic detected, but no suitable extension available"
 		fi

--- a/bin/util/newrelic.sh
+++ b/bin/util/newrelic.sh
@@ -5,9 +5,10 @@ install_newrelic_ext() {
 	# otherwise users would have to have it in their require section, which is annoying in development environments
 	NEW_RELIC_LICENSE_KEY=${NEW_RELIC_LICENSE_KEY:-}
 	if [[ -n "$NEW_RELIC_LICENSE_KEY" ]] && ! platform-composer show --installed --quiet heroku-sys/ext-newrelic 2>/dev/null; then
-		if ! platform-composer require --update-no-dev -- "heroku-sys/ext-newrelic:*" "heroku-sys/ext-newrelic.native:*" >> $build_dir/.heroku/php/install.log 2>&1; then
+		echo "- New Relic config var detected, installing ext-newrelic..." | indent
+		if ! PHP_PLATFORM_INSTALLER_DISPLAY_OUTPUT_INDENT=9 platform-composer require --update-no-dev -- "heroku-sys/ext-newrelic:*" "heroku-sys/ext-newrelic.native:*" >> $build_dir/.heroku/php/install.log 2>&1; then
 			mcount "warnings.addons.newrelic.extension_missing"
-			warning_inline "New Relic detected, but no suitable extension available"
+			warning_inline -i9 "no suitable version of ext-newrelic available"
 		fi
 	fi
 }

--- a/test/spec/blackfire-buildpackagent_spec.rb
+++ b/test/spec/blackfire-buildpackagent_spec.rb
@@ -17,7 +17,8 @@ describe "A PHP application using ext-blackfire and, as its agent, buildpack" do
 				}
 			)
 			app.deploy do |app|
-				expect(app.output).to match(/Blackfire detected, but no suitable extension available/)
+				expect(app.output).to match(/Blackfire config vars detected, installing ext-blackfire/)
+				expect(app.output).to match(/no suitable version of ext-blackfire available/)
 				expect(app.output).not_to match(/- ext-blackfire \(\d+\.\d+\.\d+/)
 			end
 		end
@@ -35,7 +36,8 @@ describe "A PHP application using ext-blackfire and, as its agent, buildpack" do
 				}
 			)
 			app.deploy do |app|
-				expect(app.output).not_to match(/Blackfire detected, but no suitable extension available/)
+				expect(app.output).to match(/Blackfire config vars detected, installing ext-blackfire/)
+				expect(app.output).not_to match(/no suitable version of ext-blackfire available/)
 				expect(app.output).to match(/- ext-blackfire \(\d+\.\d+\.\d+/)
 			end
 		end

--- a/test/spec/blackfire-buildpackagent_spec.rb
+++ b/test/spec/blackfire-buildpackagent_spec.rb
@@ -18,7 +18,7 @@ describe "A PHP application using ext-blackfire and, as its agent, buildpack" do
 			)
 			app.deploy do |app|
 				expect(app.output).to match(/Blackfire detected, but no suitable extension available/)
-				expect(app.output).not_to match(/Blackfire detected, installed ext-blackfire/)
+				expect(app.output).not_to match(/- ext-blackfire \(\d+\.\d+\.\d+/)
 			end
 		end
 	end
@@ -36,7 +36,7 @@ describe "A PHP application using ext-blackfire and, as its agent, buildpack" do
 			)
 			app.deploy do |app|
 				expect(app.output).not_to match(/Blackfire detected, but no suitable extension available/)
-				expect(app.output).to match(/Blackfire detected, installed ext-blackfire/)
+				expect(app.output).to match(/- ext-blackfire \(\d+\.\d+\.\d+/)
 			end
 		end
 	end

--- a/test/spec/blackfire_shared.rb
+++ b/test/spec/blackfire_shared.rb
@@ -60,6 +60,7 @@ shared_examples "A PHP application using ext-blackfire and" do |agent|
 					
 					platform_installs, apm_installs = @app.output.split("Checking for additional extensions to install", 2)
 					if mode == "implicitly"
+						expect(apm_installs).to match(/Blackfire config vars detected, installing ext-blackfire/)
 						expect(apm_installs).to match(/- ext-blackfire \(\d+\.\d+\.\d+/) # auto-install at the end
 						if agent == "our blackfire package"
 							expect(apm_installs).to match(/- blackfire \(\d+\.\d+\.\d+/)

--- a/test/spec/blackfire_shared.rb
+++ b/test/spec/blackfire_shared.rb
@@ -60,7 +60,12 @@ shared_examples "A PHP application using ext-blackfire and" do |agent|
 					
 					platform_installs, apm_installs = @app.output.split("Checking for additional extensions to install", 2)
 					if mode == "implicitly"
-						expect(apm_installs).to match(/Blackfire detected, installed ext-blackfire/) # auto-install at the end
+						expect(apm_installs).to match(/- ext-blackfire \(\d+\.\d+\.\d+/) # auto-install at the end
+						if agent == "our blackfire package"
+							expect(apm_installs).to match(/- blackfire \(\d+\.\d+\.\d+/)
+						else
+							expect(apm_installs).not_to match(/- blackfire \(\d+\.\d+\.\d+/)
+						end
 					else
 						if agent == "our blackfire package"
 							expect(platform_installs).to match(/- blackfire \(\d+\.\d+\.\d+/)

--- a/test/spec/composer-2_spec.rb
+++ b/test/spec/composer-2_spec.rb
@@ -5,7 +5,6 @@ describe "A PHP application intended for Composer 2" do
 		it "builds using Composer 2.2" do
 			new_app_with_stack_and_platrepo('test/fixtures/composer/basic_lock_v2lts').deploy do |app|
 				expect(app.output).to match(/- composer \(2\.2\./)
-				expect(app.output).to match(/Composer version 2\.2\./)
 			end
 		end
 	end
@@ -21,7 +20,6 @@ describe "A PHP application intended for Composer 2" do
 		
 		it "builds using Composer 2.3 or later" do
 			expect(@app.output).to match(/- composer \(2\.([3-9]|\d{2,})\./)
-			expect(@app.output).to match(/Composer version 2\.([3-9]|\d{2,}\.)/)
 		end
 		
 		context "with a malformed COMPOSER_AUTH env var" do
@@ -38,7 +36,6 @@ describe "A PHP application intended for Composer 2" do
 		it "builds using Composer 2.3 or later" do
 			new_app_with_stack_and_platrepo('test/fixtures/composer/basic_lock_v2.999').deploy do |app|
 				expect(app.output).to match(/- composer \(2\.([3-9]|\d{2,})\./)
-				expect(app.output).to match(/Composer version 2\.([3-9]|\d{2,}\.)/)
 			end
 		end
 	end
@@ -46,7 +43,6 @@ describe "A PHP application intended for Composer 2" do
 		it "builds using Composer 2.2" do
 			new_app_with_stack_and_platrepo('test/fixtures/default').deploy do |app|
 				expect(app.output).to match(/- composer \(2\.2\./)
-				expect(app.output).to match(/Composer version 2\.2\./)
 			end
 		end
 	end

--- a/test/spec/newrelic_spec.rb
+++ b/test/spec/newrelic_spec.rb
@@ -41,7 +41,7 @@ describe "A PHP application using New Relic" do
 				platform_installs, apm_installs = @app.output.split("Checking for additional extensions to install", 2)
 				if mode == "implicitly"
 					expect(@app.output).not_to match(/New Relic PHP Agent globally disabled/) # NR daemon should never start, since NR is installed at the very end
-					expect(apm_installs).to match(/New Relic detected, installed ext-newrelic/) # auto-install at the end
+					expect(apm_installs).to match(/- ext-newrelic \(\d+\.\d+\.\d+/) # auto-install at the end
 				else
 					expect(platform_installs).to match(/- ext-newrelic \(\d+\.\d+\.\d+/)
 					if mode == "with default NEW_RELIC_LOG_LEVEL"
@@ -119,7 +119,7 @@ describe "A PHP application using New Relic" do
 			)
 			app.deploy do |app|
 				expect(app.output).to match(/New Relic detected, but no suitable extension available/)
-				expect(app.output).not_to match(/New Relic detected, installed ext-newrelic/)
+				expect(app.output).not_to match(/- ext-newrelic \(\d+\.\d+\.\d+/)
 			end
 		end
 	end
@@ -134,7 +134,7 @@ describe "A PHP application using New Relic" do
 			)
 			app.deploy do |app|
 				expect(app.output).not_to match(/New Relic detected, but no suitable extension available/)
-				expect(app.output).to match(/New Relic detected, installed ext-newrelic/)
+				expect(app.output).to match(/- ext-newrelic \(\d+\.\d+\.\d+/)
 			end
 		end
 	end

--- a/test/spec/newrelic_spec.rb
+++ b/test/spec/newrelic_spec.rb
@@ -41,6 +41,7 @@ describe "A PHP application using New Relic" do
 				platform_installs, apm_installs = @app.output.split("Checking for additional extensions to install", 2)
 				if mode == "implicitly"
 					expect(@app.output).not_to match(/New Relic PHP Agent globally disabled/) # NR daemon should never start, since NR is installed at the very end
+					expect(apm_installs).to match(/New Relic config var detected, installing ext-newrelic/)
 					expect(apm_installs).to match(/- ext-newrelic \(\d+\.\d+\.\d+/) # auto-install at the end
 				else
 					expect(platform_installs).to match(/- ext-newrelic \(\d+\.\d+\.\d+/)
@@ -118,7 +119,8 @@ describe "A PHP application using New Relic" do
 				}
 			)
 			app.deploy do |app|
-				expect(app.output).to match(/New Relic detected, but no suitable extension available/)
+				expect(app.output).to match(/New Relic config var detected, installing ext-newrelic/)
+				expect(app.output).to match(/no suitable version of ext-newrelic available/)
 				expect(app.output).not_to match(/- ext-newrelic \(\d+\.\d+\.\d+/)
 			end
 		end
@@ -133,7 +135,8 @@ describe "A PHP application using New Relic" do
 				}
 			)
 			app.deploy do |app|
-				expect(app.output).not_to match(/New Relic detected, but no suitable extension available/)
+				expect(app.output).to match(/New Relic config var detected, installing ext-newrelic/)
+				expect(app.output).not_to match(/no suitable version of ext-newrelic available/)
 				expect(app.output).to match(/- ext-newrelic \(\d+\.\d+\.\d+/)
 			end
 		end


### PR DESCRIPTION
For APM extension auto-installs, the output was very different from the main platform packages installation. The same method as for the main install is now used, where the installer plugin writes the "readable progress" output to a dedicated FD.

For userland polyfills, the output is now indented further so there is an obvious structure to which polyfill triggered which additional installs.

In both cases, the notices/warnings if an extension isn't available are aligned correctly, as well.

We were also still printing the Composer version before a userland install, a leftover practice from a time before Composer itself was installed as a platform package (which prints the version).

Altogether more "bullet stream" CNB style now (PR for PHP CNB to align the output with this) :)

### Old vs new:

<img width="374" height="562" alt="Heroku Dashboard build logs old" src="https://github.com/user-attachments/assets/51223867-d1d9-4a65-8cb6-f8e2a0c56902" />
<img width="374" height="562" alt="Heroku Dashboard build logs new" src="https://github.com/user-attachments/assets/2d9cd44d-67ee-4f03-a7e2-654798e11ead" />

GUS-W-19126271
