### PR TITLE
Replace /dev/stderr with standard stream channel

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -454,7 +454,7 @@ status "Preparing platform package installation..."
 HEROKU_PHP_DEFAULT_RUNTIME_VERSION="^8.1.0 <8.6"
 export HEROKU_PHP_DEFAULT_RUNTIME_VERSION
 # extract requirements from composer.lock
-{ platform_stderr=$(/app/.heroku/php-min/bin/php $bp_dir/bin/util/platform.php ${have_custom_platform_repos:+"--list-repositories"} "$bp_dir/support/installer/" $HEROKU_PHP_PLATFORM_REPOSITORIES 2>&1 >$build_dir/.heroku/php/composer.json | tee >(indent > /dev/stderr)); } || {
+{ platform_stderr=$(/app/.heroku/php-min/bin/php $bp_dir/bin/util/platform.php ${have_custom_platform_repos:+"--list-repositories"} "$bp_dir/support/installer/" $HEROKU_PHP_PLATFORM_REPOSITORIES 2>&1 >$build_dir/.heroku/php/composer.json | tee >(indent >&2)); } || {
 	code=$?
 	if (( code == 3 )); then
 		build_report::set_string failure_reason platform.prepare.runtime_only_in_dev


### PR DESCRIPTION
https://github.com/gliderlabs/herokuish uses an unprivileged user to run the buildpack. Unfortunately, this causes writing to `/dev/stderr` to fail with permission denied.

Back in march I tried to resolve this in https://github.com/gliderlabs/herokuish/issues/1818 but my attempt uses TTY which is not available during `git push`.

After a lot of try and error, it seems the simplest would be to update the code here with an equivalent solution that uses the standard stream channel instead of `/dev/stderr`. Based on my tests, this implementation behaves the same and now supports herokuish.