### PR TITLE
Add Heroku-26 to Dev Center generator stacks list

### DIFF
--- a/.github/workflows/update-devcenter.yml
+++ b/.github/workflows/update-devcenter.yml
@@ -4,7 +4,8 @@ env:
   # ensure these are in sync with other relevant workflow files
   setup_php_php_version: "8.4"
   setup_php_composer_version: "2.9"
-  # ensure these also match the input defaults below
+  # ensure these also match the input defaults below, and also keep in sync with
+  # the stack versions in support/devcenter/generate.php
   stacks_list_for_shell_expansion: "{heroku-22-amd64,heroku-24-amd64,heroku-26-amd64}"
   repo_path_suffix: "-stable/"
 

--- a/support/build/formulae/php
+++ b/support/build/formulae/php
@@ -39,7 +39,9 @@ dep_manifest=${dep_package}.composer.json
 
 # When we add support for a new stack, we only build PHP versions that at that time are
 # still in "Active support" upstream: https://www.php.net/supported-versions.php
-# Keep this list in sync with php_on_stack? in test/spec/spec_helper.rb
+# Keep this list in sync with the PHP version lists in:
+# - support/devcenter/generate.php
+# - test/spec/spec_helper.rb
 case "$STACK" in
 	heroku-22)
 		# 8.0 could not be built on jammy due to OpenSSL 3

--- a/support/devcenter/generate.php
+++ b/support/devcenter/generate.php
@@ -20,10 +20,11 @@ if(isset($sections['s'])) {
 	unset($sections['s']);
 	$stacks = array_combine(range(1, count($stacks)), $stacks); // re-index to start at 1, relevant for the numbering of footnotes
 } else {
-	// these need updating from time to time to add new stacks and remove EOL ones
+	// Keep the Heroku stack versions here in sync with .github/workflows/update-devcenter.yml
 	$stacks = [
 		1 => '22', // the offset we start with here is relevant for the numbering of footnotes
 		'24',
+		'26',
 	];
 }
 
@@ -32,7 +33,7 @@ if(isset($sections['p'])) {
 	$series = explode(',', $sections['p']);
 	unset($sections['p']);
 } else {
-	// these need updating from time to time to add new series and remove series no longer on any stack
+	// Keep this PHP versions list in sync with the supported_series values in support/build/formulae/php
 	$series = [
 		'8.1',
 		'8.2',


### PR DESCRIPTION
Spotted one more place (in addition to the Dev Center GitHub Actions workflow inputs settings) that need Heroku-26 related updates in order for the new stack to appear on Dev Center:
https://github.com/heroku/heroku-buildpack-php/actions/runs/24571508019/job/71845593776#step:12:34

I've also added some comments to make it harder to miss this next time either the list of stacks or PHP versions are updated.

GUS-W-20775727.