### PR TITLE
Move test gems into a test/development group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,13 @@
 source "https://rubygems.org"
 
-ruby '>= 3.2', '< 4.1'
+ruby '>= 3.3', '< 4.1'
 
-gem 'heroku_hatchet', git: 'https://github.com/heroku/hatchet.git', branch: 'timeouts-etc'
-gem 'rspec-retry'
-gem 'rspec-expectations'
-gem 'sem_version'
-gem "parallel_tests", ">= 4.0.0"
-gem "rake"
-gem "ansi"
+group :test, :development do
+  gem 'heroku_hatchet', git: 'https://github.com/heroku/hatchet.git', branch: 'timeouts-etc'
+  gem 'rspec-retry'
+  gem 'rspec-expectations'
+  gem 'sem_version'
+  gem "parallel_tests", ">= 4.0.0"
+  gem "rake"
+  gem "ansi"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,7 +24,7 @@ GEM
       json
       moneta
       webrick
-    json (3.0.0)
+    json (3.0.2)
     logger (1.7.0)
     moneta (1.0.0)
     parallel (2.2.0)
@@ -67,11 +67,12 @@ DEPENDENCIES
 CHECKSUMS
   ansi (1.6.0) sha256=ac9ea0c0ea8d32fb4e271348e609963ac78882f34b73836c2a02b3622e666658
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
+  bundler (4.0.20) sha256=7978a8ac648767f5e635bc522445b79e80a52b907a39a36c2d8085ed6bc762ae
   diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
   excon (1.7.1) sha256=dd2d870eece1b5ce4e4f9efd938e67a69ccd8c003c3825b638b937e1082eaac2
   heroics (0.1.4) sha256=8d843fb0a2cb55f36d1754d1f684e2e2685573ab90ff23dad122d30c66b7021c
   heroku_hatchet (8.0.6)
-  json (3.0.0) sha256=1ff82a28c05c5cc7b646f3e3a3ac710e4ae2aa933690cba12f1f650b0ecdeb99
+  json (3.0.2) sha256=8e6d7e7b11384c21230430cef90b71f14849a34a1f4452796670f7c981bd19df
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
   moneta (1.0.0) sha256=2224e5a68156e8eceb525fb0582c8c4e0f29f67cae86507cdcfb406abbb1fc5d
   parallel (2.2.0) sha256=e1059c5fd7b649558a0aec38a769f06a42942bdb40503d005a59c352fe011cd8
@@ -90,7 +91,7 @@ CHECKSUMS
   webrick (1.9.2) sha256=beb4a15fc474defed24a3bda4ffd88a490d517c9e4e6118c3edce59e45864131
 
 RUBY VERSION
-  ruby 4.0.2
+  ruby 4.0.6
 
 BUNDLED WITH
-  4.0.8
+  4.0.20


### PR DESCRIPTION
Ports the improvements made to the classic Node.js buildpack while fixing its CI (heroku/heroku-buildpack-nodejs#1790) to this repo.

- Move the gems into a `test`, `development` group and tighten the
  Ruby constraint to `ruby ">= 3.3", "< 4.1"`.
- Regenerate `Gemfile.lock`: update bundler to 4.0.20 and refresh all
  dependencies.

GUS-W-24141750.