### PR TITLE
Record durations via bin/report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add new internal data store for capturing measurements at build time [Ed Morley]
 - Record basic measurements about the build (number of dependencies, PHP versions) and make them available for consumption by a build system via bin/report [David Zuelke]
+- Record durations of relevant build steps for bin/report [David Zuelke]
 
 ## [v271] - 2025-07-31
 

--- a/bin/compile
+++ b/bin/compile
@@ -24,6 +24,9 @@ bp_dir=$(cd $(dirname $0); cd ..; pwd)
 # build is still reset if the build fails due to an internal error when importing other modules.
 source "$bp_dir/bin/util/build_report.sh"
 build_report::setup
+declare -A start_times
+
+start_times[__main__]=$(build_report::current_unix_realtime)
 
 # TODO: Remove these and the mcount/... utils in common.sh once all consumers are converted to `build_report::*`.
 export BPLOG_PREFIX="buildpack.php"
@@ -241,6 +244,8 @@ ignore_config_vars+=("COMPOSER_(CACHE_DIR|HOME|NO_INTERACTION)")
 # if the build dir is not "/app", we symlink in the .heroku/php subdir (and only that, to avoid problems with other buildpacks) so that PHP correctly finds its INI files etc
 [[ $build_dir == '/app' ]] || ln -s $build_dir/.heroku/php /app/.heroku/php
 
+start_times[bootstrap]=$(build_report::current_unix_realtime)
+
 status "Bootstrapping..."
 
 if [[ $STACK == "heroku-22" ]]; then
@@ -338,6 +343,8 @@ platform-composer() {
 }
 export -f platform-composer
 
+build_report::set_duration bootstrap.duration "${start_times[bootstrap]}"
+
 mkdir -p $build_dir/.profile.d
 
 # we perform this check early so people with stale lock files are reminded why if their lock file errors in the next step
@@ -416,6 +423,8 @@ platform-composer validate --no-plugins --no-check-publish --no-check-all --quie
 	EOF
 }
 
+start_times[platform.prepare]=$(build_report::current_unix_realtime)
+
 status "Preparing platform package installation..."
 
 HEROKU_PHP_DEFAULT_RUNTIME_VERSION="^8.1.0 <8.5"
@@ -456,7 +465,13 @@ export HEROKU_PHP_DEFAULT_RUNTIME_VERSION
 	fi
 }
 
+build_report::set_duration platform.prepare.duration "${start_times[platform.prepare]}"
+
+start_times[platform.install]=$(build_report::current_unix_realtime)
+
 status "Installing platform packages..."
+
+start_times[platform.install.main]=$(build_report::current_unix_realtime)
 
 # providedextensionslog_file_path is used to record packages that provide native extensions for this one install step only
 export providedextensionslog_file_path=$(mktemp -t "provided-extensions.log.XXXXXX" -u)
@@ -547,8 +562,11 @@ else
 	EOF
 fi
 
+build_report::set_duration platform.install.main.duration "${start_times[platform.install.main]}"
+
 export -n providedextensionslog_file_path # export no longer needed (and we don't want more entries written by the plugin even if it encounters them)
 if [[ -s "$providedextensionslog_file_path" ]]; then
+	start_times[platform.install.polyfill_replacement]=$(build_report::current_unix_realtime)
 	notice_inline "detected userland polyfill packages for PHP extensions"
 	notice_inline "now attempting to install native extension packages"
 	# the platform installer recorded userland packages that "provide" a PHP extension
@@ -570,6 +588,7 @@ if [[ -s "$providedextensionslog_file_path" ]]; then
 		done
 	done {fd_num}< "$providedextensionslog_file_path" # use bash 4.1+ automatic file descriptor allocation (better than hardcoding e.g. "3<"), otherwise this loop's stdin (the lines of the file) will be consumed by programs called inside the loop
 	exec {fd_num}>&-
+	build_report::set_duration platform.install.polyfill_replacement.duration "${start_times[platform.install.polyfill_replacement]}"
 fi
 
 # clean up installer variables and files
@@ -610,6 +629,8 @@ source $bp_dir/export
 php_version=($(php -r 'printf("%s\n%d.%d", PHP_VERSION, PHP_MAJOR_VERSION, PHP_MINOR_VERSION);'))
 build_report::set_string platform.php.version "${php_version[0]}"
 build_report::set_string platform.php.series "${php_version[1]}"
+
+build_report::set_duration platform.install.duration "${start_times[platform.install]}"
 
 if eoldate=$(php $bp_dir/bin/util/eol.php); then
 	:
@@ -670,6 +691,8 @@ else
 		EOF
 	fi
 fi
+
+start_times[dependencies.install]=$(build_report::current_unix_realtime)
 
 status "Installing dependencies..."
 
@@ -791,11 +814,15 @@ if [[ -z "${HEROKU_PHP_INSTALL_DEV+are-we-running-in-ci}" ]]; then
 	}
 fi
 
+build_report::set_duration dependencies.install.duration "${start_times[dependencies.install]}"
+
 # log number of installed dependencies
 # if there are no packages, 'composer show -f json' returns an empty array instead of an object with empty "installed" key
 build_report::set_raw dependencies.packages.installed_count "$(composer show -f json | jq -r '.installed? // {} | length')"
 
 if cat "$COMPOSER" | python3 -c 'import sys,json; sys.exit("compile" not in json.load(sys.stdin).get("scripts", {}));'; then
+	start_times[scripts.compile]=$(build_report::current_unix_realtime)
+	
 	status "Running 'composer compile'..."
 	composer run-script ${HEROKU_PHP_INSTALL_DEV-"--no-dev"} --no-interaction compile 2>&1 | indent || {
 		mcount "failures.compile_step"
@@ -814,6 +841,8 @@ if cat "$COMPOSER" | python3 -c 'import sys,json; sys.exit("compile" not in json
 			https://devcenter.heroku.com/articles/php-support
 		EOF
 	}
+	
+	build_report::set_duration scripts.compile.duration "${start_times[scripts.compile]}"
 fi
 
 status "Preparing runtime environment..."
@@ -847,6 +876,8 @@ fi
 
 # unless we're running a CI build...
 if [[ "${HEROKU_PHP_INSTALL_DEV+CI}" != "CI" ]]; then
+	start_times[apm.automagic]=$(build_report::current_unix_realtime)
+	
 	# see if we want to auto-enable blackfire and newrelic extensions
 	# we do this at the end because even with our apm ext "do not start" overrides via PHP_INI_SCAN_DIR,
 	# there can still be startup messages that clobber output during userland composer install etc
@@ -862,7 +893,11 @@ if [[ "${HEROKU_PHP_INSTALL_DEV+CI}" != "CI" ]]; then
 	# final FD cleanup so nothing after us can inherit it for any reason
 	exec {PHP_PLATFORM_INSTALLER_DISPLAY_OUTPUT_FDNO}>&-
 	unset PHP_PLATFORM_INSTALLER_DISPLAY_OUTPUT_FDNO
+	
+	build_report::set_duration apm.automagic.duration "${start_times[apm.automagic]}"
 fi
 
 # clean up our bootstrapped PHP and Composer
 rm -rf /app/.heroku/php-min $build_dir/.heroku/php-min
+
+build_report::set_duration duration "${start_times[__main__]}"

--- a/test/fixtures/composer/compile_script/composer.json
+++ b/test/fixtures/composer/compile_script/composer.json
@@ -1,0 +1,8 @@
+{
+    "require": {
+        "php": "*"
+    },
+    "scripts": {
+        "compile": "echo hi; sleep 5"
+    }
+}

--- a/test/fixtures/composer/compile_script/composer.lock
+++ b/test/fixtures/composer/compile_script/composer.lock
@@ -1,0 +1,20 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "72101c8f469cc44b8806e95314197d4d",
+    "packages": [],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": "*"
+    },
+    "platform-dev": [],
+    "plugin-api-version": "2.3.0"
+}

--- a/test/spec/composer-2_spec.rb
+++ b/test/spec/composer-2_spec.rb
@@ -62,5 +62,11 @@ describe "A PHP application intended for Composer 2" do
 				 .to include("Running 'composer compile'...")
 				.and include("echo hi")
 		end
+		
+		it "captures the duration of the script run as part of the information about the build" do
+			expect(@app.bin_report_dump).to include(
+				"scripts.compile.duration" => a_kind_of(Float).and(a_value > 5),
+			)
+		end
 	end
 end

--- a/test/spec/composer-2_spec.rb
+++ b/test/spec/composer-2_spec.rb
@@ -46,4 +46,21 @@ describe "A PHP application intended for Composer 2" do
 			end
 		end
 	end
+	
+	context "with a 'compile' script" do
+		before(:all) do
+			@app = new_app_with_stack_and_platrepo_and_bin_report_dumper('test/fixtures/composer/compile_script')
+			@app.deploy
+		end
+		
+		after(:all) do
+			@app.teardown!
+		end
+		
+		it "runs 'composer compile' at the end of the build" do
+			expect(@app.output)
+				 .to include("Running 'composer compile'...")
+				.and include("echo hi")
+		end
+	end
 end

--- a/test/spec/php_base_shared.rb
+++ b/test/spec/php_base_shared.rb
@@ -49,10 +49,17 @@ shared_examples "A basic PHP application" do |series|
 		
 		it "captures information about the build" do
 			expect(@app.bin_report_dump).to match(
+				"bootstrap.duration" => a_kind_of(Float),
+				"platform.prepare.duration" => a_kind_of(Float),
+				"platform.install.main.duration" => a_kind_of(Float),
 				"platform.packages.installed_count" => 4,
 				"platform.php.version" => a_string_matching(/^#{Regexp.escape(series)}\.\d+$/),
 				"platform.php.series" => series,
+				"platform.install.duration" => a_kind_of(Float),
+				"dependencies.install.duration" => a_kind_of(Float),
 				"dependencies.packages.installed_count" => 0,
+				"apm.automagic.duration" => a_kind_of(Float),
+				"duration" => a_kind_of(Float),
 			)
 		end
 		

--- a/test/spec/php_default_spec.rb
+++ b/test/spec/php_default_spec.rb
@@ -57,10 +57,17 @@ describe "A PHP application" do
 		
 		it "captures information about the build" do
 			expect(@app.bin_report_dump).to match(
+				"bootstrap.duration" => a_kind_of(Float),
+				"platform.prepare.duration" => a_kind_of(Float),
+				"platform.install.main.duration" => a_kind_of(Float),
 				"platform.packages.installed_count" => 4,
 				"platform.php.version" => a_string_matching(/^#{Regexp.escape(series)}\.\d+$/),
 				"platform.php.series" => series,
+				"platform.install.duration" => a_kind_of(Float),
+				"dependencies.install.duration" => a_kind_of(Float),
 				"dependencies.packages.installed_count" => 0,
+				"apm.automagic.duration" => a_kind_of(Float),
+				"duration" => a_kind_of(Float),
 			)
 		end
 		

--- a/test/var/log/parallel_runtime_rspec.heroku-22.log
+++ b/test/var/log/parallel_runtime_rspec.heroku-22.log
@@ -5,7 +5,7 @@ test/spec/ci_frameworks-a_spec.rb:120
 test/spec/ci_frameworks-k_spec.rb:120
 test/spec/ci_spec.rb:140
 test/spec/composer-1_spec.rb:30
-test/spec/composer-2_spec.rb:90
+test/spec/composer-2_spec.rb:110
 test/spec/devcenter_spec.rb:5
 test/spec/httpd_spec.rb:18
 test/spec/newrelic_spec.rb:130

--- a/test/var/log/parallel_runtime_rspec.heroku-24.log
+++ b/test/var/log/parallel_runtime_rspec.heroku-24.log
@@ -5,7 +5,7 @@ test/spec/ci_frameworks-a_spec.rb:120
 test/spec/ci_frameworks-k_spec.rb:120
 test/spec/ci_spec.rb:140
 test/spec/composer-1_spec.rb:30
-test/spec/composer-2_spec.rb:90
+test/spec/composer-2_spec.rb:110
 test/spec/devcenter_spec.rb:5
 test/spec/httpd_spec.rb:18
 test/spec/newrelic_spec.rb:130


### PR DESCRIPTION
For the "logical" steps:
- bootstrapping
- platform package preparation
- platform package install
- polyfill replacement processing
- userland installs
- script execution
- APM automagic

Tests include a sanity check against a known time (the fixture's `composer compile` script has a fixed `sleep`).

GUS-W-19473499
