### PR TITLE
Fix `build_report::clear_timer()`'s implicit `key` variable usage

### DIFF
--- a/bin/util/build_report.sh
+++ b/bin/util/build_report.sh
@@ -187,6 +187,7 @@ function build_report::get_timer() {
 # build_report::clear_timer "my_timer_name"
 # ```
 function build_report::clear_timer() {
+	local key="${1}"
 	declare -gA __build_report_start_times
 	unset __build_report_start_times["${key}"]
 }


### PR DESCRIPTION
Previously the `key` variable in `build_report::clear_timer` was implicitly inherited from its caller, rather than being explicitly defined via `$1` - so while it works for now, would break if the caller was ever refactored.

Found by Claude/Opus when asking it to look for Bash bugs as part of debugging Heroku-26 support.