### PR TITLE
Disable `fail-fast` for CI unit and integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
   unit-test:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: ["ubuntu-22.04", "ubuntu-24.04"]
     steps:
@@ -55,6 +56,7 @@ jobs:
   integration-test:
     runs-on: ubuntu-24.04
     strategy:
+      fail-fast: false
       matrix:
         stack: ["heroku-22", "heroku-24"]
     env:


### PR DESCRIPTION
Since otherwise when one stack fails, all other tests are cancelled, which prevents proper Hatchet test cleanup, and also prevents being able to see if there were other real failures in the other jobs.

https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idstrategyfail-fast