### PR TITLE
Log details for unhandled and internal errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Show linter error message if composer.json or composer.lock is malformed [David Zuelke]
 - Log reason and details for bin/report on build failure [David Zuelke]
 - Automatically log details about failures for bin/report if not handled explicitly [David Zuelke]
+- Log details about unhandled internal errors for bin/report [David Zuelke]
 
 ## [v275] - 2025-09-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Automatically finish recording durations of build steps for bin/report where needed (e.g. on build failure) [David Zuelke]
 - Show linter error message if composer.json or composer.lock is malformed [David Zuelke]
 - Log reason and details for bin/report on build failure [David Zuelke]
+- Automatically log details about failures for bin/report if not handled explicitly [David Zuelke]
 
 ## [v275] - 2025-09-30
 

--- a/bin/compile
+++ b/bin/compile
@@ -39,7 +39,8 @@ source $bp_dir/bin/util/common.sh
 # we do not 'set -o errtrace', because that would cause subshell failures to fire the trap twice, e.g. with someval=$(func_that_fails)
 trap 'err_trap' ERR
 
-# use exit_trap from common.sh on exit to stop all open timers
+# use exit_trap from common.sh on exit to stop all open timers and, on non-zero exit, log a failure reason and call stack, if not already present
+# (the second part acts as a "fallback" failure log mechanism for any explicit non-zero exit calls that do not log a reason/detail)
 trap 'exit_trap' EXIT
 
 # failure counting

--- a/bin/compile
+++ b/bin/compile
@@ -35,7 +35,7 @@ ignore_config_vars+=("BPLOG_PREFIX" "BUILDPACK_LOG_FILE")
 # convenience functions
 source $bp_dir/bin/util/common.sh
 
-# use err_trap from common.sh on error
+# use err_trap from common.sh on error to log and output a call stack
 # we do not 'set -o errtrace', because that would cause subshell failures to fire the trap twice, e.g. with someval=$(func_that_fails)
 trap 'err_trap' ERR
 

--- a/bin/util/common.sh
+++ b/bin/util/common.sh
@@ -279,18 +279,23 @@ curl_retry_on_18() {
 }
 
 err_trap() {
+	local trace=$(
+		local frame=0
+		while caller "$frame"; do
+			(( ++frame ));
+		done
+	)
+
+	build_report::set_string failure_reason errexit
+	build_report::set_string failure_detail "$trace"
+
 	error <<-EOF
 		An unknown internal error occurred.
 	
 		Contact Heroku Support for assistance if this problem persists.
 		
 		Stack trace follows for debugging purposes:
-		$(
-			local frame=0
-			while caller $frame; do
-				((frame++));
-			done
-		)
+		${trace}
 	EOF
 }
 

--- a/bin/util/common.sh
+++ b/bin/util/common.sh
@@ -295,12 +295,28 @@ err_trap() {
 }
 
 exit_trap() {
+	local exit_status=$?
+
 	build_report::has_running_timers && {
 		local open_timers
 		mapfile -t open_timers < <(build_report::get_running_timer_names)
 		build_report::set_string open_timers "$(IFS=","; echo "${open_timers[*]}")"
 		build_report::stop_timers
-	} || true
+	}
+
+	# if exit status was 0, or if a failure_reason is already set, skip the rest
+	(( exit_status )) || return
+	build_report::has failure_reason && return
+
+	local trace=$(
+		local frame=0
+		while caller "$frame"; do
+			(( ++frame ));
+		done
+	)
+
+	build_report::set_string failure_reason unknown
+	build_report::set_string failure_detail "$trace"
 }
 
 # Logging


### PR DESCRIPTION
Covers both explicit non-zero `exit` calls, e.g. from an invocation of `error` that does not have a preceding log call for `failure_reason`, as well as unhandled errors that are caught by the `ERR` trap.

GUS-W-19638135
GUS-W-19638118
