### PR TITLE
Make `exit_trap()` compatible with Bash 5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### CHG
+
+- Make buildpack exit trap compatible with Bash 5.3. ([#936](https://github.com/heroku/heroku-buildpack-php//pull/936))
 
 ## [v286] - 2026-04-15
 

--- a/bin/util/common.sh
+++ b/bin/util/common.sh
@@ -309,9 +309,9 @@ exit_trap() {
 		build_report::stop_timers
 	}
 
-	# if exit status was 0, or if a failure_reason is already set, skip the rest
-	(( exit_status )) || return
-	build_report::has failure_reason && return
+	if (( exit_status == 0 )) || build_report::has failure_reason; then
+		return "$exit_status";
+	fi
 
 	local trace=$(
 		local frame=0


### PR DESCRIPTION
In Bash 5.2 and older, the bare `return` without an explicit exit code would exit code zero after the arithmetic operation, however, in Bash 5.3 it now strictly returns the last command's exit status, which in the case of `(( exit_status ))` was 1.

This is problematic, since the upcoming Ubuntu 26.04-based Heroku-26 ships with Bash 5.3.

The new implementation is compatible with both Bash 5.3 and older versions.

Fixes #932.
GUS-W-22061085.