### PR TITLE
Remove concurrency limit on platform build workflow

### DIFF
--- a/.github/workflows/platform-build.yml
+++ b/.github/workflows/platform-build.yml
@@ -30,11 +30,6 @@ on:
         type: boolean
         default: false
         required: false
-      concurrency:
-        description: 'GitHub Actions runner concurrency'
-        type: number
-        default: 3
-        required: true
 
 permissions:
   contents: read
@@ -84,7 +79,6 @@ jobs:
     runs-on: ${{ endsWith(inputs.stack, '-arm64') && 'pub-hk-ubuntu-24.04-arm-xlarge' || 'pub-hk-ubuntu-24.04-xlarge' }}
     strategy:
       fail-fast: false
-      max-parallel: ${{ fromJSON(inputs.concurrency) }}
       matrix:
         formula: ${{ fromJSON(needs.formulae-list.outputs.formulae) }}
     env:


### PR DESCRIPTION
Since:
- The current custom runner groups have a larger max size than the old groups did in the past (50 vs 10), and we want the jobs to always run as fast as possible.
- Having yet another option adds cognitive complexity to an already complex workflow input values form.

GUS-W-22047358.