### PR TITLE
Increase Apache HTTP and Nginx keep-alive timeouts to 95 seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Print full package/version details on auto-installation of ext-blackfire and ext-newrelic [David Zuelke]
 - Streamline formatting and indentation for userland polyfill and ext-blackfire/ext-newrelic installation steps [David Zuelke]
 - Remove redundant printing of Composer version before userland dependency installation [David Zuelke]
+- Increase Apache HTTPD and Nginx keep-alive timeouts to 95 seconds for compatibility with Heroku Router 2.0 idle timeout of 90 seconds [David Zuelke]
 
 ## [v269] - 2025-07-04
 

--- a/conf/apache2/heroku.conf
+++ b/conf/apache2/heroku.conf
@@ -16,6 +16,10 @@ Listen ${PORT}
 
 <VirtualHost *:${PORT}>
 
+	# Heroku Router 2.0 idle timeout for KeepAlive connections to dynos is 90 seconds
+	# We must pick a slightly higher value to avoid race conditions where we close a connection just as the router begins to use it
+	KeepAliveTimeout 95
+
 	ServerName localhost
 
 	ErrorLog /tmp/heroku.apache2_error.${PORT}.log

--- a/conf/nginx/heroku.conf.php
+++ b/conf/nginx/heroku.conf.php
@@ -12,8 +12,9 @@ http {
 	sendfile        on;
 	#tcp_nopush     on;
 
-	#keepalive_timeout  0;
-	keepalive_timeout  65;
+	# Heroku Router 2.0 idle timeout for KeepAlive connections to dynos is 90 seconds
+	# We must pick a slightly higher value to avoid race conditions where we close a connection just as the router begins to use it
+	keepalive_timeout 95;
 
 	#gzip  on;
 


### PR DESCRIPTION
For compatibility with Heroku Router 2.0, which has an idle timeout of 90 seconds, we must set a keep-alive timeout that is slightly longer than 90 seconds. This ensures that there cannot be a race condition where the router selects an existing open connection to the dyno to re-use, and the dyno simultaneously closes it (standard practice for any kind of load balancer).

GUS-W-19165676