### PR TITLE
Unpin Heroku build image versions

### DIFF
--- a/support/build/docker/heroku-22.Dockerfile
+++ b/support/build/docker/heroku-22.Dockerfile
@@ -1,4 +1,4 @@
-FROM heroku/heroku:22-build.v160
+FROM heroku/heroku:22-build
 
 ARG TARGETARCH
 

--- a/support/build/docker/heroku-24.Dockerfile
+++ b/support/build/docker/heroku-24.Dockerfile
@@ -1,4 +1,4 @@
-FROM heroku/heroku:24-build.v160
+FROM heroku/heroku:24-build
 
 ARG TARGETARCH
 


### PR DESCRIPTION
Since the issues that the pinning was intended to avoid (ABI feature additions in a newer header versions) are so rare that it's not worth the toil tradeoff of having to keep these up to date. (Particularly now that we have repository snapshots meaning that people can roll back buildpack versions in the unlikely event an issue does occur.)

Removing pins also simplifies adding the Heroku-26 Dockerfile, since I'd have to first add it as unpinned, and then repin it later.

(Split out of the Heroku-26 PR.)

GUS-W-22048918.