### PR TITLE
Initial bin/report implementation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,8 @@ run:
 			[[ -x /tmp/build_1/bin/compile ]] && { echo -e "\n~ Compile (Inline Buildpack):" && (source ./export && /tmp/build_1/bin/compile /tmp/build_1 /tmp/cache /tmp/env); }; \
 			echo -e "\n~ Release:" && ./bin/release /tmp/build_1; \
 			rm -rf /app/* /tmp/buildpack/export /tmp/build_1; \
-			cp -r /src/$(FIXTURE) /tmp/build_2; \
-			echo -e "\n~ Recompile:" && ./bin/compile /tmp/build_2 /tmp/cache /tmp/env; \
-			echo -e "\nBuild successful!"; \
+			#cp -r /src/$(FIXTURE) /tmp/build_2; \
+			#echo -e "\n~ Recompile:" && ./bin/compile /tmp/build_2 /tmp/cache /tmp/env; \
+			#echo -e "\nBuild successful!"; \
 		'
 	@echo

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,39 @@
+# The `run` target is useful for local testing/iteration.
+# Locally run this using watchexec (or file watcher of choice), eg:
+# ```
+# brew install watchexec
+# watchexec -qrc --stop-timeout 0 -- make run
+# watchexec -qrc --stop-timeout 0 -- make run FIXTURE=test/fixtures/composer/basic_lock_v2
+# ```
+
+.PHONY: run
+
+STACK ?= heroku-24
+FIXTURE ?= test/fixtures/default
+# Allow overriding the exit code in CI, so we can test bin/report works for failing builds.
+COMPILE_FAILURE_EXIT_CODE ?= 1
+
+# Converts a stack name of `heroku-NN` to its build Docker image tag of `heroku/heroku:NN-build`.
+STACK_IMAGE_TAG := heroku/$(subst -,:,$(STACK))-build
+
+run:
+	@echo "Running buildpack using: STACK=$(STACK) FIXTURE=$(FIXTURE)"
+	@docker run --rm -v $(PWD):/src:ro --tmpfs /app -e "HOME=/app" -e "STACK=$(STACK)" "$(STACK_IMAGE_TAG)" \
+		bash -euo pipefail -O dotglob -c '\
+			mkdir /tmp/buildpack /tmp/cache /tmp/env; \
+			cp -r /src/{bin,conf,support,composer.json} /tmp/buildpack; \
+			cp -r /src/$(FIXTURE) /tmp/build_1; \
+			cd /tmp/buildpack; \
+			unset $$(printenv | cut -d '=' -f 1 | grep -vE "^(HOME|LANG|PATH|STACK)$$"); \
+			echo -en "\n~ Detect: " && ./bin/detect /tmp/build_1; \
+			echo -e "\n~ Compile:" && { ./bin/compile /tmp/build_1 /tmp/cache /tmp/env || COMPILE_FAILED=1; }; \
+			echo -e "\n~ Report:" && ./bin/report /tmp/build_1 /tmp/cache /tmp/env; \
+			[[ "$${COMPILE_FAILED:-}" == "1" ]] && exit $(COMPILE_FAILURE_EXIT_CODE); \
+			[[ -f /tmp/build_1/bin/compile ]] && { echo -e "\n~ Compile (Inline Buildpack):" && (source ./export && /tmp/build_1/bin/compile /tmp/build_1 /tmp/cache /tmp/env); }; \
+			echo -e "\n~ Release:" && ./bin/release /tmp/build_1; \
+			rm -rf /app/* /tmp/buildpack/export /tmp/build_1; \
+			cp -r /src/$(FIXTURE) /tmp/build_2; \
+			echo -e "\n~ Recompile:" && ./bin/compile /tmp/build_2 /tmp/cache /tmp/env; \
+			echo -e "\nBuild successful!"; \
+		'
+	@echo

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ run:
 			echo -e "\n~ Compile:" && { ./bin/compile /tmp/build_1 /tmp/cache /tmp/env || COMPILE_FAILED=1; }; \
 			echo -e "\n~ Report:" && ./bin/report /tmp/build_1 /tmp/cache /tmp/env; \
 			[[ "$${COMPILE_FAILED:-}" == "1" ]] && exit $(COMPILE_FAILURE_EXIT_CODE); \
-			[[ -f /tmp/build_1/bin/compile ]] && { echo -e "\n~ Compile (Inline Buildpack):" && (source ./export && /tmp/build_1/bin/compile /tmp/build_1 /tmp/cache /tmp/env); }; \
+			[[ -x /tmp/build_1/bin/compile ]] && { echo -e "\n~ Compile (Inline Buildpack):" && (source ./export && /tmp/build_1/bin/compile /tmp/build_1 /tmp/cache /tmp/env); }; \
 			echo -e "\n~ Release:" && ./bin/release /tmp/build_1; \
 			rm -rf /app/* /tmp/buildpack/export /tmp/build_1; \
 			cp -r /src/$(FIXTURE) /tmp/build_2; \

--- a/bin/compile
+++ b/bin/compile
@@ -14,11 +14,18 @@ ignore_config_vars=("IFS" "HOME" "PATH" "CPATH" "CPPATH" "LD_PRELOAD" "LIBRARY_P
 
 STACK=${STACK:-heroku-22} # Anvil has none
 build_dir=$1
-cache_dir=$2/php
-mkdir -p "$cache_dir"
+cache_dir=$2
+php_cache_dir="$cache_dir/php"
+mkdir -p "$php_cache_dir"
 env_dir=${3:-} # Anvil has none
 bp_dir=$(cd $(dirname $0); cd ..; pwd)
 
+# Initialise the build report data store. We do this first to ensure the data store from the previous
+# build is still reset if the build fails due to an internal error when importing other modules.
+source "$bp_dir/bin/util/build_report.sh"
+build_report::setup
+
+# TODO: Remove these and the mcount/... utils in common.sh once all consumers are converted to `build_report::*`.
 export BPLOG_PREFIX="buildpack.php"
 export BUILDPACK_LOG_FILE=${BUILDPACK_LOG_FILE:-/dev/null}
 ignore_config_vars+=("BPLOG_PREFIX" "BUILDPACK_LOG_FILE")
@@ -224,7 +231,7 @@ mkdir $build_dir/.heroku/php || {
 	EOF
 }
 # set up Composer
-export COMPOSER_HOME=$cache_dir/.composer
+export COMPOSER_HOME=$php_cache_dir/.composer
 # $COMPOSER_HOME/cache is the default, but we want to be explicit
 export COMPOSER_CACHE_DIR=$COMPOSER_HOME/cache
 mkdir -p $COMPOSER_CACHE_DIR

--- a/bin/compile
+++ b/bin/compile
@@ -606,7 +606,8 @@ source $bp_dir/export
 # from here onwards we're using the composer we installed via platform install with the PHP runtime that we installed via platform install
 
 # log runtime version
-mcount "platform.packages.php.$(php -r "echo PHP_VERSION;")"
+php_version=$(php -r "echo PHP_VERSION;")
+build_report::set_string "php_version" "${php_version}"
 
 if eoldate=$(php $bp_dir/bin/util/eol.php); then
 	:

--- a/bin/compile
+++ b/bin/compile
@@ -528,8 +528,8 @@ else
 		For reference, the following runtimes are currently available:
 		
 		PHP: $(
-			platform-composer show --available heroku-sys/php 2>&1 |
-			sed -n 's/^versions : //p' | # composer lists them like "versions : 1.2.3, 1.2.4"
+			platform-composer show -f json --available heroku-sys/php |
+			jq -r '.versions | join(", ")' |
 			fold -b -s -w 59 | # 59 characters at a time, wrap on whitespace
 			indent -i5 --no-first-line-indent || true # indent all lines except first to line up with "PHP: "
 		)
@@ -581,7 +581,8 @@ exec {PHP_PLATFORM_INSTALLER_DISPLAY_OUTPUT_FDNO}>&-
 unset PHP_PLATFORM_INSTALLER_DISPLAY_OUTPUT_FDNO
 
 # log number of installed platform packages
-mmeasure "platform.count" $(platform-composer show --installed "heroku-sys/*" 2> /dev/null | wc -l)
+# if there are no packages, 'composer show -f json' returns an empty array instead of empty object
+mmeasure "platform.count" $(platform-composer show -f json "heroku-sys/*" | jq -r 'if type == "array" then {} else . end | .installed | length')
 
 # export our "do not auto.start APM extensions" magic INI directory to PHP_INI_SCAN_DIR for ourself and for later buildpacks (but not for runtime)
 # but first, there might be a user-supplied scan dir we have to take into account, so load that config var
@@ -790,7 +791,8 @@ if [[ -z "${HEROKU_PHP_INSTALL_DEV+are-we-running-in-ci}" ]]; then
 fi
 
 # log number of installed dependencies
-mmeasure "dependencies.count" $(composer show --installed 2> /dev/null | wc -l)
+# if there are no packages, 'composer show -f json' returns an empty array instead of empty object
+mmeasure "dependencies.count" $(composer show -f json | jq -r 'if type == "array" then {} else . end | .installed | length')
 
 if cat "$COMPOSER" | python3 -c 'import sys,json; sys.exit("compile" not in json.load(sys.stdin).get("scripts", {}));'; then
 	status "Running 'composer compile'..."

--- a/bin/compile
+++ b/bin/compile
@@ -606,9 +606,10 @@ source $bp_dir/export
 
 # from here onwards we're using the composer we installed via platform install with the PHP runtime that we installed via platform install
 
-# log runtime version
-php_version=$(php -r "echo PHP_VERSION;")
-build_report::set_string "php_version" "${php_version}"
+# log runtime version and series
+php_version=($(php -r 'printf("%s\n%d.%d", PHP_VERSION, PHP_MAJOR_VERSION, PHP_MINOR_VERSION);'))
+build_report::set_string platform.php.version "${php_version[0]}"
+build_report::set_string platform.php.series "${php_version[1]}"
 
 if eoldate=$(php $bp_dir/bin/util/eol.php); then
 	:

--- a/bin/compile
+++ b/bin/compile
@@ -581,8 +581,8 @@ exec {PHP_PLATFORM_INSTALLER_DISPLAY_OUTPUT_FDNO}>&-
 unset PHP_PLATFORM_INSTALLER_DISPLAY_OUTPUT_FDNO
 
 # log number of installed platform packages
-# if there are no packages, 'composer show -f json' returns an empty array instead of empty object
-mmeasure "platform.count" $(platform-composer show -f json "heroku-sys/*" | jq -r 'if type == "array" then {} else . end | .installed | length')
+# if there are no packages, 'composer show -f json' returns an empty array instead of an object with empty "installed" key
+build_report::set_raw platform.packages.installed_count "$(platform-composer show -f json "heroku-sys/*" | jq -r '.installed? // {} | length')"
 
 # export our "do not auto.start APM extensions" magic INI directory to PHP_INI_SCAN_DIR for ourself and for later buildpacks (but not for runtime)
 # but first, there might be a user-supplied scan dir we have to take into account, so load that config var
@@ -792,8 +792,8 @@ if [[ -z "${HEROKU_PHP_INSTALL_DEV+are-we-running-in-ci}" ]]; then
 fi
 
 # log number of installed dependencies
-# if there are no packages, 'composer show -f json' returns an empty array instead of empty object
-mmeasure "dependencies.count" $(composer show -f json | jq -r 'if type == "array" then {} else . end | .installed | length')
+# if there are no packages, 'composer show -f json' returns an empty array instead of an object with empty "installed" key
+build_report::set_raw dependencies.packages.installed_count "$(composer show -f json | jq -r '.installed? // {} | length')"
 
 if cat "$COMPOSER" | python3 -c 'import sys,json; sys.exit("compile" not in json.load(sys.stdin).get("scripts", {}));'; then
 	status "Running 'composer compile'..."

--- a/bin/report
+++ b/bin/report
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Usage: bin/report <build-dir> <cache-dir> <env-dir>
+
+# Produces a build report emitted to stdout, containing metadata about the build, that's
+# consumed by the build system.
+#
+# This script is run for both successful and failing builds, so it should not assume the
+# build ran to completion (e.g. PHP or other tools may not even have been installed).
+#
+# Failures in this script don't cause the overall build to fail (and won't appear in user
+# facing build logs) to avoid breaking builds unnecessarily / causing confusion. To debug
+# issues check the internal build system logs for `buildpack.report.failed` events.
+#
+# Note: The build system doesn't source the `export` script before running this script.
+
+set -euo pipefail
+shopt -s inherit_errexit
+
+cache_dir="${2}"
+
+# The absolute path to the root of the buildpack.
+BUILDPACK_DIR=$(cd "$(dirname "$(dirname "${BASH_SOURCE[0]}")")" && pwd)
+
+source "${BUILDPACK_DIR}/bin/util/build_report.sh"
+
+build_report::print_bin_report_json

--- a/bin/util/build_report.sh
+++ b/bin/util/build_report.sh
@@ -12,6 +12,14 @@ BUILD_DATA_FILE="${cache_dir:?}/build-data/php.json"
 function build_report::setup() {
 	mkdir -p "$(dirname "${BUILD_DATA_FILE}")"
 	echo "{}" >"${BUILD_DATA_FILE}"
+	# just a simple check, sometimes there are broken old versions from unmaintained buildpacks
+	if ! jq --version >/dev/null; then
+		echo >&2 "ERROR: 'jq' not found or incompatible."
+		echo >&2 "Ensure you aren't running outdated buildpacks or overriding PATH."
+		echo >&2 "For reference, the lookup result for command 'jq' follows:"
+		type -a jq # writes success list and failure message to stderr
+		return 1
+	fi
 }
 
 # Sets a string build data value. The value will be wrapped in double quotes and escaped for JSON.

--- a/test/spec/php_base_shared.rb
+++ b/test/spec/php_base_shared.rb
@@ -49,8 +49,10 @@ shared_examples "A basic PHP application" do |series|
 		
 		it "captures information about the build" do
 			expect(@app.bin_report_dump).to match(
+				"platform.packages.installed_count" => 4,
 				"platform.php.version" => a_string_matching(/^#{Regexp.escape(series)}\.\d+$/),
 				"platform.php.series" => series,
+				"dependencies.packages.installed_count" => 0,
 			)
 		end
 		

--- a/test/spec/php_default_spec.rb
+++ b/test/spec/php_default_spec.rb
@@ -23,8 +23,10 @@ describe "A PHP application" do
 	end
 
 	context "with just an index.php" do
+		let(:series) { expected_default_php(ENV["STACK"]) }
+		
 		before(:all) do
-			@app = new_app_with_stack_and_platrepo('test/fixtures/default')
+			@app = new_app_with_stack_and_platrepo_and_bin_report_dumper("test/fixtures/default")
 			@app.deploy
 			
 			delimiter = SecureRandom.uuid
@@ -49,9 +51,15 @@ describe "A PHP application" do
 		end
 		
 		it "picks a default version from the expected series" do
-			series = expected_default_php(ENV["STACK"])
 			expect(@app.output).to match(/- php \(#{Regexp.escape(series)}\./)
 			expect(@run[0]).to match(/#{Regexp.escape(series)}\./)
+		end
+		
+		it "captures information about the build" do
+			expect(@app.bin_report_dump).to match(
+				"platform.php.version" => a_string_matching(/^#{Regexp.escape(series)}\.\d+$/),
+				"platform.php.series" => series,
+			)
 		end
 		
 		it "serves traffic" do

--- a/test/spec/php_default_spec.rb
+++ b/test/spec/php_default_spec.rb
@@ -57,8 +57,10 @@ describe "A PHP application" do
 		
 		it "captures information about the build" do
 			expect(@app.bin_report_dump).to match(
+				"platform.packages.installed_count" => 4,
 				"platform.php.version" => a_string_matching(/^#{Regexp.escape(series)}\.\d+$/),
 				"platform.php.series" => series,
+				"dependencies.packages.installed_count" => 0,
 			)
 		end
 		

--- a/test/var/log/parallel_runtime_rspec.heroku-22.log
+++ b/test/var/log/parallel_runtime_rspec.heroku-22.log
@@ -1,6 +1,6 @@
-test/spec/blackfire-buildpackagent_spec.rb:100
-test/spec/blackfire-herokuagent_spec.rb:120
-test/spec/bugs_spec.rb:40
+test/spec/blackfire-buildpackagent_spec.rb:130
+test/spec/blackfire-herokuagent_spec.rb:110
+test/spec/bugs_spec.rb:90
 test/spec/ci_frameworks-a_spec.rb:120
 test/spec/ci_frameworks-k_spec.rb:120
 test/spec/ci_spec.rb:140
@@ -8,7 +8,7 @@ test/spec/composer-1_spec.rb:30
 test/spec/composer-2_spec.rb:90
 test/spec/devcenter_spec.rb:5
 test/spec/httpd_spec.rb:18
-test/spec/newrelic_spec.rb:115
+test/spec/newrelic_spec.rb:130
 test/spec/nginx_spec.rb:25
 test/spec/php-8.1_base_spec.rb:30
 test/spec/php-8.1_boot-apache2_spec.rb:65

--- a/test/var/log/parallel_runtime_rspec.heroku-24.log
+++ b/test/var/log/parallel_runtime_rspec.heroku-24.log
@@ -1,6 +1,6 @@
-test/spec/blackfire-buildpackagent_spec.rb:100
-test/spec/blackfire-herokuagent_spec.rb:120
-test/spec/bugs_spec.rb:40
+test/spec/blackfire-buildpackagent_spec.rb:130
+test/spec/blackfire-herokuagent_spec.rb:110
+test/spec/bugs_spec.rb:90
 test/spec/ci_frameworks-a_spec.rb:120
 test/spec/ci_frameworks-k_spec.rb:120
 test/spec/ci_spec.rb:140
@@ -8,7 +8,7 @@ test/spec/composer-1_spec.rb:30
 test/spec/composer-2_spec.rb:90
 test/spec/devcenter_spec.rb:5
 test/spec/httpd_spec.rb:18
-test/spec/newrelic_spec.rb:115
+test/spec/newrelic_spec.rb:130
 test/spec/nginx_spec.rb:25
 test/spec/php-8.2_base_spec.rb:30
 test/spec/php-8.2_boot-apache2_spec.rb:65


### PR DESCRIPTION
New build report data store adapted and adopted from heroku/heroku-buildpack-python#1878 / heroku/heroku-buildpack-python#1881.

Tests use an inline buildpack script that dumps the `bin/report` payload to the build output as JSON; matching happens using RSpec matchers, which is a lot more robust and flexible than regular expressions.

We are logging:
- PHP version
- PHP series
- number of installed platform packages
- number of installed userland dependencies

GUS-W-19397005