### PR TITLE
Fix Guzzle error

### DIFF
--- a/support/devcenter/generate.php
+++ b/support/devcenter/generate.php
@@ -117,7 +117,7 @@ $handlerStack->push(GuzzleHttp\Middleware::retry(function($times, $req, $res, $e
 	if($res && $res->getStatusCode() >= 500) return true;
 	return false;
 }));
-$client = new GuzzleHttp\Client(['handler' => $handlerStack, "timeout" => "2.0"]);
+$client = new GuzzleHttp\Client(['handler' => $handlerStack, "timeout" => 2.0]);
 
 $repositories = [];
 $responses = GuzzleHttp\Pool::batch($client, (function() use($posArgs, $client) {


### PR DESCRIPTION
Getting this error when generating the PHP devcenter updates on GHA https://github.com/heroku/heroku-buildpack-php/actions/runs/33672903696/job/100390578271:

```
PHP Fatal error:  Uncaught GuzzleHttp\Exception\InvalidArgumentException: Passing string to request option "timeout" is invalid; expected int|float. in /home/runner/work/heroku-buildpack-php/heroku-buildpack-php/support/devcenter/vendor/guzzlehttp/guzzle/src/Client.php:1481
Stack trace:
#0 /home/runner/work/heroku-buildpack-php/heroku-buildpack-php/support/devcenter/vendor/guzzlehttp/guzzle/src/Client.php(1367): GuzzleHttp\Client::invalidRequestOptionType()
#1 /home/runner/work/heroku-buildpack-php/heroku-buildpack-php/support/devcenter/vendor/guzzlehttp/guzzle/src/Client.php(1029): GuzzleHttp\Client::assertIfPresentAndNotNumber()
#2 /home/runner/work/heroku-buildpack-php/heroku-buildpack-php/support/devcenter/vendor/guzzlehttp/guzzle/src/Client.php(952): GuzzleHttp\Client::assertRequestOptionTypes()
#3 /home/runner/work/heroku-buildpack-php/heroku-buildpack-php/support/devcenter/vendor/guzzlehttp/guzzle/src/Client.php(533): GuzzleHttp\Client->prepareDefaults()
#4 /home/runner/work/heroku-buildpack-php/heroku-buildpack-php/support/devcenter/vendor/guzzlehttp/guzzle/src/ClientTrait.php(848): GuzzleHttp\Client->requestAsync()
#5 /home/runner/work/heroku-buildpack-php/heroku-buildpack-php/support/devcenter/generate.php(129): GuzzleHttp\Client->getAsync()
#6 /home/runner/work/heroku-buildpack-php/heroku-buildpack-php/support/devcenter/vendor/guzzlehttp/guzzle/src/Pool.php(154): {closure:{closure:/home/runner/work/heroku-buildpack-php/heroku-buildpack-php/support/devcenter/generate.php:123}:125}()
#7 [internal function]: GuzzleHttp\Pool::{closure:GuzzleHttp\Pool::__construct():147}()
#8 /home/runner/work/heroku-buildpack-php/heroku-buildpack-php/support/devcenter/vendor/guzzlehttp/promises/src/EachPromise.php(100): Generator->rewind()
#9 /home/runner/work/heroku-buildpack-php/heroku-buildpack-php/support/devcenter/vendor/guzzlehttp/guzzle/src/Pool.php(171): GuzzleHttp\Promise\EachPromise->promise()
#10 /home/runner/work/heroku-buildpack-php/heroku-buildpack-php/support/devcenter/vendor/guzzlehttp/guzzle/src/Pool.php(278): GuzzleHttp\Pool->promise()
#11 /home/runner/work/heroku-buildpack-php/heroku-buildpack-php/support/devcenter/generate.php(123): GuzzleHttp\Pool::batch()
#12 {main}
  thrown in /home/runner/work/heroku-buildpack-php/heroku-buildpack-php/support/devcenter/vendor/guzzlehttp/guzzle/src/Client.php on line 1481
```


`generate.php` passed the Guzzle `timeout` request option as a string (`"2.0"`). Guzzle 8.1.0 (bumped in #983) now rejects a string `timeout` and requires `int|float`, crashing the `update-devcenter.yml` run for v295. Fix: pass `2.0` as a float.

CI covers this but missed it: `test/spec/devcenter_spec.rb` covers the generator but feeds local fixture files, which short-circuit before `$client->getAsync()` (line 129) — and Guzzle validates `timeout` only when preparing a request. The HTTP path runs only against live URLs in `update-devcenter.yml` at release, never on PRs.