### PR TITLE
Fix PHP extension loading when custom php.ini is provided

### DIFF
--- a/bin/heroku-php-apache2
+++ b/bin/heroku-php-apache2
@@ -389,7 +389,10 @@ echo -e "\n[global]\nlog_level = notice" >> "$fpm_config_tmp"
 
 # build command string arrays for PHP-FPM and HTTPD
 # we're using an array, because we need to correctly preserve quoting, spaces, etc
-fpm_command=( php-fpm --prefix "$php_server_root" --pid "$fpm_pidfile" --nodaemonize -y "$fpm_config_tmp" ${php_config:+-c "$php_config"} )
+# when a custom php.ini is given via -c, it replaces the buildpack's php.ini, which may not define extension_dir
+# we always pass the correct extension_dir via -d to ensure extensions are found regardless of the php.ini used
+php_extension_dir=$(php-config --extension-dir)
+fpm_command=( php-fpm --prefix "$php_server_root" --pid "$fpm_pidfile" --nodaemonize -y "$fpm_config_tmp" -d "extension_dir=$php_extension_dir" ${php_config:+-c "$php_config"} )
 httpd_command=( httpd -d "$web_server_root" -D NO_DETACH -c "Include $httpd_config" )
 
 ram=

--- a/bin/heroku-php-nginx
+++ b/bin/heroku-php-nginx
@@ -389,7 +389,10 @@ echo -e "\n[global]\nlog_level = notice" >> "$fpm_config_tmp"
 
 # build command string arrays for PHP-FPM and Nginx
 # we're using an array, because we need to correctly preserve quoting, spaces, etc
-fpm_command=( php-fpm --prefix "$php_server_root" --pid "$fpm_pidfile" --nodaemonize -y "$fpm_config_tmp" ${php_config:+-c "$php_config"} )
+# when a custom php.ini is given via -c, it replaces the buildpack's php.ini, which may not define extension_dir
+# we always pass the correct extension_dir via -d to ensure extensions are found regardless of the php.ini used
+php_extension_dir=$(php-config --extension-dir)
+fpm_command=( php-fpm --prefix "$php_server_root" --pid "$fpm_pidfile" --nodaemonize -y "$fpm_config_tmp" -d "extension_dir=$php_extension_dir" ${php_config:+-c "$php_config"} )
 nginx_command=( nginx -p "$web_server_root" -e "$web_server_root/var/log/nginx/error.log" -c "$nginx_main" -g "pid $nginx_pidfile; include $nginx_config;" )
 
 ram=


### PR DESCRIPTION
**Description:**
This PR addresses an issue where PHP extensions might not load correctly when a custom php.ini file is provided via the -c option in the PHP-FPM command. The problem occurs because a custom php.ini may not define the extension_dir directive, leading to extensions not being found even if they are installed in the correct location.

**Changes Made:**
Added logic to retrieve the correct extension directory using php-config --extension-dir.
Modified the fpm_command array in both *heroku-php-apache2* and *heroku-php-nginx* to include the -d extension_dir=$php_extension_dir parameter.
This ensures that the extension directory is always set correctly, regardless of whether a custom php.ini is used or not.

**Files Modified:**
bin/heroku-php-apache2
bin/heroku-php-nginx

**Testing:**
Verified that PHP-FPM starts correctly with custom php.ini files.
Confirmed that extensions load properly in both Apache2 and Nginx configurations.

This fix improves compatibility and reliability for users providing custom PHP configurations in Heroku deployments.