### PR TITLE
Fix unsupported formula skipping when using dry-run

### DIFF
--- a/.github/workflows/platform-build.yml
+++ b/.github/workflows/platform-build.yml
@@ -97,7 +97,15 @@ jobs:
         run: docker load -i /tmp/docker-cache.tar.gz
       - name: Build formula without deploying
         if: ${{ inputs.dry-run == true }}
-        run: docker run --rm --env-file=support/build/docker/env.default heroku-php-build-${{inputs.stack}}:${{github.sha}} deploy.sh --dry-run ${{matrix.formula}}
+        run: |
+          docker run --rm --env-file=support/build/docker/env.default heroku-php-build-${{inputs.stack}}:${{github.sha}} deploy.sh --dry-run ${{matrix.formula}} || {
+            status=$?
+            if (( status == 9 )); then
+              echo "::notice title=Skipped formula ${{matrix.formula}}::Not available on this stack or architecture."
+            else
+              exit "$status"
+            fi
+          }
       - name: Build and deploy${{ inputs.overwrite == true && '(+overwrite)' || '' }} formula
         if: ${{ inputs.dry-run == false }}
         run: |


### PR DESCRIPTION
Previously the "skip the formula if it exited with status code 9" feature only worked when performing a real deploy. Now it also works when using the `dry-run` option, making it possible to fully test the same formula glob in dry mode first.

See a few lines lower down in the workflow file for the non-dry-run implementation from which this is copied.

(Split out of the Heroku-26 PR.)

GUS-W-22048754.