### PR TITLE
Use the default `hatchet-` app name prefix

### DIFF
--- a/.github/workflows/ci-cleanup.yml
+++ b/.github/workflows/ci-cleanup.yml
@@ -14,7 +14,6 @@ jobs:
   hatchet-app-cleaner:
     runs-on: ubuntu-24.04
     env:
-      HATCHET_APP_PREFIX: "htcht-"
       HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
       HEROKU_API_USER: ${{ secrets.HEROKU_API_USER }}
       HEROKU_DISABLE_AUTOUPDATE: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,6 @@ env:
   HATCHET_RETRIES: 3
   IS_RUNNING_ON_CI: true
   HATCHET_APP_LIMIT: 300
-  HATCHET_APP_PREFIX: ${{ format('htcht-{0}-', github.run_id) }}
   HATCHET_EXPENSIVE_MODE: 1
   HATCHET_BUILDPACK_BASE: https://github.com/heroku/heroku-buildpack-php
   HATCHET_BUILDPACK_BRANCH: ${{ github.head_ref || github.ref_name }}


### PR DESCRIPTION
For consistency with the other language buildpacks, since the custom namespacing is no longer required after #705.

GUS-W-19751296.