### PR TITLE
Fix bootstrap_url_filepath path resolution when invoked via relative path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,13 @@ jobs:
           ruby-version: "${{ env.setup_ruby_ruby_version }}"
       - name: Execute tests
         run: bundle exec rspec test/spec/cgroup_spec.rb
+  container-test:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Run buildpack using default app fixture
+        run: make run
   integration-test:
     runs-on: ubuntu-24.04
     strategy:

--- a/bin/compile
+++ b/bin/compile
@@ -285,7 +285,7 @@ if [[ "${HEROKU_PHP_PLATFORM_REPOSITORIES}" == *" - "* ]]; then
 fi
 
 bootstrap_url_filepath() {
-	local bootstrap_scan_dir=$(dirname "$BASH_SOURCE")/../support/build/packages
+	local bootstrap_scan_dir="$bp_dir/support/build/packages"
 	
 	# 1. Find
 	#   - in $bootstrap_scan_dir


### PR DESCRIPTION
Use $bp_dir (already resolved to an absolute path on line 21) instead of
$(dirname "$BASH_SOURCE") which produces a relative path when bin/compile
is called as ./bin/compile. After `cd $build_dir`, the relative path no
longer resolves to the buildpack's support/build/packages directory.

Fixes https://github.com/heroku/heroku-buildpack-php/issues/928