### PR TITLE
Harden against faulty Composer plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### FIX
+
+- Faulty Composer plugins printing to stdout during activation may cause build failures [David Zuelke]
 
 ## [v273] - 2025-09-04
 

--- a/bin/compile
+++ b/bin/compile
@@ -855,7 +855,7 @@ build_report::set_duration dependencies.install.duration "${start_times[dependen
 
 # log number of installed dependencies
 # if there are no packages, 'composer show -f json' returns an empty array instead of an object with empty "installed" key
-build_report::set_raw dependencies.packages.installed_count "$(composer show -f json | jq -r '.installed? // {} | length')"
+build_report::set_raw dependencies.packages.installed_count "$(composer show --no-plugins -f json | jq -r '.installed? // {} | length')"
 
 if cat "$COMPOSER" | python3 -c 'import sys,json; sys.exit("compile" not in json.load(sys.stdin).get("scripts", {}));'; then
 	start_times[scripts.compile]=$(build_report::current_unix_realtime)

--- a/bin/compile
+++ b/bin/compile
@@ -830,7 +830,7 @@ fi
 
 # only perform the check for buildpack package if we're not running in Heroku CI
 if [[ -z "${HEROKU_PHP_INSTALL_DEV+are-we-running-in-ci}" ]]; then
-	composer show --installed heroku/heroku-buildpack-php &> /dev/null && {
+	composer show --quiet heroku/heroku-buildpack-php 2>/dev/null && {
 		mcount "failures.dependencies.buildpack_as_dependency"
 		error <<-EOF
 			Package 'heroku/heroku-buildpack-php' found!

--- a/bin/compile
+++ b/bin/compile
@@ -619,6 +619,7 @@ if [[ -s "$providedextensionslog_file_path" ]]; then
 	# back up the count of installed packages from the previous step
 	platform_packages_installed_count_previous=$platform_packages_installed_count
 	# set the new grand total (will be logged again further down) to what we have now
+	# if there are no packages, 'composer show -f json' returns an empty array instead of an object with empty "installed" key
 	platform_packages_installed_count=$(platform-composer show -f json "heroku-sys/*" | jq -r '.installed? // {} | length')
 	# log the difference between the two as the count for this step
 	build_report::set_raw platform.install.polyfill_replacement.packages.installed_count "$(( platform_packages_installed_count - platform_packages_installed_count_previous ))"
@@ -637,7 +638,6 @@ unset PHP_PLATFORM_INSTALLER_DISPLAY_OUTPUT_FDNO
 
 # log total number of installed platform packages (user deps, polyfill replacements, composer, web servers)
 # this variable may have been updated by the polyfill replacement step
-# if there are no packages, 'composer show -f json' returns an empty array instead of an object with empty "installed" key
 build_report::set_raw platform.packages.installed_count "$platform_packages_installed_count"
 
 # export our "do not auto.start APM extensions" magic INI directory to PHP_INI_SCAN_DIR for ourself and for later buildpacks (but not for runtime)

--- a/bin/compile
+++ b/bin/compile
@@ -565,7 +565,7 @@ fi
 # log number of platform packages installed based on the packages and requirements we assembled
 # this includes composer and web servers, but may not include extensions skipped due to the presence of polyfill packages
 # if there are no packages, 'composer show -f json' returns an empty array instead of an object with empty "installed" key
-platform_packages_installed_count=$(platform-composer show -f json "heroku-sys/*" | jq -r '.installed? // {} | length')
+platform_packages_installed_count=$(platform-composer show -f json "heroku-sys/*" | jq -r '.installed? // {} | length' || printf -- "-1")
 build_report::set_raw platform.install.main.packages.installed_count "$platform_packages_installed_count"
 
 build_report::set_duration platform.install.main.duration "${start_times[platform.install.main]}"
@@ -620,7 +620,7 @@ if [[ -s "$providedextensionslog_file_path" ]]; then
 	platform_packages_installed_count_previous=$platform_packages_installed_count
 	# set the new grand total (will be logged again further down) to what we have now
 	# if there are no packages, 'composer show -f json' returns an empty array instead of an object with empty "installed" key
-	platform_packages_installed_count=$(platform-composer show -f json "heroku-sys/*" | jq -r '.installed? // {} | length')
+	platform_packages_installed_count=$(platform-composer show -f json "heroku-sys/*" | jq -r '.installed? // {} | length' || printf -- "-1")
 	# log the difference between the two as the count for this step
 	build_report::set_raw platform.install.polyfill_replacement.packages.installed_count "$(( platform_packages_installed_count - platform_packages_installed_count_previous ))"
 fi
@@ -855,7 +855,7 @@ build_report::set_duration dependencies.install.duration "${start_times[dependen
 
 # log number of installed dependencies
 # if there are no packages, 'composer show -f json' returns an empty array instead of an object with empty "installed" key
-build_report::set_raw dependencies.packages.installed_count "$(composer show --no-plugins -f json | jq -r '.installed? // {} | length')"
+build_report::set_raw dependencies.packages.installed_count "$(composer show --no-plugins -f json | jq -r '.installed? // {} | length' || printf -- "-1")"
 
 if cat "$COMPOSER" | python3 -c 'import sys,json; sys.exit("compile" not in json.load(sys.stdin).get("scripts", {}));'; then
 	start_times[scripts.compile]=$(build_report::current_unix_realtime)

--- a/bin/heroku-php-apache2
+++ b/bin/heroku-php-apache2
@@ -318,8 +318,8 @@ composer() {
 	fi
 }
 # these exports are used in default web server configs to lock down access to composer directories
-COMPOSER_VENDOR_DIR=$(composer config vendor-dir 2> /dev/null | tail -n 1) && export COMPOSER_VENDOR_DIR || { echo "Unable to determine Composer vendor-dir setting; is 'composer' executable on path or 'composer.phar' in current working directory?" >&2; exit 1; } # tail, as composer echos outdated version warnings to STDOUT; export after the assignment or exit status will that be of 'export
-COMPOSER_BIN_DIR=$(composer config bin-dir 2> /dev/null | tail -n 1) && export COMPOSER_BIN_DIR || { echo "Unable to determine Composer bin-dir setting; is 'composer' executable on path or 'composer.phar' in current working directory?" >&2; exit 1; } # tail, as composer echos outdated version warnings to STDOUT; export after the assignment or exit status will that be of 'export
+COMPOSER_VENDOR_DIR=$(composer config --no-plugins vendor-dir 2> /dev/null | tail -n 1) && export COMPOSER_VENDOR_DIR || { echo "Unable to determine Composer vendor-dir setting; is 'composer' executable on path or 'composer.phar' in current working directory?" >&2; exit 1; } # tail, as composer echos outdated version warnings to STDOUT; export after the assignment or exit status will that be of 'export
+COMPOSER_BIN_DIR=$(composer config --no-plugins bin-dir 2> /dev/null | tail -n 1) && export COMPOSER_BIN_DIR || { echo "Unable to determine Composer bin-dir setting; is 'composer' executable on path or 'composer.phar' in current working directory?" >&2; exit 1; } # tail, as composer echos outdated version warnings to STDOUT; export after the assignment or exit status will that be of 'export
 
 if [[ "$#" == "1" ]]; then
 	DOCUMENT_ROOT="$HEROKU_APP_DIR/$1"

--- a/bin/heroku-php-nginx
+++ b/bin/heroku-php-nginx
@@ -316,8 +316,8 @@ composer() {
 	fi
 }
 # these exports are used in default web server configs to lock down access to composer directories
-COMPOSER_VENDOR_DIR=$(composer config vendor-dir 2> /dev/null | tail -n 1) && export COMPOSER_VENDOR_DIR || { echo "Unable to determine Composer vendor-dir setting; is 'composer' executable on path or 'composer.phar' in current working directory?" >&2; exit 1; } # tail, as composer echos outdated version warnings to STDOUT; export after the assignment or exit status will that be of 'export
-COMPOSER_BIN_DIR=$(composer config bin-dir 2> /dev/null | tail -n 1) && export COMPOSER_BIN_DIR || { echo "Unable to determine Composer bin-dir setting; is 'composer' executable on path or 'composer.phar' in current working directory?" >&2; exit 1; } # tail, as composer echos outdated version warnings to STDOUT; export after the assignment or exit status will that be of 'export
+COMPOSER_VENDOR_DIR=$(composer config --no-plugins vendor-dir 2> /dev/null | tail -n 1) && export COMPOSER_VENDOR_DIR || { echo "Unable to determine Composer vendor-dir setting; is 'composer' executable on path or 'composer.phar' in current working directory?" >&2; exit 1; } # tail, as composer echos outdated version warnings to STDOUT; export after the assignment or exit status will that be of 'export
+COMPOSER_BIN_DIR=$(composer config --no-plugins bin-dir 2> /dev/null | tail -n 1) && export COMPOSER_BIN_DIR || { echo "Unable to determine Composer bin-dir setting; is 'composer' executable on path or 'composer.phar' in current working directory?" >&2; exit 1; } # tail, as composer echos outdated version warnings to STDOUT; export after the assignment or exit status will that be of 'export
 
 if [[ "$#" == "1" ]]; then
 	DOCUMENT_ROOT="$HEROKU_APP_DIR/$1"

--- a/bin/util/blackfire.sh
+++ b/bin/util/blackfire.sh
@@ -5,7 +5,7 @@ install_blackfire_ext() {
 	# otherwise users would have to have it in their require section, which is annoying in development environments
 	BLACKFIRE_SERVER_ID=${BLACKFIRE_SERVER_ID:-}
 	BLACKFIRE_SERVER_TOKEN=${BLACKFIRE_SERVER_TOKEN:-}
-	if [[ -n "$BLACKFIRE_SERVER_TOKEN" && -n "$BLACKFIRE_SERVER_ID" ]] && ! platform-composer show --installed --quiet heroku-sys/ext-blackfire 2>/dev/null; then
+	if [[ -n "$BLACKFIRE_SERVER_TOKEN" && -n "$BLACKFIRE_SERVER_ID" ]] && ! platform-composer show --quiet heroku-sys/ext-blackfire 2>/dev/null; then
 		echo "- Blackfire config vars detected, installing ext-blackfire..." | indent
 		if ! PHP_PLATFORM_INSTALLER_DISPLAY_OUTPUT_INDENT=9 platform-composer require --update-no-dev -- "heroku-sys/ext-blackfire:*" "heroku-sys/ext-blackfire.native:*" >> $build_dir/.heroku/php/install.log 2>&1; then
 			mcount "warnings.addons.blackfire.extension_missing"

--- a/bin/util/newrelic.sh
+++ b/bin/util/newrelic.sh
@@ -4,7 +4,7 @@ install_newrelic_ext() {
 	# special treatment for New Relic; we enable it if we detect a license key for it
 	# otherwise users would have to have it in their require section, which is annoying in development environments
 	NEW_RELIC_LICENSE_KEY=${NEW_RELIC_LICENSE_KEY:-}
-	if [[ -n "$NEW_RELIC_LICENSE_KEY" ]] && ! platform-composer show --installed --quiet heroku-sys/ext-newrelic 2>/dev/null; then
+	if [[ -n "$NEW_RELIC_LICENSE_KEY" ]] && ! platform-composer show --quiet heroku-sys/ext-newrelic 2>/dev/null; then
 		echo "- New Relic config var detected, installing ext-newrelic..." | indent
 		if ! PHP_PLATFORM_INSTALLER_DISPLAY_OUTPUT_INDENT=9 platform-composer require --update-no-dev -- "heroku-sys/ext-newrelic:*" "heroku-sys/ext-newrelic.native:*" >> $build_dir/.heroku/php/install.log 2>&1; then
 			mcount "warnings.addons.newrelic.extension_missing"

--- a/test/fixtures/composer/faulty_plugin/README.md
+++ b/test/fixtures/composer/faulty_plugin/README.md
@@ -1,0 +1,5 @@
+This fixture contains a Composer plugin that prints to stdout during activation.
+
+Because we read the output of various Composer commands such as `composer config` or `composer show -f json`, this would cause problems unless those command invocations explicitly specified `--no-plugins`.
+
+By having this test fixture's dummy plugin misbehave in the manner above, we can test that all relevant calls do so (both during build and during dyno boot).

--- a/test/fixtures/composer/faulty_plugin/composer.json
+++ b/test/fixtures/composer/faulty_plugin/composer.json
@@ -1,0 +1,16 @@
+{
+	"config": {
+		"allow-plugins": {
+			"my/faulty-plugin": true
+		}
+	},
+	"repositories": [
+		{
+			"type": "path",
+			"url": "./faulty-plugin/"
+		}
+	],
+	"require": {
+		"my/faulty-plugin": "*"
+	}
+}

--- a/test/fixtures/composer/faulty_plugin/composer.lock
+++ b/test/fixtures/composer/faulty_plugin/composer.lock
@@ -1,0 +1,43 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "5982d92cbfac83e54bc9c615e1f96d82",
+    "packages": [
+        {
+            "name": "my/faulty-plugin",
+            "version": "1.0.0",
+            "dist": {
+                "type": "path",
+                "url": "./faulty-plugin",
+                "reference": "d1db4374a0c4c36bf468af7b79c756b62bbde0b0"
+            },
+            "require": {
+                "composer-plugin-api": "^2.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "My\\FaultyPlugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "My\\": "./"
+                }
+            },
+            "transport-options": {
+                "relative": true
+            }
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {},
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
+}

--- a/test/fixtures/composer/faulty_plugin/faulty-plugin/FaultyPlugin.php
+++ b/test/fixtures/composer/faulty_plugin/faulty-plugin/FaultyPlugin.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace My;
+
+use Composer\Composer;
+use Composer\IO\IOInterface;
+use Composer\Plugin\PluginInterface;
+
+class FaultyPlugin implements PluginInterface
+{
+	public function activate(Composer $composer, IOInterface $io)
+	{
+		$io->write("Hello, I am FaultyPlugin, writing to stdout instead of stderr in PluginInterface::activate()");
+	}
+
+	public function deactivate(Composer $composer, IOInterface $io)
+	{
+	}
+	
+	public function uninstall(Composer $composer, IOInterface $io)
+	{
+	}
+}

--- a/test/fixtures/composer/faulty_plugin/faulty-plugin/composer.json
+++ b/test/fixtures/composer/faulty_plugin/faulty-plugin/composer.json
@@ -1,0 +1,16 @@
+{
+	"name": "my/faulty-plugin",
+	"version": "1.0.0",
+	"type": "composer-plugin",
+	"require": {
+		"composer-plugin-api": "^2.0"
+	},
+	"extra": {
+		"class": "My\\FaultyPlugin"
+	},
+	"autoload": {
+		"psr-4": {
+			"My\\": "./"
+		}
+	}
+}

--- a/test/fixtures/composer/faulty_plugin/index.php
+++ b/test/fixtures/composer/faulty_plugin/index.php
@@ -1,0 +1,3 @@
+<?php
+
+echo "Hello World";

--- a/test/spec/composer-2_spec.rb
+++ b/test/spec/composer-2_spec.rb
@@ -69,4 +69,29 @@ describe "A PHP application intended for Composer 2" do
 			)
 		end
 	end
+	
+	context "with a faulty Composer plugin that prints to stderr during activation" do
+		before(:all) do
+			@app = new_app_with_stack_and_platrepo_and_bin_report_dumper('test/fixtures/composer/faulty_plugin')
+			@app.deploy
+		end
+		
+		after(:all) do
+			@app.teardown!
+		end
+		
+		it "builds successfully" do
+			expect(@app.output).to include("Hello, I am FaultyPlugin, writing to stdout instead of stderr in PluginInterface::activate()")
+		end
+		
+		it "captures the number of dependencies that were installed as part of the information about the build" do
+			expect(@app.bin_report_dump).to include(
+				"dependencies.packages.installed_count" => 1,
+			)
+		end
+		
+		it "boots and serves traffic" do
+			expect(successful_body(@app))
+		end
+	end
 end


### PR DESCRIPTION
If a plugin prints e.g. to stdout during activation, as https://github.com/themosis/composer-exclude-files/issues/1 does, the JSON output from `composer show` becomes unparseable, `composer config` would print it, etc.

Because we read the output of various Composer commands such as `composer config` or `composer show -f json`, this would cause problems unless those command invocations explicitly specified `--no-plugins`.

This adds `--no-plugin` in a few remaining places, and adds tests to prevent any regressions or future omissions.

GUS-W-19663146
